### PR TITLE
implement bgp message tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "hyper",
  "ispf",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "mg-common",
  "opte-ioctl",
  "oxide-vpc",
  "pretty_assertions",
@@ -719,7 +720,7 @@ dependencies = [
 name = "ddm-admin-client"
 version = "0.1.0"
 dependencies = [
- "ddm",
+ "mg-common",
  "percent-encoding",
  "progenitor 0.5.0 (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "reqwest",
@@ -1881,6 +1882,9 @@ version = "0.1.0"
 dependencies = [
  "anstyle",
  "clap",
+ "schemars",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ name = "bgp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "lazy_static",
  "mg-common",
  "nom",
@@ -1862,6 +1863,8 @@ name = "mg-admin-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bgp",
+ "chrono",
  "percent-encoding",
  "progenitor 0.5.0 (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "rdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,6 +1866,7 @@ dependencies = [
  "progenitor 0.5.0 (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "rdb",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "slog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0", features = ["derive"] }
 hostname = "0.3"
 thiserror = "1.0"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
-schemars = { version = "0.8", features = [ "uuid" ] }
+schemars = { version = "0.8", features = [ "uuid", "chrono" ] }
 tokio = { version = "1.36", features = ["full"] }
 serde_repr = "0.1"
 anyhow = "1.0"
@@ -78,6 +78,7 @@ http = "0.2"
 humantime = "2.1"
 rand = "0.8"
 mg-common = { path = "mg-common" }
+chrono = { version = "0.4", features = ["serde"] }
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"

--- a/bgp/Cargo.toml
+++ b/bgp/Cargo.toml
@@ -16,6 +16,7 @@ schemars.workspace = true
 sled.workspace = true
 anyhow.workspace = true
 mg-common.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 pretty-hex.workspace = true

--- a/bgp/src/messages.rs
+++ b/bgp/src/messages.rs
@@ -55,6 +55,7 @@ impl From<&Message> for MessageType {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum Message {
     Open(OpenMessage),
     Update(UpdateMessage),
@@ -698,6 +699,7 @@ pub mod path_attribute_flags {
     Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum PathAttributeTypeCode {
     /// RFC 4271
     Origin = 1,
@@ -746,6 +748,7 @@ impl From<PathAttributeValue> for PathAttributeTypeCode {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum PathAttributeValue {
     Origin(PathOrigin),
     /* TODO according to RFC 4893 we do not have this as an explicit attribute
@@ -872,6 +875,7 @@ impl PathAttributeValue {
     JsonSchema,
 )]
 #[repr(u32)]
+#[serde(rename_all = "snake_case")]
 pub enum Community {
     /// All routes received carrying a communities attribute
     /// containing this value MUST NOT be advertised outside a BGP
@@ -901,6 +905,7 @@ pub enum Community {
     Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum PathOrigin {
     Igp = 0,
     Egp = 1,
@@ -962,6 +967,7 @@ impl As4PathSegment {
     Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum AsPathType {
     AsSet = 1,
     AsSequence = 2,
@@ -1097,6 +1103,7 @@ impl NotificationMessage {
     Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum ErrorCode {
     Header = 1,
     Open,
@@ -1107,6 +1114,7 @@ pub enum ErrorCode {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ErrorSubcode {
     Header(HeaderErrorSubcode),
     Open(OpenErrorSubcode),
@@ -1151,6 +1159,7 @@ impl ErrorSubcode {
     Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum HeaderErrorSubcode {
     Unspecific = 0,
     ConnectionNotSynchronized,
@@ -1162,6 +1171,7 @@ pub enum HeaderErrorSubcode {
     Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum OpenErrorSubcode {
     Unspecific = 0,
     UnsupportedVersionNumber,
@@ -1177,6 +1187,7 @@ pub enum OpenErrorSubcode {
     Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
 )]
 #[repr(u8)]
+#[serde(rename_all = "snake_case")]
 pub enum UpdateErrorSubcode {
     Unspecific = 0,
     MalformedAttributeList,
@@ -1194,6 +1205,7 @@ pub enum UpdateErrorSubcode {
 
 /// The IANA/IETF currently defines the following optional parameter types.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum OptionalParameter {
     /// Code 0
     Reserved,
@@ -1285,6 +1297,7 @@ pub struct AddPathElement {
 /// the TODOs below is here
 /// <https://github.com/oxidecomputer/maghemite/issues/80>
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum Capability {
     /// RFC 2858 TODO
     MultiprotocolExtensions {

--- a/bgp/src/messages.rs
+++ b/bgp/src/messages.rs
@@ -251,7 +251,7 @@ impl OpenMessage {
             .push(OptionalParameter::Capabilities(capabilities.into()));
     }
 
-    /// Serilize an open message to wire format.
+    /// Serialize an open message to wire format.
     pub fn to_wire(&self) -> Result<Vec<u8>, Error> {
         let mut buf = Vec::new();
 
@@ -510,7 +510,7 @@ impl UpdateMessage {
     }
 }
 
-/// This data structure captures a network prefix as it's layed out in a BGP
+/// This data structure captures a network prefix as it's laid out in a BGP
 /// message. There is a prefix length followed by a variable number of bytes.
 /// Just enough bytes to express the prefix.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
@@ -705,9 +705,9 @@ pub mod path_attribute_flags {
     pub const OPTIONAL: u8 = 0b10000000;
     /// Path attribute must be redistributed
     pub const TRANSITIVE: u8 = 0b01000000;
-    /// Treat path attribute as parrital
+    /// Treat path attribute as partial
     pub const PARTIAL: u8 = 0b00100000;
-    /// If set the path attribute lenght is encoded in two octets instead o
+    /// If set the path attribute length is encoded in two octets instead o
     /// one
     pub const EXTENDED_LENGTH: u8 = 0b00010000;
 }
@@ -1043,7 +1043,7 @@ pub enum AsPathType {
 }
 
 /// Notification messages are exchanged between BGP peers when an exceptional
-/// event has occured.
+/// event has occurred.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct NotificationMessage {
     /// Error code associated with the notification
@@ -1389,7 +1389,7 @@ impl OptionalParameter {
     }
 }
 
-/// The `AddPathElement` comes as a BGP capability extension as described in
+/// The add path element comes as a BGP capability extension as described in
 /// RFC 7911.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AddPathElement {
@@ -1405,92 +1405,137 @@ pub struct AddPathElement {
     pub send_receive: u8,
 }
 
-/// Optional capabilities supported by a BGP implementation. An issue tracking
-/// the TODOs below is here
-/// <https://github.com/oxidecomputer/maghemite/issues/80>
+// An issue tracking the TODOs below is here
+// <https://github.com/oxidecomputer/maghemite/issues/80>
+
+/// Optional capabilities supported by a BGP implementation.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Capability {
-    /// RFC 2858 TODO
+    /// Multiprotocol extensions as defined in RFC 2858
     MultiprotocolExtensions {
         afi: u16,
         safi: u8,
     },
 
-    /// RFC 2918 TODO
+    //TODO
+    /// Route refresh capability as defined in RFC 2918. Note this capability
+    /// is not yet implemented.
     RouteRefresh {},
 
-    /// RFC 5291 TODO
+    //TODO
+    /// Outbound filtering capability as defined in RFC 5291. Note this
+    /// capability is not yet implemented.
     OutboundRouteFiltering {},
 
-    /// RFC 8277 (deprecated) TODO
+    //TODO
+    /// Multiple routes to destination capability as defined in RFC 8277
+    /// (deprecated). Note this capability is not yet implemented.
     MultipleRoutesToDestination {},
 
-    /// RFC 8950 TODO
+    //TODO
+    /// Multiple nexthop encoding capability as defined in RFC 8950. Note this
+    /// capability is not yet implemented.
     ExtendedNextHopEncoding {},
 
-    /// RFC 8654 TODO
+    //TODO
+    /// Extended message capability as defined in RFC 8654. Note this
+    /// capability is not yet implemented.
     BGPExtendedMessage {},
 
-    /// RFC 8205 TODO
+    //TODO
+    /// BGPSec as defined in RFC 8205. Note this capability is not yet
+    /// implemented.
     BgpSec {},
 
-    /// RFC 8277 TODO
+    //TODO
+    /// Multiple label support as defined in RFC 8277. Note this capability
+    /// is not yet implemented.
     MultipleLabels {},
 
-    /// RFC 9234 TODO
+    //TODO
+    /// BGP role capability as defined in RFC 9234. Note this capability is not
+    /// yet implemented.
     BgpRole {},
 
-    /// RFC 4724 TODO
+    //TODO
+    /// Graceful restart as defined in RFC 4724. Note this capability is not
+    /// yet implemented.
     GracefulRestart {},
 
-    /// RFC 6793
+    /// Four octet AS numbers as defined in RFC 6793.
     FourOctetAs {
         asn: u32,
     },
 
-    /// draft-ietf-idr-dynamic-cap TODO
+    //TODO
+    /// Dynamic capabilities as defined in draft-ietf-idr-dynamic-cap. Note
+    /// this capability is not yet implemented.
     DynamicCapability {},
 
-    /// draft-ietf-idr-bgp-multisession TODO
+    //TODO
+    /// Multi session support as defined in draft-ietf-idr-bgp-multisession.
+    /// Note this capability is not yet supported.
     MultisessionBgp {},
 
-    /// RFC 7911
+    /// Add path capability as defined in RFC 7911.
     AddPath {
         elements: Vec<AddPathElement>,
     },
 
-    /// RFC 7313 TODO
+    //TODO
+    /// Enhanced route refresh as defined in RFC 7313. Note this capability is
+    /// not yet supported.
     EnhancedRouteRefresh {},
 
-    /// draft-uttaro-idr-bgp-persistence TODO
+    //TODO
+    /// Long-lived graceful restart as defined in
+    /// draft-uttaro-idr-bgp-persistence. Note this capability is not yet
+    /// supported.
     LongLivedGracefulRestart {},
 
-    /// draft-ietf-idr-rpd-04 TODO
+    //TODO
+    /// Routing policy distribution as defined indraft-ietf-idr-rpd-04. Note
+    /// this capability is not yet supported.
     RoutingPolicyDistribution {},
 
-    /// draft-walton-bgp-hostname-capability TODO
+    //TODO
+    /// Fully qualified domain names as defined
+    /// intdraft-walton-bgp-hostname-capability. Note this capability is not
+    /// yet supported.
     Fqdn {},
 
-    /// RFC 8810 (deprecated) TODO
+    //TODO
+    /// Pre-standard route refresh as defined in RFC 8810 (deprecated). Note
+    /// this capability is not yet supported.
     PrestandardRouteRefresh {},
 
-    /// RFC 8810 (deprecated) TODO
+    //TODO
+    /// Pre-standard prefix-based outbound route filtering as defined in
+    /// RFC 8810 (deprecated). Note this is not yet implemented.
     PrestandardOrfAndPd {},
 
-    /// RFC 8810 (deprecated) TODO
+    //TODO
+    /// Pre-standard outbound route filtering as defined in RFC 8810
+    /// (deprecated). Note this is not yet implemented.
     PrestandardOutboundRouteFiltering {},
 
-    /// RFC 8810 (deprecated) TODO
+    //TODO
+    /// Pre-standard multisession as defined in RFC 8810 (deprecated). Note
+    /// this is not yet implemented.
     PrestandardMultisession {},
 
-    /// RFC 8810 (deprecated) TODO
+    //TODO
+    /// Pre-standard fully qualified domain names as defined in RFC 8810
+    /// (deprecated). Note this is not yet implemented.
     PrestandardFqdn {},
 
-    /// RFC 8810 (deprecated) TODO
+    //TODO
+    /// Pre-standard operational messages as defined in RFC 8810 (deprecated).
+    /// Note this is not yet implemented.
     PrestandardOperationalMessage {},
 
-    /// RFC 8810
+    /// Experimental capability as defined in RFC 8810.
     Experimental {
         code: u8,
     },
@@ -1498,6 +1543,7 @@ pub enum Capability {
     Unassigned {
         code: u8,
     },
+
     Reserved {
         code: u8,
     },
@@ -1862,7 +1908,7 @@ impl Capability {
     }
 }
 
-// The set of capabilitiy codes supported by this BGP implementation
+/// The set of capability codes supported by this BGP implementation
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum CapabilityCode {

--- a/bgp/src/messages.rs
+++ b/bgp/src/messages.rs
@@ -8,6 +8,8 @@ use nom::{
     number::complete::{be_u16, be_u32, be_u8, u8 as parse_u8},
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use schemars::JsonSchema;
+use serde::Serialize;
 use std::net::{IpAddr, Ipv4Addr};
 
 pub const MAX_MESSAGE_SIZE: usize = 4096;
@@ -52,7 +54,7 @@ impl From<&Message> for MessageType {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, JsonSchema)]
 pub enum Message {
     Open(OpenMessage),
     Update(UpdateMessage),
@@ -186,7 +188,7 @@ pub const BGP4: u8 = 4;
 /// ```
 ///
 /// Ref: RFC 4271 §4.2
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct OpenMessage {
     /// BGP protocol version.
     pub version: u8,
@@ -358,7 +360,7 @@ pub struct Tlv {
 /// ```
 ///
 /// Ref: RFC 4271 §4.3
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, Serialize, JsonSchema)]
 pub struct UpdateMessage {
     pub withdrawn: Vec<Prefix>,
     pub path_attributes: Vec<PathAttribute>,
@@ -506,7 +508,7 @@ impl UpdateMessage {
 /// This data structure captures a network prefix as it's layed out in a BGP
 /// message. There is a prefix length followed by a variable number of bytes.
 /// Just enough bytes to express the prefix.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct Prefix {
     pub length: u8,
     pub value: Vec<u8>,
@@ -599,7 +601,7 @@ impl From<rdb::Prefix4> for Prefix {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct PathAttribute {
     pub typ: PathAttributeType,
     pub value: PathAttributeValue,
@@ -666,7 +668,7 @@ impl PathAttribute {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct PathAttributeType {
     pub flags: u8,
     pub type_code: PathAttributeTypeCode,
@@ -692,7 +694,9 @@ pub mod path_attribute_flags {
     pub const EXTENDED_LENGTH: u8 = 0b00010000;
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum PathAttributeTypeCode {
     /// RFC 4271
@@ -741,7 +745,7 @@ impl From<PathAttributeValue> for PathAttributeTypeCode {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub enum PathAttributeValue {
     Origin(PathOrigin),
     /* TODO according to RFC 4893 we do not have this as an explicit attribute
@@ -857,7 +861,15 @@ impl PathAttributeValue {
 }
 
 #[derive(
-    Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, IntoPrimitive,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    TryFromPrimitive,
+    IntoPrimitive,
+    Serialize,
+    JsonSchema,
 )]
 #[repr(u32)]
 pub enum Community {
@@ -885,7 +897,9 @@ pub enum Community {
     GracefulShutdown = 0xFFFF0000,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum PathOrigin {
     Igp = 0,
@@ -899,7 +913,7 @@ pub struct AsPathSegment {
     pub value: Vec<u16>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct As4PathSegment {
     pub typ: AsPathType,
     pub value: Vec<u32>,
@@ -944,14 +958,16 @@ impl As4PathSegment {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum AsPathType {
     AsSet = 1,
     AsSequence = 2,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct NotificationMessage {
     pub error_code: ErrorCode,
     pub error_subcode: ErrorSubcode,
@@ -1077,7 +1093,9 @@ impl NotificationMessage {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum ErrorCode {
     Header = 1,
@@ -1088,7 +1106,7 @@ pub enum ErrorCode {
     Cease,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub enum ErrorSubcode {
     Header(HeaderErrorSubcode),
     Open(OpenErrorSubcode),
@@ -1129,7 +1147,9 @@ impl ErrorSubcode {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum HeaderErrorSubcode {
     Unspecific = 0,
@@ -1138,7 +1158,9 @@ pub enum HeaderErrorSubcode {
     BadMessageType,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum OpenErrorSubcode {
     Unspecific = 0,
@@ -1151,7 +1173,9 @@ pub enum OpenErrorSubcode {
     UnsupportedCapability,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, TryFromPrimitive, Serialize, JsonSchema,
+)]
 #[repr(u8)]
 pub enum UpdateErrorSubcode {
     Unspecific = 0,
@@ -1169,7 +1193,7 @@ pub enum UpdateErrorSubcode {
 }
 
 /// The IANA/IETF currently defines the following optional parameter types.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub enum OptionalParameter {
     /// Code 0
     Reserved,
@@ -1243,7 +1267,7 @@ impl OptionalParameter {
 
 /// The `AddPathElement` comes as a BGP capability extension as described in
 /// RFC 7911.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub struct AddPathElement {
     /// Address family identifier.
     /// <https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml>
@@ -1260,7 +1284,7 @@ pub struct AddPathElement {
 /// Optional capabilities supported by a BGP implementation. An issue tracking
 /// the TODOs below is here
 /// <https://github.com/oxidecomputer/maghemite/issues/80>
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, JsonSchema)]
 pub enum Capability {
     /// RFC 2858 TODO
     MultiprotocolExtensions {

--- a/bgp/src/messages.rs
+++ b/bgp/src/messages.rs
@@ -707,7 +707,7 @@ pub mod path_attribute_flags {
     pub const TRANSITIVE: u8 = 0b01000000;
     /// Treat path attribute as partial
     pub const PARTIAL: u8 = 0b00100000;
-    /// If set the path attribute length is encoded in two octets instead o
+    /// If set the path attribute length is encoded in two octets instead of
     /// one
     pub const EXTENDED_LENGTH: u8 = 0b00010000;
 }
@@ -973,7 +973,7 @@ pub struct AsPathSegment {
     pub value: Vec<u16>,
 }
 
-// A self 4-byte describing segment found in path sets and sequences.
+// A self describing segment found in path sets and sequences of 4-byte ASNs.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct As4PathSegment {
     // Indicates if this segment is a part of a set or sequence.

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -373,10 +373,18 @@ pub struct NeighborInfo {
 
 pub const MAX_MESSAGE_HISTORY: usize = 1024;
 
-#[derive(Default, Debug, Clone, Serialize, JsonSchema)]
+/// A message history entry is a BGP message with an associated timestamp
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MessageHistoryEntry {
+    timestamp: chrono::DateTime<chrono::Utc>,
+    message: Message,
+}
+
+/// Message history for a BGP session
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MessageHistory {
-    pub received: VecDeque<Message>,
-    pub sent: VecDeque<Message>,
+    pub received: VecDeque<MessageHistoryEntry>,
+    pub sent: VecDeque<MessageHistoryEntry>,
 }
 
 impl MessageHistory {
@@ -384,14 +392,20 @@ impl MessageHistory {
         if self.received.len() >= MAX_MESSAGE_HISTORY {
             self.received.pop_back();
         }
-        self.received.push_front(msg);
+        self.received.push_front(MessageHistoryEntry {
+            message: msg,
+            timestamp: chrono::Utc::now(),
+        });
     }
 
     fn send(&mut self, msg: Message) {
         if self.sent.len() >= MAX_MESSAGE_HISTORY {
             self.sent.pop_back();
         }
-        self.sent.push_front(msg);
+        self.sent.push_front(MessageHistoryEntry {
+            message: msg,
+            timestamp: chrono::Utc::now(),
+        });
     }
 }
 

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -19,7 +19,7 @@ use rdb::{Asn, Db, Prefix4};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Logger;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::fmt::{self, Display, Formatter};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -371,6 +371,30 @@ pub struct NeighborInfo {
     pub host: SocketAddr,
 }
 
+pub const MAX_MESSAGE_HISTORY: usize = 1024;
+
+#[derive(Default, Debug, Clone, Serialize, JsonSchema)]
+pub struct MessageHistory {
+    pub received: VecDeque<Message>,
+    pub sent: VecDeque<Message>,
+}
+
+impl MessageHistory {
+    fn receive(&mut self, msg: Message) {
+        if self.received.len() >= MAX_MESSAGE_HISTORY {
+            self.received.pop_back();
+        }
+        self.received.push_front(msg);
+    }
+
+    fn send(&mut self, msg: Message) {
+        if self.sent.len() >= MAX_MESSAGE_HISTORY {
+            self.sent.pop_back();
+        }
+        self.sent.push_front(msg);
+    }
+}
+
 /// This is the top level object that tracks a BGP session with a peer.
 pub struct SessionRunner<Cnx: BgpConnection> {
     /// A sender that can be used to send FSM events to this session. When a
@@ -381,6 +405,10 @@ pub struct SessionRunner<Cnx: BgpConnection> {
 
     /// Information about the neighbor this session is to peer with.
     pub neighbor: NeighborInfo,
+
+    /// A log of the last `MAX_MESSAGE_HISTORY` messages. Keepalives are not
+    /// included in message history.
+    pub message_history: Arc<Mutex<MessageHistory>>,
 
     session: Arc<Mutex<SessionInfo>>,
     event_rx: Receiver<FsmEvent<Cnx>>,
@@ -449,6 +477,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             running: AtomicBool::new(false),
             fanout,
             router,
+            message_history: Arc::new(Mutex::new(MessageHistory::default())),
             db,
         }
     }
@@ -634,7 +663,13 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         // The only thing we really care about in the active state is receiving
         // an open message from the peer.
         let om = match event {
-            FsmEvent::Message(Message::Open(om)) => om,
+            FsmEvent::Message(Message::Open(om)) => {
+                self.message_history
+                    .lock()
+                    .unwrap()
+                    .receive(om.clone().into());
+                om
+            }
             FsmEvent::ConnectRetryTimerExpires => {
                 inf!(self; "active: connect retry timer expired");
                 return FsmState::Idle;
@@ -692,7 +727,13 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         // The only thing we really care about in the open sent state is
         // receiving a reciprocal open message from the peer.
         let om = match event {
-            FsmEvent::Message(Message::Open(om)) => om,
+            FsmEvent::Message(Message::Open(om)) => {
+                self.message_history
+                    .lock()
+                    .unwrap()
+                    .receive(om.clone().into());
+                om
+            }
             FsmEvent::HoldTimerExpires => {
                 wrn!(self; "open sent: hold timer expired");
                 self.send_hold_timer_expired_notification(&conn);
@@ -743,6 +784,10 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             // Our open message has been rejected with a notifiction. Fail back
             // to the connect state, dropping the TCP connection.
             FsmEvent::Message(Message::Notification(m)) => {
+                self.message_history
+                    .lock()
+                    .unwrap()
+                    .receive(m.clone().into());
                 wrn!(self; "notification received: {:#?}", m);
                 lock!(self.session).connect_retry_counter += 1;
                 self.clock.timers.hold_timer.disable();
@@ -846,7 +891,8 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             FsmEvent::Message(Message::Update(m)) => {
                 self.clock.timers.hold_timer.reset();
                 inf!(self; "update received: {m:#?}");
-                self.apply_update(m, pc.id);
+                self.apply_update(m.clone(), pc.id);
+                self.message_history.lock().unwrap().receive(m.into());
                 FsmState::Established(pc)
             }
 
@@ -854,6 +900,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             // with us. Exit established and restart from the connect state.
             FsmEvent::Message(Message::Notification(m)) => {
                 wrn!(self; "notification received: {m:#?}");
+                self.message_history.lock().unwrap().receive(m.into());
                 self.exit_established(pc)
             }
 
@@ -954,11 +1001,14 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         error_subcode: ErrorSubcode,
     ) {
         inf!(self; "sending notification {error_code:?}/{error_subcode:?}");
-        if let Err(e) = conn.send(Message::Notification(NotificationMessage {
+        let msg = Message::Notification(NotificationMessage {
             error_code,
             error_subcode,
             data: Vec::new(),
-        })) {
+        });
+        self.message_history.lock().unwrap().send(msg.clone());
+
+        if let Err(e) = conn.send(msg) {
             err!(self; "failed to send notification {e}");
         }
     }
@@ -994,6 +1044,11 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                 }],
             },
         ]);
+        self.message_history
+            .lock()
+            .unwrap()
+            .send(msg.clone().into());
+
         conn.send(msg.into())
     }
 
@@ -1014,6 +1069,11 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         update
             .path_attributes
             .push(PathAttributeValue::NextHop(nexthop).into());
+
+        self.message_history
+            .lock()
+            .unwrap()
+            .send(update.clone().into());
 
         conn.send(update.into())
     }

--- a/ddm-admin-client/Cargo.toml
+++ b/ddm-admin-client/Cargo.toml
@@ -10,4 +10,4 @@ slog.workspace = true
 percent-encoding.workspace = true
 reqwest.workspace = true
 progenitor.workspace = true
-ddm = { path = "../ddm" }
+mg-common = { path = "../mg-common" }

--- a/ddm-admin-client/src/lib.rs
+++ b/ddm-admin-client/src/lib.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-pub use ddm::db::IpPrefix;
-pub use ddm::db::Ipv4Prefix;
-pub use ddm::db::Ipv6Prefix;
-pub use ddm::db::TunnelOrigin;
+pub use mg_common::net::IpPrefix;
+pub use mg_common::net::Ipv4Prefix;
+pub use mg_common::net::Ipv6Prefix;
+pub use mg_common::net::TunnelOrigin;
 
 progenitor::generate_api!(
     spec = "../openapi/ddm-admin.json",
@@ -20,10 +20,10 @@ progenitor::generate_api!(
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::trace!(log, "client response"; "result" => ?result);
     }),
-    replace = {
-        IpPrefix = ddm::db::IpPrefix,
-        Ipv4Prefix = ddm::db::Ipv4Prefix,
-        Ipv6Prefix = ddm::db::Ipv6Prefix,
-        TunnelOrigin = ddm::db::TunnelOrigin,
-    }
+       replace = {
+           IpPrefix = mg_common::net::IpPrefix,
+           Ipv4Prefix = mg_common::net::Ipv4Prefix,
+           Ipv6Prefix = mg_common::net::Ipv6Prefix,
+           TunnelOrigin = mg_common::net::TunnelOrigin,
+       }
 );

--- a/ddm/Cargo.toml
+++ b/ddm/Cargo.toml
@@ -26,3 +26,4 @@ dendrite-common.workspace = true
 opte-ioctl.workspace = true
 oxide-vpc.workspace = true
 sled.workspace = true
+mg-common.workspace = true

--- a/ddm/src/admin.rs
+++ b/ddm/src/admin.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::db::{Db, Ipv6Prefix, PeerInfo, TunnelOrigin, TunnelRoute};
+use crate::db::{Db, PeerInfo, TunnelRoute};
 use crate::exchange::PathVector;
 use crate::sm::{AdminEvent, Event, PrefixSet};
 use dropshot::endpoint;
@@ -17,6 +17,7 @@ use dropshot::HttpServerStarter;
 use dropshot::Path;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
+use mg_common::net::{Ipv6Prefix, TunnelOrigin};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::{error, info, warn, Logger};

--- a/ddm/src/exchange.rs
+++ b/ddm/src/exchange.rs
@@ -15,10 +15,7 @@
 //! of a ddm router is defined in the state machine implementation in sm.rs.
 //!
 
-use crate::db::{
-    effective_route_set, Ipv6Prefix, Route, RouterKind, TunnelOrigin,
-    TunnelRoute,
-};
+use crate::db::{effective_route_set, Route, RouterKind, TunnelRoute};
 use crate::discovery::Version;
 use crate::sm::{Config, Event, PeerEvent, SmContext};
 use crate::{dbg, err, inf, wrn};
@@ -34,6 +31,7 @@ use dropshot::HttpServerStarter;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
 use hyper::body::Bytes;
+use mg_common::net::{Ipv6Prefix, TunnelOrigin};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Logger;

--- a/ddm/src/sm.rs
+++ b/ddm/src/sm.rs
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::db::{Db, Ipv6Prefix, RouterKind, TunnelOrigin};
+use crate::db::{Db, RouterKind};
 use crate::discovery::Version;
 use crate::exchange::{PathVector, TunnelUpdate, UnderlayUpdate, Update};
 use crate::{dbg, discovery, err, exchange, inf, wrn};
 use libnet::get_ipaddr_info;
+use mg_common::net::{Ipv6Prefix, TunnelOrigin};
 use slog::Logger;
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv6Addr};

--- a/ddm/src/sys.rs
+++ b/ddm/src/sys.rs
@@ -235,8 +235,8 @@ pub fn add_routes_dendrite(
 
 fn tunnel_route_update_map(
     routes: &HashSet<TunnelRoute>,
-) -> HashMap<crate::db::IpPrefix, Vec<TunnelEndpoint>> {
-    let mut m: HashMap<crate::db::IpPrefix, Vec<TunnelEndpoint>> =
+) -> HashMap<mg_common::net::IpPrefix, Vec<TunnelEndpoint>> {
+    let mut m: HashMap<mg_common::net::IpPrefix, Vec<TunnelEndpoint>> =
         HashMap::new();
     for r in routes {
         let pfx = r.origin.overlay_prefix;
@@ -279,11 +279,11 @@ pub fn add_tunnel_routes(
             );
         }
         let vip = match pfx {
-            crate::db::IpPrefix::V4(p) => IpCidr::Ip4(Ipv4Cidr::new(
+            mg_common::net::IpPrefix::V4(p) => IpCidr::Ip4(Ipv4Cidr::new(
                 p.addr.into(),
                 Ipv4PrefixLen::new(p.len).unwrap(),
             )),
-            crate::db::IpPrefix::V6(p) => IpCidr::Ip6(Ipv6Cidr::new(
+            mg_common::net::IpPrefix::V6(p) => IpCidr::Ip6(Ipv6Cidr::new(
                 p.addr.into(),
                 Ipv6PrefixLen::new(p.len).unwrap(),
             )),
@@ -319,11 +319,11 @@ pub fn remove_tunnel_routes(
             );
         }
         let vip = match pfx {
-            crate::db::IpPrefix::V4(p) => IpCidr::Ip4(Ipv4Cidr::new(
+            mg_common::net::IpPrefix::V4(p) => IpCidr::Ip4(Ipv4Cidr::new(
                 p.addr.into(),
                 Ipv4PrefixLen::new(p.len).unwrap(),
             )),
-            crate::db::IpPrefix::V6(p) => IpCidr::Ip6(Ipv6Cidr::new(
+            mg_common::net::IpPrefix::V6(p) => IpCidr::Ip6(Ipv6Cidr::new(
                 p.addr.into(),
                 Ipv6PrefixLen::new(p.len).unwrap(),
             )),

--- a/ddmadm/src/main.rs
+++ b/ddmadm/src/main.rs
@@ -5,9 +5,9 @@
 use anyhow::Result;
 use clap::Parser;
 use colored::*;
-use ddm::db::{IpPrefix, Ipv6Prefix, TunnelOrigin};
 use ddm_admin_client::Client;
 use mg_common::cli::oxide_cli_style;
+use mg_common::net::{IpPrefix, Ipv6Prefix, TunnelOrigin};
 use slog::{Drain, Logger};
 use std::io::{stdout, Write};
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/mg-admin-client/Cargo.toml
+++ b/mg-admin-client/Cargo.toml
@@ -11,4 +11,5 @@ anyhow.workspace = true
 percent-encoding.workspace = true
 reqwest.workspace = true
 progenitor.workspace = true
+schemars.workspace = true
 rdb = { path = "../rdb" }

--- a/mg-admin-client/Cargo.toml
+++ b/mg-admin-client/Cargo.toml
@@ -12,4 +12,6 @@ percent-encoding.workspace = true
 reqwest.workspace = true
 progenitor.workspace = true
 schemars.workspace = true
+chrono.workspace = true
 rdb = { path = "../rdb" }
+bgp = { path = "../bgp" }

--- a/mg-admin-client/src/lib.rs
+++ b/mg-admin-client/src/lib.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+pub use bgp::messages::Message;
+pub use bgp::session::{MessageHistory, MessageHistoryEntry};
 pub use rdb::{PolicyAction, Prefix4};
 
 progenitor::generate_api!(
@@ -21,5 +23,8 @@ progenitor::generate_api!(
     replace = {
         Prefix4 = rdb::Prefix4,
         PolicyAction = rdb::PolicyAction,
+        Message = bgp::messages::Message,
+        MessageHistoryEntry = bgp::session::MessageHistoryEntry,
+        MessageHistory = bgp::session::MessageHistory,
     }
 );

--- a/mg-admin-client/src/lib.rs
+++ b/mg-admin-client/src/lib.rs
@@ -17,6 +17,7 @@ progenitor::generate_api!(
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::trace!(log, "client response"; "result" => ?result);
     }),
+    derives = [schemars::JsonSchema],
     replace = {
         Prefix4 = rdb::Prefix4,
         PolicyAction = rdb::PolicyAction,

--- a/mg-common/Cargo.toml
+++ b/mg-common/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 clap.workspace = true
 anstyle.workspace = true
+serde.workspace = true
+schemars.workspace = true
+thiserror.workspace = true

--- a/mg-common/src/lib.rs
+++ b/mg-common/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 pub mod cli;
+pub mod net;
 
 #[macro_export]
 macro_rules! lock {

--- a/mg-common/src/net.rs
+++ b/mg-common/src/net.rs
@@ -1,0 +1,155 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{
+    net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr},
+    num::ParseIntError,
+};
+use thiserror::Error;
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub enum IpPrefix {
+    V4(Ipv4Prefix),
+    V6(Ipv6Prefix),
+}
+
+impl std::fmt::Display for IpPrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V4(p) => p.fmt(f),
+            Self::V6(p) => p.fmt(f),
+        }
+    }
+}
+
+impl IpPrefix {
+    pub fn addr(&self) -> IpAddr {
+        match self {
+            Self::V4(s) => s.addr.into(),
+            Self::V6(s) => s.addr.into(),
+        }
+    }
+
+    pub fn length(&self) -> u8 {
+        match self {
+            Self::V4(s) => s.len,
+            Self::V6(s) => s.len,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum IpPrefixParseError {
+    #[error("v4 address parse error: {0}")]
+    V4(#[from] Ipv4PrefixParseError),
+
+    #[error("v4 address parse error: {0}")]
+    V6(#[from] Ipv6PrefixParseError),
+}
+
+impl std::str::FromStr for IpPrefix {
+    type Err = IpPrefixParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(result) = Ipv4Prefix::from_str(s) {
+            return Ok(IpPrefix::V4(result));
+        }
+        Ok(IpPrefix::V6(Ipv6Prefix::from_str(s)?))
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct Ipv4Prefix {
+    pub addr: Ipv4Addr,
+    pub len: u8,
+}
+
+impl std::fmt::Display for Ipv4Prefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.addr, self.len)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Ipv4PrefixParseError {
+    #[error("expected CIDR representation <addr>/<mask>")]
+    Cidr,
+
+    #[error("address parse error: {0}")]
+    Addr(#[from] AddrParseError),
+
+    #[error("mask parse error: {0}")]
+    Mask(#[from] ParseIntError),
+}
+
+impl std::str::FromStr for Ipv4Prefix {
+    type Err = Ipv4PrefixParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() < 2 {
+            return Err(Ipv4PrefixParseError::Cidr);
+        }
+
+        Ok(Ipv4Prefix {
+            addr: Ipv4Addr::from_str(parts[0])?,
+            len: u8::from_str(parts[1])?,
+        })
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct Ipv6Prefix {
+    pub addr: Ipv6Addr,
+    pub len: u8,
+}
+
+impl std::fmt::Display for Ipv6Prefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.addr, self.len)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Ipv6PrefixParseError {
+    #[error("expected CIDR representation <addr>/<mask>")]
+    Cidr,
+
+    #[error("address parse error: {0}")]
+    Addr(#[from] AddrParseError),
+
+    #[error("mask parse error: {0}")]
+    Mask(#[from] ParseIntError),
+}
+
+impl std::str::FromStr for Ipv6Prefix {
+    type Err = Ipv6PrefixParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() < 2 {
+            return Err(Ipv6PrefixParseError::Cidr);
+        }
+
+        Ok(Ipv6Prefix {
+            addr: Ipv6Addr::from_str(parts[0])?,
+            len: u8::from_str(parts[1])?,
+        })
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct TunnelOrigin {
+    pub overlay_prefix: IpPrefix,
+    pub boundary_addr: Ipv6Addr,
+    pub vni: u32,
+    #[serde(default)]
+    pub metric: u64,
+}

--- a/mgd/src/admin.rs
+++ b/mgd/src/admin.rs
@@ -76,6 +76,7 @@ pub fn api_description() -> ApiDescription<Arc<HandlerContext>> {
     register!(api, bgp_admin::get_imported4);
     register!(api, bgp_admin::bgp_apply);
     register!(api, bgp_admin::graceful_shutdown);
+    register!(api, bgp_admin::message_history);
 
     // static
     register!(api, static_admin::static_add_v4_route);

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -10,7 +10,7 @@ use bgp::{
     connection_tcp::BgpConnectionTcp,
     messages::Prefix,
     router::Router,
-    session::{FsmEvent, FsmStateKind, SessionInfo},
+    session::{FsmEvent, FsmStateKind, MessageHistory, SessionInfo},
     BGP_PORT,
 };
 use dropshot::{
@@ -720,4 +720,33 @@ fn start_bgp_session<Cnx: BgpConnection>(
             format!("failed to start bgp session {e}",),
         )
     })
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Clone)]
+pub struct MessageHistoryRequest {
+    asn: u32,
+}
+
+#[derive(Debug, Serialize, JsonSchema, Clone)]
+pub struct MessageHistoryResponse {
+    by_peer: HashMap<IpAddr, MessageHistory>,
+}
+
+#[endpoint { method = POST, path = "/bgp/message-history" }]
+pub async fn message_history(
+    ctx: RequestContext<Arc<HandlerContext>>,
+    request: TypedBody<MessageHistoryRequest>,
+) -> Result<HttpResponseOk<MessageHistoryResponse>, HttpError> {
+    let rq = request.into_inner();
+    let ctx = ctx.context();
+
+    let mut result = HashMap::new();
+
+    for (addr, session) in
+        get_router!(ctx, rq.asn)?.sessions.lock().unwrap().iter()
+    {
+        result.insert(*addr, session.message_history.lock().unwrap().clone());
+    }
+
+    Ok(HttpResponseOk(MessageHistoryResponse { by_peer: result }))
 }

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -732,7 +732,7 @@ pub struct MessageHistoryResponse {
     by_peer: HashMap<IpAddr, MessageHistory>,
 }
 
-#[endpoint { method = POST, path = "/bgp/message-history" }]
+#[endpoint { method = GET, path = "/bgp/message-history" }]
 pub async fn message_history(
     ctx: RequestContext<Arc<HandlerContext>>,
     request: TypedBody<MessageHistoryRequest>,

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -710,8 +710,8 @@
       "AsPathType": {
         "type": "string",
         "enum": [
-          "AsSet",
-          "AsSequence"
+          "as_set",
+          "as_sequence"
         ]
       },
       "BfdPeerConfig": {
@@ -866,7 +866,7 @@
             "description": "RFC 2858 TODO",
             "type": "object",
             "properties": {
-              "MultiprotocolExtensions": {
+              "multiprotocol_extensions": {
                 "type": "object",
                 "properties": {
                   "afi": {
@@ -887,7 +887,7 @@
               }
             },
             "required": [
-              "MultiprotocolExtensions"
+              "multiprotocol_extensions"
             ],
             "additionalProperties": false
           },
@@ -895,12 +895,12 @@
             "description": "RFC 2918 TODO",
             "type": "object",
             "properties": {
-              "RouteRefresh": {
+              "route_refresh": {
                 "type": "object"
               }
             },
             "required": [
-              "RouteRefresh"
+              "route_refresh"
             ],
             "additionalProperties": false
           },
@@ -908,12 +908,12 @@
             "description": "RFC 5291 TODO",
             "type": "object",
             "properties": {
-              "OutboundRouteFiltering": {
+              "outbound_route_filtering": {
                 "type": "object"
               }
             },
             "required": [
-              "OutboundRouteFiltering"
+              "outbound_route_filtering"
             ],
             "additionalProperties": false
           },
@@ -921,12 +921,12 @@
             "description": "RFC 8277 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "MultipleRoutesToDestination": {
+              "multiple_routes_to_destination": {
                 "type": "object"
               }
             },
             "required": [
-              "MultipleRoutesToDestination"
+              "multiple_routes_to_destination"
             ],
             "additionalProperties": false
           },
@@ -934,12 +934,12 @@
             "description": "RFC 8950 TODO",
             "type": "object",
             "properties": {
-              "ExtendedNextHopEncoding": {
+              "extended_next_hop_encoding": {
                 "type": "object"
               }
             },
             "required": [
-              "ExtendedNextHopEncoding"
+              "extended_next_hop_encoding"
             ],
             "additionalProperties": false
           },
@@ -947,12 +947,12 @@
             "description": "RFC 8654 TODO",
             "type": "object",
             "properties": {
-              "BGPExtendedMessage": {
+              "b_g_p_extended_message": {
                 "type": "object"
               }
             },
             "required": [
-              "BGPExtendedMessage"
+              "b_g_p_extended_message"
             ],
             "additionalProperties": false
           },
@@ -960,12 +960,12 @@
             "description": "RFC 8205 TODO",
             "type": "object",
             "properties": {
-              "BgpSec": {
+              "bgp_sec": {
                 "type": "object"
               }
             },
             "required": [
-              "BgpSec"
+              "bgp_sec"
             ],
             "additionalProperties": false
           },
@@ -973,12 +973,12 @@
             "description": "RFC 8277 TODO",
             "type": "object",
             "properties": {
-              "MultipleLabels": {
+              "multiple_labels": {
                 "type": "object"
               }
             },
             "required": [
-              "MultipleLabels"
+              "multiple_labels"
             ],
             "additionalProperties": false
           },
@@ -986,12 +986,12 @@
             "description": "RFC 9234 TODO",
             "type": "object",
             "properties": {
-              "BgpRole": {
+              "bgp_role": {
                 "type": "object"
               }
             },
             "required": [
-              "BgpRole"
+              "bgp_role"
             ],
             "additionalProperties": false
           },
@@ -999,12 +999,12 @@
             "description": "RFC 4724 TODO",
             "type": "object",
             "properties": {
-              "GracefulRestart": {
+              "graceful_restart": {
                 "type": "object"
               }
             },
             "required": [
-              "GracefulRestart"
+              "graceful_restart"
             ],
             "additionalProperties": false
           },
@@ -1012,7 +1012,7 @@
             "description": "RFC 6793",
             "type": "object",
             "properties": {
-              "FourOctetAs": {
+              "four_octet_as": {
                 "type": "object",
                 "properties": {
                   "asn": {
@@ -1027,7 +1027,7 @@
               }
             },
             "required": [
-              "FourOctetAs"
+              "four_octet_as"
             ],
             "additionalProperties": false
           },
@@ -1035,12 +1035,12 @@
             "description": "draft-ietf-idr-dynamic-cap TODO",
             "type": "object",
             "properties": {
-              "DynamicCapability": {
+              "dynamic_capability": {
                 "type": "object"
               }
             },
             "required": [
-              "DynamicCapability"
+              "dynamic_capability"
             ],
             "additionalProperties": false
           },
@@ -1048,12 +1048,12 @@
             "description": "draft-ietf-idr-bgp-multisession TODO",
             "type": "object",
             "properties": {
-              "MultisessionBgp": {
+              "multisession_bgp": {
                 "type": "object"
               }
             },
             "required": [
-              "MultisessionBgp"
+              "multisession_bgp"
             ],
             "additionalProperties": false
           },
@@ -1061,7 +1061,7 @@
             "description": "RFC 7911",
             "type": "object",
             "properties": {
-              "AddPath": {
+              "add_path": {
                 "type": "object",
                 "properties": {
                   "elements": {
@@ -1077,7 +1077,7 @@
               }
             },
             "required": [
-              "AddPath"
+              "add_path"
             ],
             "additionalProperties": false
           },
@@ -1085,12 +1085,12 @@
             "description": "RFC 7313 TODO",
             "type": "object",
             "properties": {
-              "EnhancedRouteRefresh": {
+              "enhanced_route_refresh": {
                 "type": "object"
               }
             },
             "required": [
-              "EnhancedRouteRefresh"
+              "enhanced_route_refresh"
             ],
             "additionalProperties": false
           },
@@ -1098,12 +1098,12 @@
             "description": "draft-uttaro-idr-bgp-persistence TODO",
             "type": "object",
             "properties": {
-              "LongLivedGracefulRestart": {
+              "long_lived_graceful_restart": {
                 "type": "object"
               }
             },
             "required": [
-              "LongLivedGracefulRestart"
+              "long_lived_graceful_restart"
             ],
             "additionalProperties": false
           },
@@ -1111,12 +1111,12 @@
             "description": "draft-ietf-idr-rpd-04 TODO",
             "type": "object",
             "properties": {
-              "RoutingPolicyDistribution": {
+              "routing_policy_distribution": {
                 "type": "object"
               }
             },
             "required": [
-              "RoutingPolicyDistribution"
+              "routing_policy_distribution"
             ],
             "additionalProperties": false
           },
@@ -1124,12 +1124,12 @@
             "description": "draft-walton-bgp-hostname-capability TODO",
             "type": "object",
             "properties": {
-              "Fqdn": {
+              "fqdn": {
                 "type": "object"
               }
             },
             "required": [
-              "Fqdn"
+              "fqdn"
             ],
             "additionalProperties": false
           },
@@ -1137,12 +1137,12 @@
             "description": "RFC 8810 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "PrestandardRouteRefresh": {
+              "prestandard_route_refresh": {
                 "type": "object"
               }
             },
             "required": [
-              "PrestandardRouteRefresh"
+              "prestandard_route_refresh"
             ],
             "additionalProperties": false
           },
@@ -1150,12 +1150,12 @@
             "description": "RFC 8810 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "PrestandardOrfAndPd": {
+              "prestandard_orf_and_pd": {
                 "type": "object"
               }
             },
             "required": [
-              "PrestandardOrfAndPd"
+              "prestandard_orf_and_pd"
             ],
             "additionalProperties": false
           },
@@ -1163,12 +1163,12 @@
             "description": "RFC 8810 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "PrestandardOutboundRouteFiltering": {
+              "prestandard_outbound_route_filtering": {
                 "type": "object"
               }
             },
             "required": [
-              "PrestandardOutboundRouteFiltering"
+              "prestandard_outbound_route_filtering"
             ],
             "additionalProperties": false
           },
@@ -1176,12 +1176,12 @@
             "description": "RFC 8810 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "PrestandardMultisession": {
+              "prestandard_multisession": {
                 "type": "object"
               }
             },
             "required": [
-              "PrestandardMultisession"
+              "prestandard_multisession"
             ],
             "additionalProperties": false
           },
@@ -1189,12 +1189,12 @@
             "description": "RFC 8810 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "PrestandardFqdn": {
+              "prestandard_fqdn": {
                 "type": "object"
               }
             },
             "required": [
-              "PrestandardFqdn"
+              "prestandard_fqdn"
             ],
             "additionalProperties": false
           },
@@ -1202,12 +1202,12 @@
             "description": "RFC 8810 (deprecated) TODO",
             "type": "object",
             "properties": {
-              "PrestandardOperationalMessage": {
+              "prestandard_operational_message": {
                 "type": "object"
               }
             },
             "required": [
-              "PrestandardOperationalMessage"
+              "prestandard_operational_message"
             ],
             "additionalProperties": false
           },
@@ -1215,7 +1215,7 @@
             "description": "RFC 8810",
             "type": "object",
             "properties": {
-              "Experimental": {
+              "experimental": {
                 "type": "object",
                 "properties": {
                   "code": {
@@ -1230,14 +1230,14 @@
               }
             },
             "required": [
-              "Experimental"
+              "experimental"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Unassigned": {
+              "unassigned": {
                 "type": "object",
                 "properties": {
                   "code": {
@@ -1252,14 +1252,14 @@
               }
             },
             "required": [
-              "Unassigned"
+              "unassigned"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Reserved": {
+              "reserved": {
                 "type": "object",
                 "properties": {
                   "code": {
@@ -1274,7 +1274,7 @@
               }
             },
             "required": [
-              "Reserved"
+              "reserved"
             ],
             "additionalProperties": false
           }
@@ -1286,28 +1286,28 @@
             "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised outside a BGP confederation boundary (a stand-alone autonomous system that is not part of a confederation should be considered a confederation itself)",
             "type": "string",
             "enum": [
-              "NoExport"
+              "no_export"
             ]
           },
           {
             "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised to other BGP peers.",
             "type": "string",
             "enum": [
-              "NoAdvertise"
+              "no_advertise"
             ]
           },
           {
             "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised to external BGP peers (this includes peers in other members autonomous systems inside a BGP confederation).",
             "type": "string",
             "enum": [
-              "NoExportSubConfed"
+              "no_export_sub_confed"
             ]
           },
           {
             "description": "All routes received carrying a communities attribute containing this value must set the local preference for the received routes to a low value, preferably zero.",
             "type": "string",
             "enum": [
-              "GracefulShutdown"
+              "graceful_shutdown"
             ]
           }
         ]
@@ -1377,12 +1377,12 @@
       "ErrorCode": {
         "type": "string",
         "enum": [
-          "Header",
-          "Open",
-          "Update",
-          "HoldTimerExpired",
-          "Fsm",
-          "Cease"
+          "header",
+          "open",
+          "update",
+          "hold_timer_expired",
+          "fsm",
+          "cease"
         ]
       },
       "ErrorSubcode": {
@@ -1390,78 +1390,78 @@
           {
             "type": "object",
             "properties": {
-              "Header": {
+              "header": {
                 "$ref": "#/components/schemas/HeaderErrorSubcode"
               }
             },
             "required": [
-              "Header"
+              "header"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Open": {
+              "open": {
                 "$ref": "#/components/schemas/OpenErrorSubcode"
               }
             },
             "required": [
-              "Open"
+              "open"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Update": {
+              "update": {
                 "$ref": "#/components/schemas/UpdateErrorSubcode"
               }
             },
             "required": [
-              "Update"
+              "update"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "HoldTime": {
+              "hold_time": {
                 "type": "integer",
                 "format": "uint8",
                 "minimum": 0
               }
             },
             "required": [
-              "HoldTime"
+              "hold_time"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Fsm": {
+              "fsm": {
                 "type": "integer",
                 "format": "uint8",
                 "minimum": 0
               }
             },
             "required": [
-              "Fsm"
+              "fsm"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Cease": {
+              "cease": {
                 "type": "integer",
                 "format": "uint8",
                 "minimum": 0
               }
             },
             "required": [
-              "Cease"
+              "cease"
             ],
             "additionalProperties": false
           }
@@ -1571,10 +1571,10 @@
       "HeaderErrorSubcode": {
         "type": "string",
         "enum": [
-          "Unspecific",
-          "ConnectionNotSynchronized",
-          "BadMessageLength",
-          "BadMessageType"
+          "unspecific",
+          "connection_not_synchronized",
+          "bad_message_length",
+          "bad_message_type"
         ]
       },
       "Message": {
@@ -1582,42 +1582,42 @@
           {
             "type": "string",
             "enum": [
-              "KeepAlive"
+              "keep_alive"
             ]
           },
           {
             "type": "object",
             "properties": {
-              "Open": {
+              "open": {
                 "$ref": "#/components/schemas/OpenMessage"
               }
             },
             "required": [
-              "Open"
+              "open"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Update": {
+              "update": {
                 "$ref": "#/components/schemas/UpdateMessage"
               }
             },
             "required": [
-              "Update"
+              "update"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Notification": {
+              "notification": {
                 "$ref": "#/components/schemas/NotificationMessage"
               }
             },
             "required": [
-              "Notification"
+              "notification"
             ],
             "additionalProperties": false
           }
@@ -1724,14 +1724,14 @@
       "OpenErrorSubcode": {
         "type": "string",
         "enum": [
-          "Unspecific",
-          "UnsupportedVersionNumber",
-          "BadPeerAS",
-          "BadBgpIdentifier",
-          "UnsupportedOptionalParameter",
-          "Deprecated",
-          "UnacceptableHoldTime",
-          "UnsupportedCapability"
+          "unspecific",
+          "unsupported_version_number",
+          "bad_peer_a_s",
+          "bad_bgp_identifier",
+          "unsupported_optional_parameter",
+          "deprecated",
+          "unacceptable_hold_time",
+          "unsupported_capability"
         ]
       },
       "OpenMessage": {
@@ -1784,28 +1784,28 @@
           {
             "type": "string",
             "enum": [
-              "Unassigned"
+              "unassigned"
             ]
           },
           {
             "description": "Code 0",
             "type": "string",
             "enum": [
-              "Reserved"
+              "reserved"
             ]
           },
           {
             "description": "Code 1: RFC 4217, RFC 5492 (deprecated)",
             "type": "string",
             "enum": [
-              "Authentication"
+              "authentication"
             ]
           },
           {
             "description": "Code 2: RFC 5492",
             "type": "object",
             "properties": {
-              "Capabilities": {
+              "capabilities": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Capability"
@@ -1813,7 +1813,7 @@
               }
             },
             "required": [
-              "Capabilities"
+              "capabilities"
             ],
             "additionalProperties": false
           },
@@ -1821,7 +1821,7 @@
             "description": "Code 255: RFC 9072",
             "type": "string",
             "enum": [
-              "ExtendedLength"
+              "extended_length"
             ]
           }
         ]
@@ -1885,28 +1885,28 @@
           {
             "type": "string",
             "enum": [
-              "AsPath",
-              "NextHop",
-              "MultiExitDisc",
-              "LocalPref",
-              "AtomicAggregate",
-              "Aggregator",
-              "Communities",
-              "As4Aggregator"
+              "as_path",
+              "next_hop",
+              "multi_exit_disc",
+              "local_pref",
+              "atomic_aggregate",
+              "aggregator",
+              "communities",
+              "as4_aggregator"
             ]
           },
           {
             "description": "RFC 4271",
             "type": "string",
             "enum": [
-              "Origin"
+              "origin"
             ]
           },
           {
             "description": "RFC 6793",
             "type": "string",
             "enum": [
-              "As4Path"
+              "as4_path"
             ]
           }
         ]
@@ -1916,19 +1916,19 @@
           {
             "type": "object",
             "properties": {
-              "Origin": {
+              "origin": {
                 "$ref": "#/components/schemas/PathOrigin"
               }
             },
             "required": [
-              "Origin"
+              "origin"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "AsPath": {
+              "as_path": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/As4PathSegment"
@@ -1936,55 +1936,55 @@
               }
             },
             "required": [
-              "AsPath"
+              "as_path"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "NextHop": {
+              "next_hop": {
                 "type": "string",
                 "format": "ip"
               }
             },
             "required": [
-              "NextHop"
+              "next_hop"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "MultiExitDisc": {
+              "multi_exit_disc": {
                 "type": "integer",
                 "format": "uint32",
                 "minimum": 0
               }
             },
             "required": [
-              "MultiExitDisc"
+              "multi_exit_disc"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "LocalPref": {
+              "local_pref": {
                 "type": "integer",
                 "format": "uint32",
                 "minimum": 0
               }
             },
             "required": [
-              "LocalPref"
+              "local_pref"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Aggregator": {
+              "aggregator": {
                 "type": "array",
                 "items": {
                   "type": "integer",
@@ -1996,14 +1996,14 @@
               }
             },
             "required": [
-              "Aggregator"
+              "aggregator"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "Communities": {
+              "communities": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Community"
@@ -2011,14 +2011,14 @@
               }
             },
             "required": [
-              "Communities"
+              "communities"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "As4Path": {
+              "as4_path": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/As4PathSegment"
@@ -2026,14 +2026,14 @@
               }
             },
             "required": [
-              "As4Path"
+              "as4_path"
             ],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "As4Aggregator": {
+              "as4_aggregator": {
                 "type": "array",
                 "items": {
                   "type": "integer",
@@ -2045,7 +2045,7 @@
               }
             },
             "required": [
-              "As4Aggregator"
+              "as4_aggregator"
             ],
             "additionalProperties": false
           }
@@ -2054,9 +2054,9 @@
       "PathOrigin": {
         "type": "string",
         "enum": [
-          "Igp",
-          "Egp",
-          "Incomplete"
+          "igp",
+          "egp",
+          "incomplete"
         ]
       },
       "PeerInfo": {
@@ -2223,18 +2223,18 @@
       "UpdateErrorSubcode": {
         "type": "string",
         "enum": [
-          "Unspecific",
-          "MalformedAttributeList",
-          "UnrecognizedWellKnownAttribute",
-          "MissingWellKnownAttribute",
-          "AttributeFlags",
-          "AttributeLength",
-          "InvalidOriginAttribute",
-          "Deprecated",
-          "InvalidNexthopAttribute",
-          "OptionalAttribute",
-          "InvalidNetworkField",
-          "MalformedAsPath"
+          "unspecific",
+          "malformed_attribute_list",
+          "unrecognized_well_known_attribute",
+          "missing_well_known_attribute",
+          "attribute_flags",
+          "attribute_length",
+          "invalid_origin_attribute",
+          "deprecated",
+          "invalid_nexthop_attribute",
+          "optional_attribute",
+          "invalid_network_field",
+          "malformed_as_path"
         ]
       },
       "UpdateMessage": {

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -708,10 +708,22 @@
         ]
       },
       "AsPathType": {
-        "type": "string",
-        "enum": [
-          "as_set",
-          "as_sequence"
+        "description": "Enumeration describes possible AS path types",
+        "oneOf": [
+          {
+            "description": "The path is to be interpreted as a set",
+            "type": "string",
+            "enum": [
+              "as_set"
+            ]
+          },
+          {
+            "description": "The path is to be interpreted as a sequence",
+            "type": "string",
+            "enum": [
+              "as_sequence"
+            ]
+          }
         ]
       },
       "BfdPeerConfig": {
@@ -1281,6 +1293,7 @@
         ]
       },
       "Community": {
+        "description": "BGP communities recognized by this BGP implementation.",
         "oneOf": [
           {
             "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised outside a BGP confederation boundary (a stand-alone autonomous system that is not part of a confederation should be considered a confederation itself)",
@@ -1375,6 +1388,7 @@
         ]
       },
       "ErrorCode": {
+        "description": "This enumeration contains possible notification error codes.",
         "type": "string",
         "enum": [
           "header",
@@ -1386,6 +1400,7 @@
         ]
       },
       "ErrorSubcode": {
+        "description": "This enumeration contains possible notification error subcodes.",
         "oneOf": [
           {
             "type": "object",
@@ -1569,6 +1584,7 @@
         ]
       },
       "HeaderErrorSubcode": {
+        "description": "Header error subcode types",
         "type": "string",
         "enum": [
           "unspecific",
@@ -1578,70 +1594,115 @@
         ]
       },
       "Message": {
+        "description": "Holds a BGP message. May be an Open, Update, Notification or Keep Alive message.",
         "oneOf": [
           {
-            "type": "string",
-            "enum": [
-              "keep_alive"
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "open"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/OpenMessage"
+              }
+            },
+            "required": [
+              "type",
+              "value"
             ]
           },
           {
             "type": "object",
             "properties": {
-              "open": {
-                "$ref": "#/components/schemas/OpenMessage"
-              }
-            },
-            "required": [
-              "open"
-            ],
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "properties": {
-              "update": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "update"
+                ]
+              },
+              "value": {
                 "$ref": "#/components/schemas/UpdateMessage"
               }
             },
             "required": [
-              "update"
-            ],
-            "additionalProperties": false
+              "type",
+              "value"
+            ]
           },
           {
             "type": "object",
             "properties": {
-              "notification": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "notification"
+                ]
+              },
+              "value": {
                 "$ref": "#/components/schemas/NotificationMessage"
               }
             },
             "required": [
-              "notification"
-            ],
-            "additionalProperties": false
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "keep_alive"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
       "MessageHistory": {
+        "description": "Message history for a BGP session",
         "type": "object",
         "properties": {
           "received": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Message"
+              "$ref": "#/components/schemas/MessageHistoryEntry"
             }
           },
           "sent": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Message"
+              "$ref": "#/components/schemas/MessageHistoryEntry"
             }
           }
         },
         "required": [
           "received",
           "sent"
+        ]
+      },
+      "MessageHistoryEntry": {
+        "description": "A message history entry is a BGP message with an associated timestamp",
+        "type": "object",
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "message",
+          "timestamp"
         ]
       },
       "MessageHistoryRequest": {
@@ -1698,6 +1759,7 @@
         ]
       },
       "NotificationMessage": {
+        "description": "Notification messages are exchanged between BGP peers when an exceptional event has occured.",
         "type": "object",
         "properties": {
           "data": {
@@ -1709,10 +1771,20 @@
             }
           },
           "error_code": {
-            "$ref": "#/components/schemas/ErrorCode"
+            "description": "Error code associated with the notification",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorCode"
+              }
+            ]
           },
           "error_subcode": {
-            "$ref": "#/components/schemas/ErrorSubcode"
+            "description": "Error subcode associated with the notification",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSubcode"
+              }
+            ]
           }
         },
         "required": [
@@ -1722,6 +1794,7 @@
         ]
       },
       "OpenErrorSubcode": {
+        "description": "Open message error subcode types",
         "type": "string",
         "enum": [
           "unspecific",
@@ -1782,30 +1855,46 @@
         "description": "The IANA/IETF currently defines the following optional parameter types.",
         "oneOf": [
           {
-            "type": "string",
-            "enum": [
-              "unassigned"
-            ]
-          },
-          {
             "description": "Code 0",
-            "type": "string",
-            "enum": [
-              "reserved"
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "reserved"
+                ]
+              }
+            },
+            "required": [
+              "type"
             ]
           },
           {
             "description": "Code 1: RFC 4217, RFC 5492 (deprecated)",
-            "type": "string",
-            "enum": [
-              "authentication"
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "authentication"
+                ]
+              }
+            },
+            "required": [
+              "type"
             ]
           },
           {
             "description": "Code 2: RFC 5492",
             "type": "object",
             "properties": {
-              "capabilities": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "capabilities"
+                ]
+              },
+              "value": {
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Capability"
@@ -1813,15 +1902,38 @@
               }
             },
             "required": [
-              "capabilities"
-            ],
-            "additionalProperties": false
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Unassigned",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unassigned"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
           },
           {
             "description": "Code 255: RFC 9072",
-            "type": "string",
-            "enum": [
-              "extended_length"
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "extended_length"
+                ]
+              }
+            },
+            "required": [
+              "type"
             ]
           }
         ]
@@ -1849,13 +1961,24 @@
         ]
       },
       "PathAttribute": {
+        "description": "A self-describing BGP path attribute",
         "type": "object",
         "properties": {
           "typ": {
-            "$ref": "#/components/schemas/PathAttributeType"
+            "description": "Type encoding for the attribute",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PathAttributeType"
+              }
+            ]
           },
           "value": {
-            "$ref": "#/components/schemas/PathAttributeValue"
+            "description": "Value of the attribute",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PathAttributeValue"
+              }
+            ]
           }
         },
         "required": [
@@ -1864,15 +1987,22 @@
         ]
       },
       "PathAttributeType": {
+        "description": "Type encoding for a path attribute.",
         "type": "object",
         "properties": {
           "flags": {
+            "description": "Flags may include, Optional, Transitive, Partial and Extended Length.",
             "type": "integer",
             "format": "uint8",
             "minimum": 0
           },
           "type_code": {
-            "$ref": "#/components/schemas/PathAttributeTypeCode"
+            "description": "Type code for the path attribute.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PathAttributeTypeCode"
+              }
+            ]
           }
         },
         "required": [
@@ -1881,6 +2011,7 @@
         ]
       },
       "PathAttributeTypeCode": {
+        "description": "An enumeration describing available path attribute type codes.",
         "oneOf": [
           {
             "type": "string",
@@ -1912,8 +2043,10 @@
         ]
       },
       "PathAttributeValue": {
+        "description": "The value encoding of a path attribute.",
         "oneOf": [
           {
+            "description": "The type of origin associated with a path",
             "type": "object",
             "properties": {
               "origin": {
@@ -1926,6 +2059,7 @@
             "additionalProperties": false
           },
           {
+            "description": "The AS set associated with a path",
             "type": "object",
             "properties": {
               "as_path": {
@@ -1941,6 +2075,7 @@
             "additionalProperties": false
           },
           {
+            "description": "The nexthop associated with a path",
             "type": "object",
             "properties": {
               "next_hop": {
@@ -1954,6 +2089,7 @@
             "additionalProperties": false
           },
           {
+            "description": "A metric used for external (inter-AS) links to discriminate among multiple entry or exit points.",
             "type": "object",
             "properties": {
               "multi_exit_disc": {
@@ -1968,6 +2104,7 @@
             "additionalProperties": false
           },
           {
+            "description": "Local pref is included in update messages sent to internal peers and indicates a degree of preference.",
             "type": "object",
             "properties": {
               "local_pref": {
@@ -1982,6 +2119,7 @@
             "additionalProperties": false
           },
           {
+            "description": "This attribute is included in routes that are formed by aggregation.",
             "type": "object",
             "properties": {
               "aggregator": {
@@ -2001,6 +2139,7 @@
             "additionalProperties": false
           },
           {
+            "description": "Indicates communities associated with a path.",
             "type": "object",
             "properties": {
               "communities": {
@@ -2016,6 +2155,7 @@
             "additionalProperties": false
           },
           {
+            "description": "The 4-byte encoded AS set associated with a path",
             "type": "object",
             "properties": {
               "as4_path": {
@@ -2031,6 +2171,7 @@
             "additionalProperties": false
           },
           {
+            "description": "This attribute is included in routes that are formed by aggregation.",
             "type": "object",
             "properties": {
               "as4_aggregator": {
@@ -2052,11 +2193,29 @@
         ]
       },
       "PathOrigin": {
-        "type": "string",
-        "enum": [
-          "igp",
-          "egp",
-          "incomplete"
+        "description": "An enumeration indicating the origin type of a path.",
+        "oneOf": [
+          {
+            "description": "Interior gateway protocol",
+            "type": "string",
+            "enum": [
+              "igp"
+            ]
+          },
+          {
+            "description": "Exterior gateway protocol",
+            "type": "string",
+            "enum": [
+              "egp"
+            ]
+          },
+          {
+            "description": "Incomplete path origin",
+            "type": "string",
+            "enum": [
+              "incomplete"
+            ]
+          }
         ]
       },
       "PeerInfo": {
@@ -2221,6 +2380,7 @@
         ]
       },
       "UpdateErrorSubcode": {
+        "description": "Update message error subcode types",
         "type": "string",
         "enum": [
           "unspecific",

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -179,6 +179,39 @@
         }
       }
     },
+    "/bgp/message-history": {
+      "post": {
+        "operationId": "message_history",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageHistoryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageHistoryResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/bgp/neighbor": {
       "put": {
         "operationId": "ensure_neighbor_handler",
@@ -580,6 +613,35 @@
           "resolution"
         ]
       },
+      "AddPathElement": {
+        "description": "The `AddPathElement` comes as a BGP capability extension as described in RFC 7911.",
+        "type": "object",
+        "properties": {
+          "afi": {
+            "description": "Address family identifier. <https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml>",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "safi": {
+            "description": "Subsequent address family identifier. There are a large pile of these <https://www.iana.org/assignments/safi-namespace/safi-namespace.xhtml>",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "send_receive": {
+            "description": "This field indicates whether the sender is (a) able to receive multiple paths from its peer (value 1), (b) able to send multiple paths to its peer (value 2), or (c) both (value 3) for the <AFI, SAFI>.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "afi",
+          "safi",
+          "send_receive"
+        ]
+      },
       "AddStaticRoute4Request": {
         "type": "object",
         "properties": {
@@ -623,6 +685,33 @@
           "asn",
           "originate",
           "peers"
+        ]
+      },
+      "As4PathSegment": {
+        "type": "object",
+        "properties": {
+          "typ": {
+            "$ref": "#/components/schemas/AsPathType"
+          },
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          }
+        },
+        "required": [
+          "typ",
+          "value"
+        ]
+      },
+      "AsPathType": {
+        "type": "string",
+        "enum": [
+          "AsSet",
+          "AsSequence"
         ]
       },
       "BfdPeerConfig": {
@@ -683,7 +772,7 @@
         ]
       },
       "BfdPeerState": {
-        "description": "The possible peer states. See the `State` trait implementations `Down`, `Init`, and `Up` for detailed semantics.",
+        "description": "The possible peer states. See the `State` trait implementations `Down`, `Init`, and `Up` for detailed semantics. Data representation is u8 as this enum is used as a part of the BFD wire protocol.",
         "oneOf": [
           {
             "description": "A stable down state. Non-responsive to incoming messages.",
@@ -770,6 +859,459 @@
           "resolution"
         ]
       },
+      "Capability": {
+        "description": "Optional capabilities supported by a BGP implementation. An issue tracking the TODOs below is here <https://github.com/oxidecomputer/maghemite/issues/80>",
+        "oneOf": [
+          {
+            "description": "RFC 2858 TODO",
+            "type": "object",
+            "properties": {
+              "MultiprotocolExtensions": {
+                "type": "object",
+                "properties": {
+                  "afi": {
+                    "type": "integer",
+                    "format": "uint16",
+                    "minimum": 0
+                  },
+                  "safi": {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "afi",
+                  "safi"
+                ]
+              }
+            },
+            "required": [
+              "MultiprotocolExtensions"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 2918 TODO",
+            "type": "object",
+            "properties": {
+              "RouteRefresh": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "RouteRefresh"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 5291 TODO",
+            "type": "object",
+            "properties": {
+              "OutboundRouteFiltering": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "OutboundRouteFiltering"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8277 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "MultipleRoutesToDestination": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "MultipleRoutesToDestination"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8950 TODO",
+            "type": "object",
+            "properties": {
+              "ExtendedNextHopEncoding": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "ExtendedNextHopEncoding"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8654 TODO",
+            "type": "object",
+            "properties": {
+              "BGPExtendedMessage": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "BGPExtendedMessage"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8205 TODO",
+            "type": "object",
+            "properties": {
+              "BgpSec": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "BgpSec"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8277 TODO",
+            "type": "object",
+            "properties": {
+              "MultipleLabels": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "MultipleLabels"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 9234 TODO",
+            "type": "object",
+            "properties": {
+              "BgpRole": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "BgpRole"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 4724 TODO",
+            "type": "object",
+            "properties": {
+              "GracefulRestart": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "GracefulRestart"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 6793",
+            "type": "object",
+            "properties": {
+              "FourOctetAs": {
+                "type": "object",
+                "properties": {
+                  "asn": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "asn"
+                ]
+              }
+            },
+            "required": [
+              "FourOctetAs"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "draft-ietf-idr-dynamic-cap TODO",
+            "type": "object",
+            "properties": {
+              "DynamicCapability": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "DynamicCapability"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "draft-ietf-idr-bgp-multisession TODO",
+            "type": "object",
+            "properties": {
+              "MultisessionBgp": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "MultisessionBgp"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 7911",
+            "type": "object",
+            "properties": {
+              "AddPath": {
+                "type": "object",
+                "properties": {
+                  "elements": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AddPathElement"
+                    }
+                  }
+                },
+                "required": [
+                  "elements"
+                ]
+              }
+            },
+            "required": [
+              "AddPath"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 7313 TODO",
+            "type": "object",
+            "properties": {
+              "EnhancedRouteRefresh": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "EnhancedRouteRefresh"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "draft-uttaro-idr-bgp-persistence TODO",
+            "type": "object",
+            "properties": {
+              "LongLivedGracefulRestart": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "LongLivedGracefulRestart"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "draft-ietf-idr-rpd-04 TODO",
+            "type": "object",
+            "properties": {
+              "RoutingPolicyDistribution": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "RoutingPolicyDistribution"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "draft-walton-bgp-hostname-capability TODO",
+            "type": "object",
+            "properties": {
+              "Fqdn": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "Fqdn"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "PrestandardRouteRefresh": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "PrestandardRouteRefresh"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "PrestandardOrfAndPd": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "PrestandardOrfAndPd"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "PrestandardOutboundRouteFiltering": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "PrestandardOutboundRouteFiltering"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "PrestandardMultisession": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "PrestandardMultisession"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "PrestandardFqdn": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "PrestandardFqdn"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810 (deprecated) TODO",
+            "type": "object",
+            "properties": {
+              "PrestandardOperationalMessage": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "PrestandardOperationalMessage"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "RFC 8810",
+            "type": "object",
+            "properties": {
+              "Experimental": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            },
+            "required": [
+              "Experimental"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Unassigned": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            },
+            "required": [
+              "Unassigned"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Reserved": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            },
+            "required": [
+              "Reserved"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Community": {
+        "oneOf": [
+          {
+            "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised outside a BGP confederation boundary (a stand-alone autonomous system that is not part of a confederation should be considered a confederation itself)",
+            "type": "string",
+            "enum": [
+              "NoExport"
+            ]
+          },
+          {
+            "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised to other BGP peers.",
+            "type": "string",
+            "enum": [
+              "NoAdvertise"
+            ]
+          },
+          {
+            "description": "All routes received carrying a communities attribute containing this value MUST NOT be advertised to external BGP peers (this includes peers in other members autonomous systems inside a BGP confederation).",
+            "type": "string",
+            "enum": [
+              "NoExportSubConfed"
+            ]
+          },
+          {
+            "description": "All routes received carrying a communities attribute containing this value must set the local preference for the received routes to a low value, preferably zero.",
+            "type": "string",
+            "enum": [
+              "GracefulShutdown"
+            ]
+          }
+        ]
+      },
       "DeleteNeighborRequest": {
         "type": "object",
         "properties": {
@@ -830,6 +1372,99 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "ErrorCode": {
+        "type": "string",
+        "enum": [
+          "Header",
+          "Open",
+          "Update",
+          "HoldTimerExpired",
+          "Fsm",
+          "Cease"
+        ]
+      },
+      "ErrorSubcode": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "Header": {
+                "$ref": "#/components/schemas/HeaderErrorSubcode"
+              }
+            },
+            "required": [
+              "Header"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Open": {
+                "$ref": "#/components/schemas/OpenErrorSubcode"
+              }
+            },
+            "required": [
+              "Open"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Update": {
+                "$ref": "#/components/schemas/UpdateErrorSubcode"
+              }
+            },
+            "required": [
+              "Update"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "HoldTime": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "HoldTime"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Fsm": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "Fsm"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Cease": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "Cease"
+            ],
+            "additionalProperties": false
+          }
         ]
       },
       "FsmStateKind": {
@@ -933,6 +1568,109 @@
           "enabled"
         ]
       },
+      "HeaderErrorSubcode": {
+        "type": "string",
+        "enum": [
+          "Unspecific",
+          "ConnectionNotSynchronized",
+          "BadMessageLength",
+          "BadMessageType"
+        ]
+      },
+      "Message": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "KeepAlive"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Open": {
+                "$ref": "#/components/schemas/OpenMessage"
+              }
+            },
+            "required": [
+              "Open"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Update": {
+                "$ref": "#/components/schemas/UpdateMessage"
+              }
+            },
+            "required": [
+              "Update"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Notification": {
+                "$ref": "#/components/schemas/NotificationMessage"
+              }
+            },
+            "required": [
+              "Notification"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "MessageHistory": {
+        "type": "object",
+        "properties": {
+          "received": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          },
+          "sent": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          }
+        },
+        "required": [
+          "received",
+          "sent"
+        ]
+      },
+      "MessageHistoryRequest": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "asn"
+        ]
+      },
+      "MessageHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "by_peer": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MessageHistory"
+            }
+          }
+        },
+        "required": [
+          "by_peer"
+        ]
+      },
       "NewRouterRequest": {
         "type": "object",
         "properties": {
@@ -959,6 +1697,135 @@
           "listen"
         ]
       },
+      "NotificationMessage": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          },
+          "error_code": {
+            "$ref": "#/components/schemas/ErrorCode"
+          },
+          "error_subcode": {
+            "$ref": "#/components/schemas/ErrorSubcode"
+          }
+        },
+        "required": [
+          "data",
+          "error_code",
+          "error_subcode"
+        ]
+      },
+      "OpenErrorSubcode": {
+        "type": "string",
+        "enum": [
+          "Unspecific",
+          "UnsupportedVersionNumber",
+          "BadPeerAS",
+          "BadBgpIdentifier",
+          "UnsupportedOptionalParameter",
+          "Deprecated",
+          "UnacceptableHoldTime",
+          "UnsupportedCapability"
+        ]
+      },
+      "OpenMessage": {
+        "description": "The first message sent by each side once a TCP connection is established.\n\n```text 0                   1                   2                   3 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |    Version    |     My Autonomous System      |   Hold Time   : +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ :               |                BGP Identifier                 : +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ :               | Opt Parm Len  |     Optional Parameters       : +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ :                                                               : :             Optional Parameters (cont, variable)              : :                                                               | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ ```\n\nRef: RFC 4271 §4.2",
+        "type": "object",
+        "properties": {
+          "asn": {
+            "description": "Autonomous system number of the sender. When 4-byte ASNs are in use this value is set to AS_TRANS which has a value of 23456.\n\nRef: RFC 4893 §7",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "hold_time": {
+            "description": "Number of seconds the sender proposes for the hold timer.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "id": {
+            "description": "BGP identifier of the sender",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "parameters": {
+            "description": "A list of optional parameters.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptionalParameter"
+            }
+          },
+          "version": {
+            "description": "BGP protocol version.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "asn",
+          "hold_time",
+          "id",
+          "parameters",
+          "version"
+        ]
+      },
+      "OptionalParameter": {
+        "description": "The IANA/IETF currently defines the following optional parameter types.",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "Unassigned"
+            ]
+          },
+          {
+            "description": "Code 0",
+            "type": "string",
+            "enum": [
+              "Reserved"
+            ]
+          },
+          {
+            "description": "Code 1: RFC 4217, RFC 5492 (deprecated)",
+            "type": "string",
+            "enum": [
+              "Authentication"
+            ]
+          },
+          {
+            "description": "Code 2: RFC 5492",
+            "type": "object",
+            "properties": {
+              "Capabilities": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Capability"
+                }
+              }
+            },
+            "required": [
+              "Capabilities"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Code 255: RFC 9072",
+            "type": "string",
+            "enum": [
+              "ExtendedLength"
+            ]
+          }
+        ]
+      },
       "Originate4Request": {
         "type": "object",
         "properties": {
@@ -979,6 +1846,217 @@
         "required": [
           "asn",
           "prefixes"
+        ]
+      },
+      "PathAttribute": {
+        "type": "object",
+        "properties": {
+          "typ": {
+            "$ref": "#/components/schemas/PathAttributeType"
+          },
+          "value": {
+            "$ref": "#/components/schemas/PathAttributeValue"
+          }
+        },
+        "required": [
+          "typ",
+          "value"
+        ]
+      },
+      "PathAttributeType": {
+        "type": "object",
+        "properties": {
+          "flags": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "type_code": {
+            "$ref": "#/components/schemas/PathAttributeTypeCode"
+          }
+        },
+        "required": [
+          "flags",
+          "type_code"
+        ]
+      },
+      "PathAttributeTypeCode": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "AsPath",
+              "NextHop",
+              "MultiExitDisc",
+              "LocalPref",
+              "AtomicAggregate",
+              "Aggregator",
+              "Communities",
+              "As4Aggregator"
+            ]
+          },
+          {
+            "description": "RFC 4271",
+            "type": "string",
+            "enum": [
+              "Origin"
+            ]
+          },
+          {
+            "description": "RFC 6793",
+            "type": "string",
+            "enum": [
+              "As4Path"
+            ]
+          }
+        ]
+      },
+      "PathAttributeValue": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "Origin": {
+                "$ref": "#/components/schemas/PathOrigin"
+              }
+            },
+            "required": [
+              "Origin"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "AsPath": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/As4PathSegment"
+                }
+              }
+            },
+            "required": [
+              "AsPath"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "NextHop": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "NextHop"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "MultiExitDisc": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "MultiExitDisc"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "LocalPref": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "LocalPref"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Aggregator": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0
+                },
+                "minItems": 6,
+                "maxItems": 6
+              }
+            },
+            "required": [
+              "Aggregator"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Communities": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Community"
+                }
+              }
+            },
+            "required": [
+              "Communities"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "As4Path": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/As4PathSegment"
+                }
+              }
+            },
+            "required": [
+              "As4Path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "As4Aggregator": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0
+                },
+                "minItems": 8,
+                "maxItems": 8
+              }
+            },
+            "required": [
+              "As4Aggregator"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PathOrigin": {
+        "type": "string",
+        "enum": [
+          "Igp",
+          "Egp",
+          "Incomplete"
         ]
       },
       "PeerInfo": {
@@ -1002,6 +2080,29 @@
         "required": [
           "duration_millis",
           "state"
+        ]
+      },
+      "Prefix": {
+        "description": "This data structure captures a network prefix as it's layed out in a BGP message. There is a prefix length followed by a variable number of bytes. Just enough bytes to express the prefix.",
+        "type": "object",
+        "properties": {
+          "length": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "value": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          }
+        },
+        "required": [
+          "length",
+          "value"
         ]
       },
       "Prefix4": {
@@ -1117,6 +2218,52 @@
         },
         "required": [
           "list"
+        ]
+      },
+      "UpdateErrorSubcode": {
+        "type": "string",
+        "enum": [
+          "Unspecific",
+          "MalformedAttributeList",
+          "UnrecognizedWellKnownAttribute",
+          "MissingWellKnownAttribute",
+          "AttributeFlags",
+          "AttributeLength",
+          "InvalidOriginAttribute",
+          "Deprecated",
+          "InvalidNexthopAttribute",
+          "OptionalAttribute",
+          "InvalidNetworkField",
+          "MalformedAsPath"
+        ]
+      },
+      "UpdateMessage": {
+        "description": "An update message is used to advertise feasible routes that share common path attributes to a peer, or to withdraw multiple unfeasible routes from service.\n\n```text 0                   1                   2                   3 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |        Witdrawn Length        |       Withdrawn Routes        : +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ :                                                               : :                Withdrawn Routes (cont, variable)              : :                                                               | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |    Path Attribute Length      |       Path Attributes         : +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ :                                                               : :                Path Attributes (cont, variable)               : :                                                               | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ :                                                               : :       Network Layer Reachability Information (variable)       : :                                                               | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ ```\n\nRef: RFC 4271 §4.3",
+        "type": "object",
+        "properties": {
+          "nlri": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prefix"
+            }
+          },
+          "path_attributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PathAttribute"
+            }
+          },
+          "withdrawn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prefix"
+            }
+          }
+        },
+        "required": [
+          "nlri",
+          "path_attributes",
+          "withdrawn"
         ]
       },
       "Withdraw4Request": {

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -614,7 +614,7 @@
         ]
       },
       "AddPathElement": {
-        "description": "The `AddPathElement` comes as a BGP capability extension as described in RFC 7911.",
+        "description": "The add path element comes as a BGP capability extension as described in RFC 7911.",
         "type": "object",
         "properties": {
           "afi": {
@@ -872,10 +872,10 @@
         ]
       },
       "Capability": {
-        "description": "Optional capabilities supported by a BGP implementation. An issue tracking the TODOs below is here <https://github.com/oxidecomputer/maghemite/issues/80>",
+        "description": "Optional capabilities supported by a BGP implementation.",
         "oneOf": [
           {
-            "description": "RFC 2858 TODO",
+            "description": "Multiprotocol extensions as defined in RFC 2858",
             "type": "object",
             "properties": {
               "multiprotocol_extensions": {
@@ -904,7 +904,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 2918 TODO",
+            "description": "Route refresh capability as defined in RFC 2918. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "route_refresh": {
@@ -917,7 +917,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 5291 TODO",
+            "description": "Outbound filtering capability as defined in RFC 5291. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "outbound_route_filtering": {
@@ -930,7 +930,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8277 (deprecated) TODO",
+            "description": "Multiple routes to destination capability as defined in RFC 8277 (deprecated). Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "multiple_routes_to_destination": {
@@ -943,7 +943,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8950 TODO",
+            "description": "Multiple nexthop encoding capability as defined in RFC 8950. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "extended_next_hop_encoding": {
@@ -956,7 +956,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8654 TODO",
+            "description": "Extended message capability as defined in RFC 8654. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "b_g_p_extended_message": {
@@ -969,7 +969,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8205 TODO",
+            "description": "BGPSec as defined in RFC 8205. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "bgp_sec": {
@@ -982,7 +982,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8277 TODO",
+            "description": "Multiple label support as defined in RFC 8277. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "multiple_labels": {
@@ -995,7 +995,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 9234 TODO",
+            "description": "BGP role capability as defined in RFC 9234. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "bgp_role": {
@@ -1008,7 +1008,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 4724 TODO",
+            "description": "Graceful restart as defined in RFC 4724. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "graceful_restart": {
@@ -1021,7 +1021,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 6793",
+            "description": "Four octet AS numbers as defined in RFC 6793.",
             "type": "object",
             "properties": {
               "four_octet_as": {
@@ -1044,7 +1044,7 @@
             "additionalProperties": false
           },
           {
-            "description": "draft-ietf-idr-dynamic-cap TODO",
+            "description": "Dynamic capabilities as defined in draft-ietf-idr-dynamic-cap. Note this capability is not yet implemented.",
             "type": "object",
             "properties": {
               "dynamic_capability": {
@@ -1057,7 +1057,7 @@
             "additionalProperties": false
           },
           {
-            "description": "draft-ietf-idr-bgp-multisession TODO",
+            "description": "Multi session support as defined in draft-ietf-idr-bgp-multisession. Note this capability is not yet supported.",
             "type": "object",
             "properties": {
               "multisession_bgp": {
@@ -1070,7 +1070,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 7911",
+            "description": "Add path capability as defined in RFC 7911.",
             "type": "object",
             "properties": {
               "add_path": {
@@ -1094,7 +1094,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 7313 TODO",
+            "description": "Enhanced route refresh as defined in RFC 7313. Note this capability is not yet supported.",
             "type": "object",
             "properties": {
               "enhanced_route_refresh": {
@@ -1107,7 +1107,7 @@
             "additionalProperties": false
           },
           {
-            "description": "draft-uttaro-idr-bgp-persistence TODO",
+            "description": "Long-lived graceful restart as defined in draft-uttaro-idr-bgp-persistence. Note this capability is not yet supported.",
             "type": "object",
             "properties": {
               "long_lived_graceful_restart": {
@@ -1120,7 +1120,7 @@
             "additionalProperties": false
           },
           {
-            "description": "draft-ietf-idr-rpd-04 TODO",
+            "description": "Routing policy distribution as defined indraft-ietf-idr-rpd-04. Note this capability is not yet supported.",
             "type": "object",
             "properties": {
               "routing_policy_distribution": {
@@ -1133,7 +1133,7 @@
             "additionalProperties": false
           },
           {
-            "description": "draft-walton-bgp-hostname-capability TODO",
+            "description": "Fully qualified domain names as defined intdraft-walton-bgp-hostname-capability. Note this capability is not yet supported.",
             "type": "object",
             "properties": {
               "fqdn": {
@@ -1146,7 +1146,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810 (deprecated) TODO",
+            "description": "Pre-standard route refresh as defined in RFC 8810 (deprecated). Note this capability is not yet supported.",
             "type": "object",
             "properties": {
               "prestandard_route_refresh": {
@@ -1159,7 +1159,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810 (deprecated) TODO",
+            "description": "Pre-standard prefix-based outbound route filtering as defined in RFC 8810 (deprecated). Note this is not yet implemented.",
             "type": "object",
             "properties": {
               "prestandard_orf_and_pd": {
@@ -1172,7 +1172,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810 (deprecated) TODO",
+            "description": "Pre-standard outbound route filtering as defined in RFC 8810 (deprecated). Note this is not yet implemented.",
             "type": "object",
             "properties": {
               "prestandard_outbound_route_filtering": {
@@ -1185,7 +1185,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810 (deprecated) TODO",
+            "description": "Pre-standard multisession as defined in RFC 8810 (deprecated). Note this is not yet implemented.",
             "type": "object",
             "properties": {
               "prestandard_multisession": {
@@ -1198,7 +1198,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810 (deprecated) TODO",
+            "description": "Pre-standard fully qualified domain names as defined in RFC 8810 (deprecated). Note this is not yet implemented.",
             "type": "object",
             "properties": {
               "prestandard_fqdn": {
@@ -1211,7 +1211,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810 (deprecated) TODO",
+            "description": "Pre-standard operational messages as defined in RFC 8810 (deprecated). Note this is not yet implemented.",
             "type": "object",
             "properties": {
               "prestandard_operational_message": {
@@ -1224,7 +1224,7 @@
             "additionalProperties": false
           },
           {
-            "description": "RFC 8810",
+            "description": "Experimental capability as defined in RFC 8810.",
             "type": "object",
             "properties": {
               "experimental": {
@@ -1759,7 +1759,7 @@
         ]
       },
       "NotificationMessage": {
-        "description": "Notification messages are exchanged between BGP peers when an exceptional event has occured.",
+        "description": "Notification messages are exchanged between BGP peers when an exceptional event has occurred.",
         "type": "object",
         "properties": {
           "data": {
@@ -2242,7 +2242,7 @@
         ]
       },
       "Prefix": {
-        "description": "This data structure captures a network prefix as it's layed out in a BGP message. There is a prefix length followed by a variable number of bytes. Just enough bytes to express the prefix.",
+        "description": "This data structure captures a network prefix as it's laid out in a BGP message. There is a prefix length followed by a variable number of bytes. Just enough bytes to express the prefix.",
         "type": "object",
         "properties": {
           "length": {

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -180,7 +180,7 @@
       }
     },
     "/bgp/message-history": {
-      "post": {
+      "get": {
         "operationId": "message_history",
         "requestBody": {
           "content": {


### PR DESCRIPTION
- Fixes #101 

Adds a simple in-memory queue for incoming and outgoing messages, and an API call to retrieve them. The queue size is limited to 1024 messages in each direction. This is meant as a debugging tool and is not meant to be a persistent historian.