### PR TITLE
[deps] depend on uuid1, not uuid (which implies uuid08)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0", features = ["derive"] }
 hostname = "0.3"
 thiserror = "1.0"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
-schemars = { version = "0.8", features = [ "uuid", "chrono" ] }
+schemars = { version = "0.8", features = [ "uuid1", "chrono" ] }
 tokio = { version = "1.36", features = ["full"] }
 serde_repr = "0.1"
 anyhow = "1.0"


### PR DESCRIPTION
Noticed that we were pulling in a dependency on uuid 0.8 in omicron -- I think
this should be uuid1.
