### PR TITLE
Graceful transition to/from BFD-based networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "opte-ioctl",
  "oxide-vpc",
+ "pretty_assertions",
  "schemars",
  "serde",
  "serde_json",

--- a/ddm/Cargo.toml
+++ b/ddm/Cargo.toml
@@ -3,6 +3,9 @@ name = "ddm"
 version = "0.1.0"
 edition = "2021"
 
+[dev-dependencies]
+pretty_assertions.workspace = true
+
 [dependencies]
 slog.workspace = true
 socket2.workspace = true

--- a/ddm/src/db.rs
+++ b/ddm/src/db.rs
@@ -239,7 +239,7 @@ impl Db {
         let mut tnl_removed = HashSet::new();
         for x in &data.imported_tunnel {
             if x.nexthop == nexthop {
-                tnl_removed.insert(x.clone());
+                tnl_removed.insert(*x);
             }
         }
         for x in &tnl_removed {
@@ -389,7 +389,7 @@ impl std::str::FromStr for Ipv6Prefix {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
 )]
 pub struct TunnelRoute {
     pub origin: TunnelOrigin,
@@ -402,12 +402,14 @@ pub struct TunnelRoute {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
 )]
 pub struct TunnelOrigin {
     pub overlay_prefix: IpPrefix,
     pub boundary_addr: Ipv6Addr,
     pub vni: u32,
+    #[serde(default)]
+    pub metric: u64,
 }
 
 impl From<crate::db::TunnelRoute> for TunnelOrigin {
@@ -416,6 +418,7 @@ impl From<crate::db::TunnelRoute> for TunnelOrigin {
             overlay_prefix: x.origin.overlay_prefix,
             boundary_addr: x.origin.boundary_addr,
             vni: x.origin.vni,
+            metric: x.origin.metric,
         }
     }
 }
