### PR TITLE
Switch to building on heliosv2

### DIFF
--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "build"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/debug/*",

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "image"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/out/*",

--- a/.github/buildomat/jobs/openapi.sh
+++ b/.github/buildomat/jobs/openapi.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "openapi"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: output_rules = [
 #:   "/out/*",
 #: ]

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "mg-p5p"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "=/out/mg.p5p",

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/*.log",
@@ -44,7 +44,7 @@ banner "collect"
 get_artifact softnpu image 63813af6e737d48b1204c7aedbb44fc029989c52 softnpu
 get_artifact sidecar-lite release 85e1b73d1155c637c98c6a35019b7f9e774e20ea libsidecar_lite.so
 get_artifact sidecar-lite release 85e1b73d1155c637c98c6a35019b7f9e774e20ea scadm
-get_artifact dendrite image efd4a27827d467e8d25034c276e8860b1c001bb5 dendrite-softnpu.tar.gz
+get_artifact dendrite image c2b793dc4b6576e7f25189d90907acb2a2119e9c dendrite-softnpu.tar.gz
 
 pushd download
 chmod +x softnpu


### PR DESCRIPTION
This is a pre-requisite for moving the rack software on top of heliosv2. Once this is integrated, we can point the omicron pins at the CI artefacts built with the newer helios version. It's going to take a few days to get everything over and build machines updated.