### PR TITLE
Update to new package rev, emit images based on package name

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -14,13 +14,13 @@
 #:
 #: [[publish]]
 #: series = "image"
-#: name = "mg-ddm.tar"
-#: from_output = "/out/mg-ddm.tar"
+#: name = "maghemite.tar"
+#: from_output = "/out/maghemite.tar"
 #:
 #: [[publish]]
 #: series = "image"
-#: name = "mg-ddm.sha256.txt"
-#: from_output = "/out/mg-ddm.sha256.txt"
+#: name = "maghemite.sha256.txt"
+#: from_output = "/out/maghemite.sha256.txt"
 #:
 
 set -o errexit
@@ -37,11 +37,11 @@ banner image
 ptime -m cargo run -p mg-package
 
 banner contents
-tar tvfz out/mg-ddm.tar
+tar tvfz out/maghemite.tar
 
 banner copy
 pfexec mkdir -p /out
 pfexec chown "$UID" /out
-mv out/mg-ddm.tar /out/mg-ddm.tar
+mv out/maghemite.tar /out/maghemite.tar
 cd /out
-digest -a sha256 mg-ddm.tar > mg-ddm.sha256.txt
+digest -a sha256 maghemite.tar > maghemite.sha256.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,11 +2021,13 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.1.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd2e4dbdcf6781c86cee71b7d30a7fed585fd1653dd896c2347ff2239b553aa"
+checksum = "222c900d9a67df941c61590869a2a23de13d6cc613d9aaa5dd09c98b1e8dde45"
 dependencies = [
  "anyhow",
+ "chrono",
+ "filetime",
  "flate2",
  "reqwest 0.11.11",
  "serde",
@@ -2035,6 +2037,7 @@ dependencies = [
  "thiserror",
  "tokio 1.20.0",
  "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 tokio = "1.17"
-omicron-zone-package = "0.1.2"
+omicron-zone-package = "0.4.0"

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -9,8 +9,8 @@ async fn main() -> Result<()> {
     let output_dir = Path::new("out");
     create_dir_all(&output_dir)?;
 
-    for package in cfg.packages.values() {
-        package.create(output_dir).await?;
+    for (name, package) in cfg.packages {
+        package.create(&name, output_dir).await?;
     }
 
     Ok(())


### PR DESCRIPTION
`omicron-zone-package` version 0.4.0 expects that "output paths" of zone/tarball images are based on the package names, not service names.

This is necessary to allow for configurations where "multiple flavors of a service" are offered via different packages.

This PR pulls maghemite into that schema.

For context: https://github.com/oxidecomputer/omicron/pull/1759#discussion_r983868764