### PR TITLE
Bump OPTE to API version 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,17 +847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derror-macro"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.63",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
 
 [[package]]
 name = "indexmap"
@@ -1822,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
 dependencies = [
  "quote",
  "syn 2.0.63",
@@ -2699,10 +2688,9 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
 dependencies = [
  "cfg-if",
- "derror-macro",
  "dyn-clone",
  "illumos-sys-hdrs",
  "kstat-macro",
@@ -2717,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
 dependencies = [
  "illumos-sys-hdrs",
  "ipnetwork",
@@ -2729,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
 dependencies = [
  "libc",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
@@ -2743,7 +2731,7 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=4cc823b50d3e4a629cdfaab2b3d3382514174ba9#4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
 dependencies = [
  "cfg-if",
  "illumos-sys-hdrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
+source = "git+https://github.com/oxidecomputer/opte?rev=d6177ca84f23e60a661461bb4cece475689502d2#d6177ca84f23e60a661461bb4cece475689502d2"
 
 [[package]]
 name = "indexmap"
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
+source = "git+https://github.com/oxidecomputer/opte?rev=d6177ca84f23e60a661461bb4cece475689502d2#d6177ca84f23e60a661461bb4cece475689502d2"
 dependencies = [
  "quote",
  "syn 2.0.63",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
+source = "git+https://github.com/oxidecomputer/opte?rev=d6177ca84f23e60a661461bb4cece475689502d2#d6177ca84f23e60a661461bb4cece475689502d2"
 dependencies = [
  "cfg-if",
  "dyn-clone",
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
+source = "git+https://github.com/oxidecomputer/opte?rev=d6177ca84f23e60a661461bb4cece475689502d2#d6177ca84f23e60a661461bb4cece475689502d2"
 dependencies = [
  "illumos-sys-hdrs",
  "ipnetwork",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
+source = "git+https://github.com/oxidecomputer/opte?rev=d6177ca84f23e60a661461bb4cece475689502d2#d6177ca84f23e60a661461bb4cece475689502d2"
 dependencies = [
  "libc",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
@@ -2731,7 +2731,7 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cf268a6383861f902b0c18afb7cfe35e42987504#cf268a6383861f902b0c18afb7cfe35e42987504"
+source = "git+https://github.com/oxidecomputer/opte?rev=d6177ca84f23e60a661461bb4cece475689502d2#d6177ca84f23e60a661461bb4cece475689502d2"
 dependencies = [
  "cfg-if",
  "illumos-sys-hdrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,11 +92,11 @@ rhai = { version = "1", features = ["metadata", "sync"] }
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"
-rev = "cf268a6383861f902b0c18afb7cfe35e42987504"
+rev = "d6177ca84f23e60a661461bb4cece475689502d2"
 
 [workspace.dependencies.oxide-vpc]
 git = "https://github.com/oxidecomputer/opte"
-rev = "cf268a6383861f902b0c18afb7cfe35e42987504"
+rev = "d6177ca84f23e60a661461bb4cece475689502d2"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,11 +92,11 @@ rhai = { version = "1", features = ["metadata", "sync"] }
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"
-rev = "4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+rev = "cf268a6383861f902b0c18afb7cfe35e42987504"
 
 [workspace.dependencies.oxide-vpc]
 git = "https://github.com/oxidecomputer/opte"
-rev = "4cc823b50d3e4a629cdfaab2b3d3382514174ba9"
+rev = "cf268a6383861f902b0c18afb7cfe35e42987504"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"


### PR DESCRIPTION
This is needed to support oxidecomputer/omicron#5602.

I'm leaving in draft for now so as not to block any other maghemite updates -- I'm aiming to merge after oxidecomputer/omicron#5722.