### PR TITLE
track ddm state durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "colored",
  "ddm",
  "ddm-admin-client",
+ "humantime",
  "mg-common",
  "slog",
  "slog-async",

--- a/ddm-admin-client/src/lib.rs
+++ b/ddm-admin-client/src/lib.rs
@@ -14,7 +14,8 @@ progenitor::generate_api!(
     }),
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::trace!(log, "client response"; "result" => ?result);
-    })
+    }),
+    replace = { Duration = std::time::Duration }
 );
 
 impl Copy for types::Ipv4Prefix {}

--- a/ddm/src/admin.rs
+++ b/ddm/src/admin.rs
@@ -104,7 +104,53 @@ pub fn handler(
     Ok(())
 }
 
-/// Status of a DDM peer with state expressed as durations.
+/// Status of a DDM peer.
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename = "PeerStatus")]
+pub enum PeerStatusV1 {
+    NoContact,
+    Active,
+    Expired,
+}
+
+// Translate internal peer status which is based on instants, to API
+// representation which is based on durations.
+impl From<crate::db::PeerStatus> for PeerStatusV1 {
+    fn from(value: crate::db::PeerStatus) -> Self {
+        match value {
+            crate::db::PeerStatus::NoContact => Self::NoContact,
+            crate::db::PeerStatus::Init(_)
+            | crate::db::PeerStatus::Solicit(_)
+            | crate::db::PeerStatus::Exchange(_) => Self::Active,
+            crate::db::PeerStatus::Expired(_) => Self::Expired,
+        }
+    }
+}
+
+/// Information about a DDM peer.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename = "PeerInfo")]
+pub struct PeerInfoV1 {
+    pub status: PeerStatusV1,
+    pub addr: Ipv6Addr,
+    pub host: String,
+    pub kind: RouterKind,
+}
+
+impl From<crate::db::PeerInfo> for PeerInfoV1 {
+    fn from(value: crate::db::PeerInfo) -> Self {
+        Self {
+            status: value.status.into(),
+            addr: value.addr,
+            host: value.host,
+            kind: value.kind,
+        }
+    }
+}
+
+/// Status of a DDM peer. Includes how long the current status has been active.
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema,
 )]