@@ -522,5 +525,266 @@ impl std::str::FromStr for IpPrefix {
             return Ok(IpPrefix::V4(result));
         }
         Ok(IpPrefix::V6(Ipv6Prefix::from_str(s)?))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum EffectiveTunnelRouteSet {
+    /// The routes in the contained set are active with priority greater than
+    /// zero.
+    Active(HashSet<TunnelRoute>),
+
+    /// The routes in the contained set are inactive with a priority equal to
+    /// zero.
+    Inactive(HashSet<TunnelRoute>),
+}
+
+impl EffectiveTunnelRouteSet {
+    fn values(&self) -> &HashSet<TunnelRoute> {
+        match self {
+            EffectiveTunnelRouteSet::Active(s) => s,
+            EffectiveTunnelRouteSet::Inactive(s) => s,
+        }
+    }
+}
+
+//NOTE this is the same algorithm as rdb::Db::effective_rotue set but for
+//     tunnel routes. We need to apply the same logic here, but because
+//     the server routers get tunnel endpoint information from a disparate
+//     set of transit routers that are not in cahoots, we need to calculate
+//     the effective set for all the tunneled routes for all endpoints.
+pub fn effective_route_set(
+    full: &HashSet<TunnelRoute>,
+) -> HashSet<TunnelRoute> {
+    let mut sets = HashMap::<IpPrefix, EffectiveTunnelRouteSet>::new();
+    for x in full.iter() {
+        match sets.get_mut(&x.origin.overlay_prefix) {
+            Some(set) => {
+                if x.origin.metric > 0 {
+                    match set {
+                        EffectiveTunnelRouteSet::Active(s) => {
+                            s.insert(*x);
+                        }
+                        EffectiveTunnelRouteSet::Inactive(_) => {
+                            let mut value = HashSet::new();
+                            value.insert(*x);
+                            sets.insert(
+                                x.origin.overlay_prefix,
+                                EffectiveTunnelRouteSet::Active(value),
+                            );
+                        }
+                    }
+                } else {
+                    match set {
+                        EffectiveTunnelRouteSet::Active(_) => {
+                            //Nothing to do here, the active set takes priority
+                        }
+                        EffectiveTunnelRouteSet::Inactive(s) => {
+                            s.insert(*x);
+                        }
+                    }
+                }
+            }
+            None => {
+                let mut value = HashSet::new();
+                value.insert(*x);
+                if x.origin.metric > 0 {
+                    sets.insert(
+                        x.origin.overlay_prefix,
+                        EffectiveTunnelRouteSet::Active(value),
+                    );
+                } else {
+                    sets.insert(
+                        x.origin.overlay_prefix,
+                        EffectiveTunnelRouteSet::Inactive(value),
+                    );
+                }
+            }
+        }
+    }
+    let mut result = HashSet::new();
+    for xs in sets.values() {
+        for x in xs.values() {
+            let mut v = *x;
+            //NOTE the point of this function is to determine an effective set
+            //     of routes based on the metric value to send to a data plane.
+            //     So from the data plane's perspective all routes returned
+            //     from this function are equally viable. Thus, we set the
+            //     metric to zero so there are not hash function differences
+            //     on subsequent operations involving the returned set.
+            v.origin.metric = 0;
+            result.insert(v);
+        }
+    }
+    result
+}
+
+pub fn effective_set_for_prefix(
+    imported: &HashSet<TunnelRoute>,
+    prefix: IpPrefix,
+) -> EffectiveTunnelRouteSet {
+    let full: HashSet<TunnelRoute> = imported
+        .iter()
+        .filter(|x| x.origin.overlay_prefix == prefix)
+        .copied()
+        .collect();
+
+    let shutdown: HashSet<TunnelRoute> = full
+        .iter()
+        .filter(|x| x.origin.metric == 0)
+        .copied()
+        .collect();
+
+    let active: HashSet<TunnelRoute> = full
+        .iter()
+        .filter(|x| x.origin.metric > 0)
+        .copied()
+        .collect();
+
+    match (active.len(), shutdown.len()) {
+        (0, _) => EffectiveTunnelRouteSet::Inactive(shutdown),
+        (_, 0) => EffectiveTunnelRouteSet::Active(active),
+        _ => EffectiveTunnelRouteSet::Active(active),
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct TunnelRouteChangeSet {
+    pub added: HashSet<TunnelRoute>,
+    pub removed: HashSet<TunnelRoute>,
+}
+
+pub fn tunnel_route_change_set(
+    before: &EffectiveTunnelRouteSet,
+    after: &EffectiveTunnelRouteSet,
+) -> Option<TunnelRouteChangeSet> {
+    match (before, after) {
+        (
+            EffectiveTunnelRouteSet::Active(before),
+            EffectiveTunnelRouteSet::Active(after),
+        ) => {
+            let added: HashSet<TunnelRoute> =
+                after.difference(before).copied().collect();
+
+            let removed: HashSet<TunnelRoute> =
+                before.difference(after).copied().collect();
+
+            if added.is_empty() && removed.is_empty() {
+                return None;
+            }
+
+            Some(TunnelRouteChangeSet { added, removed })
+        }
+        (
+            EffectiveTunnelRouteSet::Active(before),
+            EffectiveTunnelRouteSet::Inactive(_after),
+        ) => Some(TunnelRouteChangeSet {
+            removed: before.clone(),
+            ..Default::default()
+        }),
+        (
+            EffectiveTunnelRouteSet::Inactive(_before),
+            EffectiveTunnelRouteSet::Active(after),
+        ) => Some(TunnelRouteChangeSet {
+            added: after.clone(),
+            ..Default::default()
+        }),
+
+        (
+            EffectiveTunnelRouteSet::Inactive(_before),
+            EffectiveTunnelRouteSet::Inactive(_after),
+        ) => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_effective_tunnel_route_set() {
+        let mut before = HashSet::<TunnelRoute>::new();
+        before.insert(TunnelRoute {
+            origin: TunnelOrigin {
+                overlay_prefix: IpPrefix::V4(Ipv4Prefix {
+                    addr: "0.0.0.0".parse().unwrap(),
+                    len: 0,
+                }),
+                boundary_addr: "fd00:a::1".parse().unwrap(),
+                vni: 99,
+                metric: 0,
+            },
+            nexthop: "fe80:a::1".parse().unwrap(),
+        });
+        before.insert(TunnelRoute {
+            origin: TunnelOrigin {
+                overlay_prefix: IpPrefix::V4(Ipv4Prefix {
+                    addr: "0.0.0.0".parse().unwrap(),
+                    len: 0,
+                }),
+                boundary_addr: "fd00:b::1".parse().unwrap(),
+                vni: 99,
+                metric: 0,
+            },
+            nexthop: "fe80:b::1".parse().unwrap(),
+        });
+        let effective_before = effective_route_set(&before);
+
+        let mut after = HashSet::<TunnelRoute>::new();
+        after.insert(TunnelRoute {
+            origin: TunnelOrigin {
+                overlay_prefix: IpPrefix::V4(Ipv4Prefix {
+                    addr: "0.0.0.0".parse().unwrap(),
+                    len: 0,
+                }),
+                boundary_addr: "fd00:a::1".parse().unwrap(),
+                vni: 99,
+                metric: 0,
+            },
+            nexthop: "fe80:a::1".parse().unwrap(),
+        });
+        after.insert(TunnelRoute {
+            origin: TunnelOrigin {
+                overlay_prefix: IpPrefix::V4(Ipv4Prefix {
+                    addr: "0.0.0.0".parse().unwrap(),
+                    len: 0,
+                }),
+                boundary_addr: "fd00:b::1".parse().unwrap(),
+                vni: 99,
+                metric: 100,
+            },
+            nexthop: "fe80:b::1".parse().unwrap(),
+        });
+        let effective_after = effective_route_set(&after);
+
+        let to_add: HashSet<TunnelRoute> = effective_after
+            .difference(&effective_before)
+            .copied()
+            .collect();
+
+        let expected_add = HashSet::<TunnelRoute>::new();
+        assert_eq!(to_add, expected_add);
+
+        let to_del: HashSet<TunnelRoute> = effective_before
+            .difference(&effective_after)
+            .copied()
+            .collect();
+
+        let mut expected_del = HashSet::<TunnelRoute>::new();
+        expected_del.insert(TunnelRoute {
+            origin: TunnelOrigin {
+                overlay_prefix: IpPrefix::V4(Ipv4Prefix {
+                    addr: "0.0.0.0".parse().unwrap(),
+                    len: 0,
+                }),
+                boundary_addr: "fd00:a::1".parse().unwrap(),
+                vni: 99,
+                metric: 0,
+            },
+            nexthop: "fe80:a::1".parse().unwrap(),
+        });
+        assert_eq!(to_del, expected_del);
     }
 }

--- a/ddmadm/src/main.rs
+++ b/ddmadm/src/main.rs
@@ -79,6 +79,9 @@ struct TunnelEndpoint {
 
     #[arg(short, long)]
     pub vni: u32,
+
+    #[arg(short, long)]
+    pub metric: u64,
 }
 
 #[derive(Debug, Parser)]
@@ -193,18 +196,20 @@ async fn run() -> Result<()> {
             let mut tw = TabWriter::new(stdout());
             writeln!(
                 &mut tw,
-                "{}\t{}\t{}",
+                "{}\t{}\t{}\t{}",
                 "Overlay Prefix".dimmed(),
                 "Boundary Address".dimmed(),
                 "VNI".dimmed(),
+                "Metric".dimmed(),
             )?;
             for endpoint in msg.into_inner() {
                 writeln!(
                     &mut tw,
-                    "{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}",
                     endpoint.origin.overlay_prefix,
                     endpoint.origin.boundary_addr,
                     endpoint.origin.vni,
+                    endpoint.origin.metric,
                 )?;
             }
             tw.flush()?;
@@ -214,18 +219,20 @@ async fn run() -> Result<()> {
             let mut tw = TabWriter::new(stdout());
             writeln!(
                 &mut tw,
-                "{}\t{}\t{}",
+                "{}\t{}\t{}\t{}",
                 "Overlay Prefix".dimmed(),
                 "Boundary Address".dimmed(),
                 "VNI".dimmed(),
+                "Metric".dimmed(),
             )?;
             for endpoint in msg.into_inner() {
                 writeln!(
                     &mut tw,
-                    "{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}",
                     endpoint.overlay_prefix,
                     endpoint.boundary_addr,
                     endpoint.vni,
+                    endpoint.metric,
                 )?;
             }
             tw.flush()?;
@@ -236,6 +243,7 @@ async fn run() -> Result<()> {
                     overlay_prefix: ep.overlay_prefix,
                     boundary_addr: ep.boundary_addr,
                     vni: ep.vni,
+                    metric: ep.metric,
                 }])
                 .await?;
         }
@@ -245,6 +253,7 @@ async fn run() -> Result<()> {
                     overlay_prefix: ep.overlay_prefix,
                     boundary_addr: ep.boundary_addr,
                     vni: ep.vni,
+                    metric: ep.metric,
                 }])
                 .await?;
         }

