### PR TITLE
Fix remove-static-v4 API call

### DIFF
--- a/bgp/src/dispatcher.rs
+++ b/bgp/src/dispatcher.rs
@@ -11,6 +11,7 @@ use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
+use std::thread::sleep;
 use std::time::Duration;
 
 pub struct Dispatcher<Cnx: BgpConnection> {
@@ -46,6 +47,7 @@ impl<Cnx: BgpConnection> Dispatcher<Cnx> {
                         self.log,
                         "bgp dispatcher failed to listen {e}"
                     );
+                    sleep(Duration::from_secs(1));
                     continue;
                 }
             };

--- a/mgadm/src/static_routing.rs
+++ b/mgadm/src/static_routing.rs
@@ -79,7 +79,7 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
             client.static_add_v4_route(&arg).await?;
         }
         Commands::RemoveV4Routes(route) => {
-            let arg = types::AddStaticRoute4Request {
+            let arg = types::DeleteStaticRoute4Request {
                 routes: types::StaticRoute4List {
                     list: vec![types::StaticRoute4 {
                         prefix: Prefix4 {
@@ -90,7 +90,7 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                     }],
                 },
             };
-            client.static_add_v4_route(&arg).await?;
+            client.static_remove_v4_route(&arg).await?;
         }
     }
     Ok(())

--- a/mgd/src/static_admin.rs
+++ b/mgd/src/static_admin.rs
@@ -92,7 +92,10 @@ pub async fn static_remove_v4_route(
         .map(Into::into)
         .collect();
     for r in routes {
-        ctx.context().db.remove_nexthop4(r);
+        ctx.context()
+            .db
+            .remove_nexthop4(r, true)
+            .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
     }
     Ok(HttpResponseDeleted())
 }


### PR DESCRIPTION
- fixes #171
- makes `remove_nexthop4` symmetric with `set_nexthop4` with regard to static/persistent updates.
- fixes `mgadm` making the wrong API call on static route removal
- also: stops the BGP dispatcher from going into a tight error loop when it can't bind