### PR TITLE
[smf] Update manifests to reflect self assembling switch zone

### DIFF
--- a/smf/ddm/manifest.xml
+++ b/smf/ddm/manifest.xml
@@ -4,10 +4,18 @@
 <service_bundle type='manifest' name='mg-ddm'>
 
 <service name='oxide/mg-ddm' type='service' version='1'>
-  <create_default_instance enabled='false' />
+  <create_default_instance enabled='true' />
   <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
   <service_fmri value='svc:/milestone/network:default' />
+  </dependency>
+
+  <dependency name='zone_network_setup' grouping='require_all' restart_on='none' type='service'>
+    <service_fmri value='svc:/oxide/zone-network-setup:default' />
+  </dependency>
+
+  <dependency name='switch_zone_setup' grouping='require_all' restart_on='none' type='service'>
+    <service_fmri value='svc:/oxide/switch_zone_setup:default' />
   </dependency>
 
   <exec_method type='method' name='start'

--- a/smf/mgd/manifest.xml
+++ b/smf/mgd/manifest.xml
@@ -4,10 +4,14 @@
 <service_bundle type='manifest' name='mgd'>
 
 <service name='oxide/mgd' type='service' version='1'>
-  <create_default_instance enabled='false' />
+  <create_default_instance enabled='true' />
   <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
   <service_fmri value='svc:/milestone/network:default' />
+  </dependency>
+
+  <dependency name='zone_network_setup' grouping='require_all' restart_on='none' type='service'>
+    <service_fmri value='svc:/oxide/zone-network-setup:default' />
   </dependency>
 
   <exec_method type='method' name='start'


### PR DESCRIPTION
**DO NOT MERGE** - let's wait until release 8 is out the door

In Omicron, we are converting all zones to be self assembling. This means we are no longer having to boot the zone, configure zone networking, configure all the services and finally refresh each service.

For the switch zone we have two new services that configure common networking in https://github.com/oxidecomputer/omicron/pull/5593. This PR adds these dependencies to the SMF files that require them, and sets the service default instance as enabled by default.

This PR should be merged in conjunction with https://github.com/oxidecomputer/omicron/pull/5593