### PR TITLE
Build macOS binaries

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,22 @@
+name: macOS binaries
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+
+    - run: cargo build -p mgd --release --no-default-features
+
+    - name: Upload mgd binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: mgd-${{ github.sha }}
+        path: target/release/mgd


### PR DESCRIPTION
Same deal as https://github.com/oxidecomputer/dendrite/pull/945

- [x] Build the binaries
- [ ] Generate and upload SHA256sums
- [ ] Get the filenames right
  * For the Linux binaries, Omicron [looks for](https://github.com/oxidecomputer/omicron/blob/95c9b3d665b63d057c5811e88fbfeecb87999f6a/tools/ci_download_maghemite_mgd#L25-L28) `https://buildomat.eng.oxide.computer/public/file/oxidecomputer/maghemite/image/<commit>/mgd.tar.gz`
- [ ] Make sure rust toolchain business is in order
- [ ] Figure out where to upload the binaries


I figure we should start with these running on all PRs but not required for merge.