--- a/mg-lower/src/ddm.rs
+++ b/mg-lower/src/ddm.rs
@@ -29,11 +29,8 @@ pub(crate) fn update_tunnel_endpoints(
     .into_iter()
     .collect();
 
-    let target: HashSet<TunnelOrigin> = routes
-        .iter()
-        .filter(|x| x.priority > 0)
-        .map(|x| route_to_tunnel(tep, x))
-        .collect();
+    let target: HashSet<TunnelOrigin> =
+        routes.iter().map(|x| route_to_tunnel(tep, x)).collect();
 
     let to_add = target.difference(&current);
     let to_remove = current.difference(&target);
@@ -84,6 +81,7 @@ fn route_to_tunnel(tep: Ipv6Addr, x: &Route4ImportKey) -> TunnelOrigin {
         ),
         boundary_addr: tep,
         vni: BOUNDARY_SERVICES_VNI, //TODO?
+        metric: x.priority,
     }
 }
 

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -128,11 +128,7 @@ fn full_sync(
 ) -> Result<u64, Error> {
     let generation = db.generation();
 
-    let db_imported: Vec<rdb::Route4ImportKey> = db
-        .get_imported4()
-        .into_iter()
-        .filter(|x| x.priority > 0)
-        .collect();
+    let db_imported: Vec<rdb::Route4ImportKey> = db.effective_route_set();
 
     ensure_tep_addr(tep, dpd, rt.clone(), log);
 

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -193,13 +193,9 @@ fn handle_change(
     if change.generation > generation + 1 {
         return full_sync(tep, db, log, dpd, ddm, rt.clone());
     }
-    let to_add: Vec<rdb::Route4ImportKey> = change
-        .import
-        .added
-        .clone()
-        .into_iter()
-        .filter(|x| x.priority > 0)
-        .collect();
+    let to_add: Vec<rdb::Route4ImportKey> =
+        change.import.added.clone().into_iter().collect();
+
     add_tunnel_routes(tep, ddm, &to_add, rt.clone(), log);
     let to_add = db_route_to_dendrite_route(to_add, log, dpd);
 

--- a/mgd/src/bfd_admin.rs
+++ b/mgd/src/bfd_admin.rs
@@ -357,6 +357,11 @@ impl Dispatcher {
     ) {
         loop {
             if kill_switch.load(std::sync::atomic::Ordering::Relaxed) {
+                warn!(
+                    log,
+                    "kill switch activated for listener on {:?}",
+                    sk.local_addr()
+                );
                 break;
             }
             // Maximum length of a BFD packet is on the order of 100 bytes (RFC

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -84,6 +84,15 @@ pub enum EffectiveRouteSet {
     Inactive(HashSet<Route4ImportKey>),
 }
 
+impl EffectiveRouteSet {
+    fn values(&self) -> &HashSet<Route4ImportKey> {
+        match self {
+            EffectiveRouteSet::Active(s) => s,
+            EffectiveRouteSet::Inactive(s) => s,
+        }
+    }
+}
+
 //TODO we need bulk operations with atomic semantics here.
 impl Db {
     /// Create a new routing database that stores persistent data at `path`.
@@ -508,6 +517,61 @@ impl Db {
             (_, 0) => EffectiveRouteSet::Active(active),
             _ => EffectiveRouteSet::Active(active),
         }
+    }
+
+    pub fn effective_route_set(&self) -> Vec<Route4ImportKey> {
+        let full = lock!(self.imported).clone();
+        let mut sets = HashMap::<Prefix4, EffectiveRouteSet>::new();
+        for x in full.iter() {
+            match sets.get_mut(&x.prefix) {
+                Some(set) => {
+                    if x.priority > 0 {
+                        match set {
+                            EffectiveRouteSet::Active(s) => {
+                                s.insert(*x);
+                            }
+                            EffectiveRouteSet::Inactive(_) => {
+                                let mut value = HashSet::new();
+                                value.insert(*x);
+                                sets.insert(
+                                    x.prefix,
+                                    EffectiveRouteSet::Active(value),
+                                );
+                            }
+                        }
+                    } else {
+                        match set {
+                            EffectiveRouteSet::Active(_) => {
+                                //Nothing to do here, the active set takes priority
+                            }
+                            EffectiveRouteSet::Inactive(s) => {
+                                s.insert(*x);
+                            }
+                        }
+                    }
+                }
+                None => {
+                    let mut value = HashSet::new();
+                    value.insert(*x);
+                    if x.priority > 0 {
+                        sets.insert(x.prefix, EffectiveRouteSet::Active(value));
+                    } else {
+                        sets.insert(
+                            x.prefix,
+                            EffectiveRouteSet::Inactive(value),
+                        );
+                    }
+                }
+            };
+        }
+
+        let mut result = Vec::new();
+        for xs in sets.values() {
+            for x in xs.values() {
+                result.push(*x);
+            }
+        }
+        result
     }
 
     /// Compute a a change set for a before/after set of routes including

--- a/tests/src/ddm.rs
+++ b/tests/src/ddm.rs
@@ -575,6 +575,7 @@ async fn run_trio_tests(
             overlay_prefix: "203.0.113.0/24".parse().unwrap(),
             boundary_addr: "fd00:1701::1".parse().unwrap(),
             vni: 47,
+            metric: 0,
         }])
         .await?;
 
@@ -591,6 +592,7 @@ async fn run_trio_tests(
             overlay_prefix: "203.0.113.0/24".parse().unwrap(),
             boundary_addr: "fd00:1701::1".parse().unwrap(),
             vni: 47,
+            metric: 0,
         }])
         .await?;
 
