### PR TITLE
backwards compatibility with ddm protocol version 1

### DIFF
--- a/.github/buildomat/jobs/test-ddm-trio-v1-server.sh
+++ b/.github/buildomat/jobs/test-ddm-trio-v1-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "test-ddm-trio"
+#: name = "test-ddm-trio-v1-server"
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"
@@ -19,4 +19,4 @@ source .github/buildomat/test-ddm-common.sh
 #
 
 banner "trio"
-pfexec cargo test --release -p mg-tests test_trio_v2 -- --nocapture
+pfexec cargo test --release -p mg-tests test_trio_v1_server -- --nocapture

--- a/.github/buildomat/jobs/test-ddm-trio-v1-transit.sh
+++ b/.github/buildomat/jobs/test-ddm-trio-v1-transit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "test-ddm-trio"
+#: name = "test-ddm-trio-v1-transit"
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"
@@ -19,4 +19,4 @@ source .github/buildomat/test-ddm-common.sh
 #
 
 banner "trio"
-pfexec cargo test --release -p mg-tests test_trio_v2 -- --nocapture
+pfexec cargo test --release -p mg-tests test_trio_v1_transit -- --nocapture

--- a/.github/buildomat/test-ddm-common.sh
+++ b/.github/buildomat/test-ddm-common.sh
@@ -33,10 +33,16 @@ get_artifact softnpu image 64beaff129b7f63a04a53dd5ed0ec09f012f5756 softnpu
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 libsidecar_lite.so
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 scadm
 get_artifact dendrite image 350fb25d724578dd2b127499edcd57981d4bbff2 dendrite-softnpu.tar.gz
+get_artifact maghemite release e76dc67706beb806b2f0ecfd6d51097c6c06d534 ddmd
+get_artifact maghemite release e76dc67706beb806b2f0ecfd6d51097c6c06d534 ddmadm
 
 pushd download
 chmod +x softnpu
 chmod +x scadm
+chmod +x ddmadm
+chmod +x ddmd
+mv ddmadm ddmadm-v1
+mv ddmd ddmd-v1
 rm -rf zones/dendrite
 mkdir -p zones/dendrite
 tar -xzf dendrite-softnpu.tar.gz -C zones/dendrite

--- a/ddm/src/discovery.rs
+++ b/ddm/src/discovery.rs
@@ -103,9 +103,15 @@ use thiserror::Error;
 
 const DDM_MADDR: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xdd);
 const DDM_PORT: u16 = 0xddd;
-const VERSION_1: u8 = 1;
 const SOLICIT: u8 = 1;
 const ADVERTISE: u8 = 1 << 1;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum Version {
+    V1 = 1,
+    V2 = 2,
+}
 
 #[derive(Error, Debug)]
 pub enum DiscoveryError {
@@ -128,7 +134,7 @@ pub struct DiscoveryPacket {
 impl DiscoveryPacket {
     pub fn new_solicitation(hostname: String, kind: RouterKind) -> Self {
         Self {
-            version: VERSION_1,
+            version: Version::V2 as u8,
             flags: SOLICIT,
             hostname,
             kind,
@@ -136,7 +142,7 @@ impl DiscoveryPacket {
     }
     pub fn new_advertisement(hostname: String, kind: RouterKind) -> Self {
         Self {
-            version: VERSION_1,
+            version: Version::V2 as u8,
             flags: ADVERTISE,
             hostname,
             kind,
@@ -365,7 +371,7 @@ fn handle_msg(ctx: &HandlerContext, msg: DiscoveryPacket, sender: &Ipv6Addr) {
         handle_solicitation(ctx, sender, msg.hostname.clone());
     }
     if msg.is_advertisement() {
-        handle_advertisement(ctx, sender, msg.hostname, msg.kind);
+        handle_advertisement(ctx, sender, msg.hostname, msg.kind, msg.version);
     }
 }
 
@@ -386,8 +392,23 @@ fn handle_advertisement(
     sender: &Ipv6Addr,
     hostname: String,
     kind: RouterKind,
+    version: u8,
 ) {
     trc!(&ctx.log, ctx.config.if_name, "advert from {}", &hostname);
+
+    let version = match version {
+        1 => Version::V1,
+        2 => Version::V2,
+        x => {
+            err!(
+                ctx.log,
+                ctx.config.if_name,
+                "unknown protocol version {}, known versions are: 1, 2",
+                x
+            );
+            return;
+        }
+    };
 
     let mut guard = match ctx.nbr.write() {
         Ok(nbr) => nbr,
@@ -444,12 +465,15 @@ fn handle_advertisement(
         },
     );
     if updated {
-        emit_nbr_update(ctx, sender);
+        emit_nbr_update(ctx, sender, version);
     }
 }
 
-fn emit_nbr_update(ctx: &HandlerContext, addr: &Ipv6Addr) {
-    if let Err(e) = ctx.event.send(NeighborEvent::Advertise(*addr).into()) {
+fn emit_nbr_update(ctx: &HandlerContext, addr: &Ipv6Addr, version: Version) {
+    if let Err(e) = ctx
+        .event
+        .send(NeighborEvent::Advertise((*addr, version)).into())
+    {
         err!(ctx.log, ctx.config.if_name, "send nbr event: {}", e);
     }
 }

--- a/ddm/src/discovery.rs
+++ b/ddm/src/discovery.rs
@@ -398,7 +398,7 @@ fn handle_advertisement(
 
     // TODO: version negotiation
     //
-    // Things currently work because ddm v1 one does no version checking at all.
+// Things currently work because ddm v1 does no version checking at all.
     // So ddm v2 speakers can send out discovery packets with the version set to
     // 2, and ddm v1 speakers can send out discovery packets with the version
     // set to 1, and as long a v2 router speaks version 1 after discovering a v1

--- a/ddm/src/discovery.rs
+++ b/ddm/src/discovery.rs
@@ -398,7 +398,7 @@ fn handle_advertisement(
 
     // TODO: version negotiation
     //
-// Things currently work because ddm v1 does no version checking at all.
+    // Things currently work because ddm v1 does no version checking at all.
     // So ddm v2 speakers can send out discovery packets with the version set to
     // 2, and ddm v1 speakers can send out discovery packets with the version
     // set to 1, and as long a v2 router speaks version 1 after discovering a v1

--- a/ddm/src/discovery.rs
+++ b/ddm/src/discovery.rs
@@ -396,6 +396,16 @@ fn handle_advertisement(
 ) {
     trc!(&ctx.log, ctx.config.if_name, "advert from {}", &hostname);
 
+    // TODO: version negotiation
+    //
+    // Things currently work because ddm v1 one does no version checking at all.
+    // So ddm v2 speakers can send out discovery packets with the version set to
+    // 2, and ddm v1 speakers can send out discovery packets with the version
+    // set to 1, and as long a v2 router speaks version 1 after discovering a v1
+    // peer, things will work. However, this will not work for version 3. So we
+    // need to implement version negotiation. This would also not work for
+    // changes in the discovery protocol, if we were to have changes there. So
+    // we need to come up with a general way for both protocols to evolve.
     let version = match version {
         1 => Version::V1,
         2 => Version::V2,


### PR DESCRIPTION
This PR now covers backward compatibility with version one of the ddm exchange protocol.

Ddm has two protocols, a router discovery protocol and a prefix exchange protocol. The tunnel routing updates did not change the discovery protocol - and that protocol carries an 8-bit version in it. I updated the exchange client/server code to speak either v1 or v2 of the protocol based on what the peer advertised in the discovery phase. I also added backward compatibility tests to CI.