### PR TITLE
add timeout to kernel route get request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
  "hostname",
  "hyper",
  "ispf",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
  "mg-common",
  "omicron-common",
  "opte-ioctl",
@@ -798,7 +798,7 @@ dependencies = [
  "ddm",
  "dpd-client",
  "hostname",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -1938,6 +1938,25 @@ dependencies = [
 [[package]]
 name = "libnet"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout#2dfa84eabc789aa8f70667559460dfc75737af38"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "colored",
+ "dlpi",
+ "libc",
+ "num_enum 0.5.11",
+ "nvpair",
+ "nvpair-sys",
+ "rusty-doors",
+ "socket2 0.4.10",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "libnet"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/netadm-sys#d44d9e084f39e844f8083d4d9b39a331061ebbcc"
 dependencies = [
  "anyhow",
@@ -2107,7 +2126,7 @@ dependencies = [
  "ddm-admin-client",
  "dpd-client",
  "http 0.2.12",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
  "mg-common",
  "rdb",
  "slog",
@@ -2131,7 +2150,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ddm-admin-client",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -4935,7 +4954,7 @@ name = "util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
  "slog",
  "slog-async",
  "slog-envlogger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
  "hostname",
  "hyper",
  "ispf",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "mg-common",
  "omicron-common",
  "opte-ioctl",
@@ -798,7 +798,7 @@ dependencies = [
  "ddm",
  "dpd-client",
  "hostname",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -1919,7 +1919,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "libnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#d44d9e084f39e844f8083d4d9b39a331061ebbcc"
+source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#1d75565d35765c57dcf1c1a34b56cf5024086fba"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1938,26 +1938,7 @@ dependencies = [
 [[package]]
 name = "libnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout#2dfa84eabc789aa8f70667559460dfc75737af38"
-dependencies = [
- "anyhow",
- "cfg-if",
- "colored",
- "dlpi",
- "libc",
- "num_enum 0.5.11",
- "nvpair",
- "nvpair-sys",
- "rusty-doors",
- "socket2 0.4.10",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "libnet"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys#d44d9e084f39e844f8083d4d9b39a331061ebbcc"
+source = "git+https://github.com/oxidecomputer/netadm-sys#1d75565d35765c57dcf1c1a34b56cf5024086fba"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2126,7 +2107,7 @@ dependencies = [
  "ddm-admin-client",
  "dpd-client",
  "http 0.2.12",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "mg-common",
  "rdb",
  "slog",
@@ -2150,7 +2131,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ddm-admin-client",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -4954,7 +4935,7 @@ name = "util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=route-get-timeout)",
+ "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "slog",
  "slog-async",
  "slog-envlogger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde_repr = "0.1"
 anyhow = "1.0"
 hyper = "0.14"
 serde_json = "1.0"
-libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "route-get-timeout" }
+libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "main" }
 percent-encoding = "2.3"
 reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"] }
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde_repr = "0.1"
 anyhow = "1.0"
 hyper = "0.14"
 serde_json = "1.0"
-libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "main" }
+libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "route-get-timeout" }
 percent-encoding = "2.3"
 reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"] }
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -21,6 +21,7 @@ use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
 const TFPORT_QSFP_DEVICE_PREFIX: &str = "tfportqsfp";
 
@@ -145,10 +146,13 @@ where
 fn get_port_and_link(
     r: &Route4ImportKey,
 ) -> Result<(PortId, types::LinkId), String> {
-    let sys_route = match get_route(IpPrefix::V4(Ipv4Prefix {
-        addr: r.nexthop,
-        mask: 32,
-    })) {
+    let sys_route = match get_route(
+        IpPrefix::V4(Ipv4Prefix {
+            addr: r.nexthop,
+            mask: 32,
+        }),
+        Some(Duration::from_secs(1)),
+    ) {
         Ok(r) => r,
         Err(e) => {
             return Err(format!("Unable to get route for {r:?}: {e:?}"));


### PR DESCRIPTION
We've observed that calls over `AF_ROUTE` sockets to `RTM_GET` (see `routing(4p)`) can go unanswered. This patch makes it so we don't wait indefinitely in such situations. A timeout of 1 second is set for `AF_ROUTE` calls. This code is in a reconciler sync path, so transient failures are handled by the nature of the execution pattern.