### PR TITLE
Update p5p job to publish via Buildomat

### DIFF
--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
 #:
-#: name = "p5p"
+#: name = "mg-p5p"
 #: variety = "basic"
 #: target = "helios"
 #: rust_toolchain = "nightly"
 #: output_rules = [
-#:   "/out/*.p5p",
+#:   "=/out/mg.p5p",
+#:   "=/out/mg.p5p.sha256",
 #: ]
+#:
 #: access_repos = [
 #:   "oxidecomputer/dendrite",
 #:   "oxidecomputer/falcon",
 #: ]
+#:
+#: [[publish]]
+#: series = "repo"
+#: name = "mg.p5p"
+#: from_output = "/out/mg.p5p"
+#:
+#: [[publish]]
+#: series = "repo"
+#: name = "mg.p5p.sha256"
+#: from_output = "/out/mg.p5p.sha256"
 #:
 
 set -o errexit
@@ -30,4 +42,6 @@ pushd pkg
 banner copy
 pfexec mkdir -p /out
 pfexec chown "$UID" /out
-mv packages/repo/*.p5p /out/
+PKG_NAME="/out/mg.p5p"
+mv packages/repo/*.p5p "$PKG_NAME"
+sha256sum "$PKG_NAME" > "$PKG_NAME.sha256"


### PR DESCRIPTION
* Generate sha256sum for mg.p5p
* Add [publish] directive for artifacts

These additions are useful for:
1. Generating predictable URLs for automating checking / fetching of generated artifacts
2. Checking integrity of fetched package before bundling with a new image