@@ -616,6 +618,7 @@ async fn run_trio_tests(
             overlay_prefix: "203.0.113.0/24".parse().unwrap(),
             boundary_addr: "fd00:1701::1".parse().unwrap(),
             vni: 47,
+            metric: 0,
         }])
         .await?;
 


### PR DESCRIPTION
This change makes it possible for operators of Oxide racks to transition to/from BFD without downtime.

In traditional BFD/static-routing setups, when a BFD session associated with the nexthop of a route enters the `down` state, that route is removed from the data plane routing tables. This means there is no graceful way to light up a BFD session, since we have to pick one end of the session to start first, and it will detect that the other side is down and start removing all the routes associated with the corresponding nexthop.

There are a few solutions to this problem. For example, the approach taken by FRR is to separate enabling BFD's upper half that implements the protocol, from the lower half that modifies the data plane routing tables. This works well for bootstrapping BFD without loss of comms if things are done carefully.

What about the reverse problem, e.g., graceful transition off of BFD? With the separation of upper and lower halves, one could carefully disable the lower halves of BFD implementations on one half of a network bisection for planned maintenance. This can definitely be done - but it's one of those scary operations that should probably be done inside a maintenance window where downtime due to a mishap would be acceptable. And this only works for planned events, if some part of a BFD network stops speaking BFD, there is going to be a loss of comms.

