### PR TITLE
mgd and mg-ddm: make rack-uuid and sled-uuid optional

### DIFF
--- a/ddmd/src/main.rs
+++ b/ddmd/src/main.rs
@@ -186,22 +186,26 @@ async fn main() {
         .collect();
 
     let stats_handler = if arg.with_stats && !dns_servers.is_empty() {
-        Some(
-            ddm::oxstats::start_server(
-                arg.admin_addr,
-                arg.oximeter_port,
-                peers.clone(),
-                router_stats.clone(),
-                dns_servers,
-                hostname.clone(),
-                arg.rack_uuid
-                    .expect("rack uuid required to start stats server"),
-                arg.sled_uuid
-                    .expect("sled uuid required to start stats server"),
-                log.clone(),
+        if let (Some(rack_uuid), Some(sled_uuid)) =
+            (arg.rack_uuid, arg.sled_uuid)
+        {
+            Some(
+                ddm::oxstats::start_server(
+                    arg.admin_addr,
+                    arg.oximeter_port,
+                    peers.clone(),
+                    router_stats.clone(),
+                    dns_servers,
+                    hostname.clone(),
+                    rack_uuid,
+                    sled_uuid,
+                    log.clone(),
+                )
+                .unwrap(),
             )
-            .unwrap(),
-        )
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -73,11 +73,11 @@ struct RunArgs {
 
     /// Id of the rack this router is running on.
     #[arg(long)]
-    rack_uuid: Uuid,
+    rack_uuid: Option<Uuid>,
 
     /// Id of the sled this router is running on.
     #[arg(long)]
-    sled_uuid: Uuid,
+    sled_uuid: Option<Uuid>,
 }
 
 #[tokio::main]
@@ -150,17 +150,21 @@ async fn run(args: RunArgs) {
         .collect();
 
     if args.with_stats && !dns_servers.is_empty() {
-        oxstats::start_server(
-            args.admin_addr,
-            args.oximeter_port,
-            context.clone(),
-            dns_servers,
-            hostname,
-            args.rack_uuid,
-            args.sled_uuid,
-            log.clone(),
-        )
-        .unwrap();
+        if let (Some(rack_uuid), Some(sled_uuid)) =
+            (args.rack_uuid, args.sled_uuid)
+        {
+            oxstats::start_server(
+                args.admin_addr,
+                args.oximeter_port,
+                context.clone(),
+                dns_servers,
+                hostname,
+                rack_uuid,
+                sled_uuid,
+                log.clone(),
+            )
+            .unwrap();
+        }
     }
 
     let j = admin::start_server(

--- a/smf/mgd_method_script.sh
+++ b/smf/mgd_method_script.sh
@@ -8,9 +8,19 @@ export RUST_LOG=info
 args=(
     --admin-port "$(svcprop -c -p config/admin_port "${SMF_FMRI}")"
     --admin-addr "$(svcprop -c -p config/admin_host "${SMF_FMRI}")"
-    --rack-uuid "$(svcprop -c -p config/rack_uuid "${SMF_FMRI}")"
-    --sled-uuid "$(svcprop -c -p config/sled_uuid "${SMF_FMRI}")"
 )
+
+val=$(svcprop -c -p config/rack_uuid "${SMF_FMRI}")
+if [[ "$val" != 'unknown' ]]; then
+    args+=( '--rack-uuid' )
+    args+=( "$val" )
+fi
+
+val=$(svcprop -c -p config/sled_uuid "${SMF_FMRI}")
+if [[ "$val" != 'unknown' ]]; then
+    args+=( '--sled-uuid' )
+    args+=( "$val" )
+fi
 
 for x in $(svcprop -c -p config/dns_servers "${SMF_FMRI}"); do
     args+=( '--dns-servers' )


### PR DESCRIPTION
If these are not provided, we will not start an `oxstats` server.

Part of fixing https://github.com/oxidecomputer/omicron/issues/5318