### PR TITLE
Build a zone image

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -21,6 +21,16 @@
 #: name = "maghemite.sha256.txt"
 #: from_output = "/out/maghemite.sha256.txt"
 #:
+#: [[publish]]
+#: series = "image"
+#: name = "mg-ddm.tar.gz"
+#: from_output = "/out/mg-ddm.tar.gz"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "mg-ddm.sha256.txt"
+#: from_output = "/out/mg-ddm.sha256.txt"
+#:
 
 set -o errexit
 set -o pipefail
@@ -42,5 +52,10 @@ banner copy
 pfexec mkdir -p /out
 pfexec chown "$UID" /out
 mv out/maghemite.tar /out/maghemite.tar
+mv out/mg-ddm.tar.gz /out/mg-ddm.tar.gz
+
+banner checksum
 cd /out
 digest -a sha256 maghemite.tar > maghemite.sha256.txt
+digest -a sha256 mg-ddm.tar.gz > mg-ddm.sha256.txt
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,11 +1580,12 @@ source = "git+https://github.com/jmesmon/rust-libzfs?branch=master#ecd5a922247a6
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222c900d9a67df941c61590869a2a23de13d6cc613d9aaa5dd09c98b1e8dde45"
+checksum = "1fc07ae764740e9da85fd0ec5e7a5834f6c24dada2d78c2313525f1afd2d02e1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "filetime",
  "flate2",

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -1,8 +1,21 @@
 [package.maghemite]
-rust.binary_names = ["ddmd", "ddmadm"]
-rust.release = true
 service_name = "mg-ddm"
-zone = false
-[[package.maghemite.paths]]
-from = "smf"
-to = "pkg"
+source.type = "local"
+source.rust.binary_names = ["ddmd", "ddmadm"]
+source.rust.release = true
+source.paths = [
+  { from = "smf", to = "pkg" }
+]
+output.type = "tarball"
+
+[package.mg-ddm]
+service_name = "mg-ddm"
+source.type = "local"
+source.rust.binary_names = ["ddmd", "ddmadm"]
+source.rust.release = true
+source.paths = [
+  { from = "smf/ddm_method_script.sh", to = "/opt/oxide/mg-ddm/pkg/ddm_method_script.sh" },
+  { from = "smf/ddm/manifest.xml", to = "/var/svc/manifest/site/mg-ddm/manifest.xml" }
+]
+output.type = "zone"
+

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 tokio = "1.21"
-omicron-zone-package = "0.4.0"
+omicron-zone-package = "0.5.1"

--- a/smf/ddm_method_script.sh
+++ b/smf/ddm_method_script.sh
@@ -39,4 +39,15 @@ for x in $(svcprop -c -p config/interfaces "${SMF_FMRI}"); do
     args+=( "$x" )
 done
 
-exec /opt/oxide/mg-ddm/ddmd "${args[@]}"
+if [[ -e /opt/oxide/mg-ddm/bin/ddmd ]];
+then
+    # mg-ddm.tar.gz gets the binaries at /opt/oxide/mg-ddm/bin/
+    exec /opt/oxide/mg-ddm/bin/ddmd "${args[@]}"
+elif [[ -e /opt/oxide/mg-ddm/ddmd ]];
+then
+    # maghemite.tar gets the binaries at /opt/oxide/mg-ddm/
+    exec /opt/oxide/mg-ddm/ddmd "${args[@]}"
+else
+    exit 1
+fi
+


### PR DESCRIPTION
In addition to maghemite.tar, build (and publish) mg-ddm.tar.gz, a zone image to be used to run Maghemite in the switch zone (see https://github.com/oxidecomputer/omicron/issues/2562)