### PR TITLE
Add `rust-toolchain.toml` specifying 1.74.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# We choose a specific toolchain (rather than "stable") for repeatability.  The
+# intent is to keep this up-to-date with recently-released stable Rust.
+channel = "1.74.0"
+profile = "default"


### PR DESCRIPTION
I just ran into a compilation issue (only necessary because I'm doing macOS shenanigans instead of downloading binaries) that I think would have been avoided by a rust-toolchain file.