@@ -148,49 +194,6 @@ pub struct PeerInfoV2 {
     pub kind: RouterKind,
 }
 
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema,
-)]
-pub enum PeerStatus {
-    NoContact,
-    Active,
-    Expired,
-}
-
-// Translate internal peer status which is based on instants, to API
-// representation which is based on durations.
-impl From<crate::db::PeerStatus> for PeerStatus {
-    fn from(value: crate::db::PeerStatus) -> Self {
-        match value {
-            crate::db::PeerStatus::NoContact => Self::NoContact,
-            crate::db::PeerStatus::Init(_)
-            | crate::db::PeerStatus::Solicit(_)
-            | crate::db::PeerStatus::Exchange(_) => Self::Active,
-            crate::db::PeerStatus::Expired(_) => Self::Expired,
-        }
-    }
-}
-
-impl From<crate::db::PeerInfo> for PeerInfo {
-    fn from(value: crate::db::PeerInfo) -> Self {
-        Self {
-            status: value.status.into(),
-            addr: value.addr,
-            host: value.host,
-            kind: value.kind,
-        }
-    }
-}
-
-/// Information about a DDM peer.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-pub struct PeerInfo {
-    pub status: PeerStatus,
-    pub addr: Ipv6Addr,
-    pub host: String,
-    pub kind: RouterKind,
-}
-
 impl From<crate::db::PeerInfo> for PeerInfoV2 {
     fn from(value: crate::db::PeerInfo) -> Self {
         Self {
@@ -205,7 +208,7 @@ impl From<crate::db::PeerInfo> for PeerInfoV2 {
 #[endpoint { method = GET, path = "/peers" }]
 async fn get_peers(
     ctx: RequestContext<Arc<Mutex<HandlerContext>>>,
-) -> Result<HttpResponseOk<HashMap<u32, PeerInfo>>, HttpError> {
+) -> Result<HttpResponseOk<HashMap<u32, PeerInfoV1>>, HttpError> {
     let ctx = ctx.context().lock().unwrap();
     let peers = ctx
         .db

--- a/ddm/src/discovery.rs
+++ b/ddm/src/discovery.rs
@@ -85,7 +85,7 @@
 //! and 1 for a transit routers. The fourth byte is a hostname length followed
 //! directly by a hostname of up to 255 bytes in length.
 
-use crate::db::{Db, PeerInfo, PeerStatus, RouterKind};
+use crate::db::{Db, RouterKind};
 use crate::sm::{Config, Event, NeighborEvent, SessionStats};
 use crate::util::u8_slice_assume_init_ref;
 use crate::{dbg, err, inf, trc, wrn};
@@ -504,15 +504,9 @@ fn handle_advertisement(
         }
     };
     drop(guard);
-    let updated = ctx.db.set_peer(
-        ctx.config.if_index,
-        PeerInfo {
-            status: PeerStatus::Active,
-            addr: *sender,
-            host: hostname,
-            kind,
-        },
-    );
+    let updated =
+        ctx.db
+            .set_peer_info(ctx.config.if_index, *sender, hostname, kind);
     if updated {
         stats.peer_address.lock().unwrap().replace(*sender);
         emit_nbr_update(ctx, sender, version);

--- a/ddmadm/Cargo.toml
+++ b/ddmadm/Cargo.toml
@@ -17,3 +17,4 @@ tabwriter.workspace = true
 colored.workspace = true
 anyhow.workspace = true
 anstyle.workspace = true
+humantime.workspace = true

--- a/openapi/ddm-admin.json
+++ b/openapi/ddm-admin.json
@@ -582,6 +582,7 @@
         ]
       },
       "PeerStatus": {
+        "description": "Status of a DDM peer.",
         "type": "string",
         "enum": [
           "NoContact",
@@ -590,7 +591,7 @@
         ]
       },
       "PeerStatusV2": {
-        "description": "Status of a DDM peer with state expressed as durations.",
+        "description": "Status of a DDM peer. Includes how long the current status has been active.",
         "oneOf": [
           {
             "type": "object",

--- a/openapi/ddm-admin.json
+++ b/openapi/ddm-admin.json
@@ -157,6 +157,33 @@
         }
       }
     },
+    "/peers_v2": {
+      "get": {
+        "operationId": "get_peers_v2",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Map_of_PeerInfoV2",
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/PeerInfoV2"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/prefix": {
       "put": {
         "operationId": "advertise_prefixes",
@@ -355,6 +382,25 @@
   },
   "components": {
     "schemas": {
+      "Duration": {
+        "type": "object",
+        "properties": {
+          "nanos": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "secs": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "nanos",
+          "secs"
+        ]
+      },
       "EnableStatsRequest": {
         "type": "object",
         "properties": {
@@ -486,6 +532,7 @@
         ]
       },
       "PeerInfo": {
+        "description": "Information about a DDM peer.",
         "type": "object",
         "properties": {
           "addr": {
@@ -509,12 +556,128 @@
           "status"
         ]
       },
+      "PeerInfoV2": {
+        "description": "Information about a DDM peer.",
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "host": {
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/RouterKind"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PeerStatusV2"
+          }
+        },
+        "required": [
+          "addr",
+          "host",
+          "kind",
+          "status"
+        ]
+      },
       "PeerStatus": {
         "type": "string",
         "enum": [
           "NoContact",
           "Active",
           "Expired"
+        ]
+      },
+      "PeerStatusV2": {
+        "description": "Status of a DDM peer with state expressed as durations.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "NoContact"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Init"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Duration"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Solicit"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Duration"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Exchange"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Duration"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Expired"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Duration"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
         ]
       },
       "RouterKind": {


### PR DESCRIPTION
This PR tracks the times of DDM session state transitions internally and provides that information through an new `GET /peers-v2` API endpoint. The existing `GET /peers` endpoint that control planes depend on remains in place.

- Fixes #54 