This PR opts for something that is hopefully a bit more robust, is fully automatic, and does not rely on careful, tedious, potentially error-prone, and certainly anxiety-driving maintenance operations.

The primary change here is that we view BFD session state as an _indicator_ of nexthop viability instead of a _necessary condition_. The basic logic is this. If there are multiple nexthops for a given prefix then:

- If some nexthops have BFD sessions that are up and some do not, only add the ones that are up to the data plane RIB.
- If all nexthops have BFD sessions that are up, add them all to the data plane RIB.
- If all nexthops have BFD sessions that are down, add them all to the data plane RIB.

The last bullet may seem a bit odd at first glance, but it's the key to achieving the goals here. If we have no viable nexthops according to BFD, then there is really no harm in trying to use any of the equally bad (according to BFD) options in front of us. This allows for graceful BFD startup and shutdown with no operator involvement required. It also handles BFD weather from neighbors gracefully.

This was always the intent of the BFD implementation. But the first cut at it fell short in two key areas.

- The full sync operation in `mg_lower` was just cutting out any routes that had their priority dropped to zero due to a BFD session going down. We had implemented the logic above on incremental `mg_lower` updates, but not for the full sync.
- The data plane routing tables on the rack switches are not the only place that matters here. We have a tunneled overlay/underlay network on the rack that adds and withdraws tunnel endpoints according to external routes coming and going (see RFD 404 for more detail). Previously, if a set of nexthops for a rack switch became unavailable according to BFD, the corresponding tunnel routes would be withdrawn from the underlay network. This is not consistent with the three-part logic above. There is also an additional wrinkle here though. Each server sled operating off tunnel routing information is getting that information from _at least two routers_. The compute sleds are manipulating OPTE's virt-to-boundary routing tables and need to be able to perform the 3-part logic above. But in order to do that, they need an indicator of whether BFD thinks the route is viable or not. We don't really want DDM to be BFD aware, so we've abstracted BFD's take on nexthop viability into a new `metric` field added to tunnel route advertisements. In this initial commit the metric is `100` for routes with a BFD session that is up, or for routes that have no BFD session configured, and is `0` for routes that have BFD configured where the session is down. More sophisticated schemes may come into play later, such as ranking prefixes based on the number of viable nexthops for static routing, or, bringing the BGP metric into play when we connect BFD and BGP. The DDM lower half for OPTE then performs a set calculation according to the three-way logic above when setting up the boundary routing tables in OPTE.

This has been tested and is behaving as expected in `a4x2`. In particular, graceful startup works, and combinatorially taking down sessions behaves as expected. The rack can continue to communicate with the outside world independent of the number of BFD sessions that are actually up (assuming the upstream routers are actually viable).

The new `metric` field in the TunnelRoute message has a `#[serde(default)],` so this should be backward compatible, defaulting to the zero-valued metric.

- Fixes #172