### PR TITLE
disable the ddm v1 tests

### DIFF
--- a/.github/buildomat/jobs/test-ddm-trio-v1-server.sh
+++ b/.github/buildomat/jobs/test-ddm-trio-v1-server.sh
@@ -10,6 +10,7 @@
 #: access_repos = [
 #:   "oxidecomputer/dendrite",
 #: ]
+#: enable = false
 #:
 
 source .github/buildomat/test-ddm-common.sh

--- a/.github/buildomat/jobs/test-ddm-trio-v1-transit.sh
+++ b/.github/buildomat/jobs/test-ddm-trio-v1-transit.sh
@@ -10,6 +10,7 @@
 #: access_repos = [
 #:   "oxidecomputer/dendrite",
 #: ]
+#: enable = false
 #:
 
 source .github/buildomat/test-ddm-common.sh


### PR DESCRIPTION
Relevant to #275. My inclination is to remove dead code and pick it back up from the git history, but @rcgoodfellow asked that we disable it instead. See #275 for a fuller explanation, but in short, these tests validate against v1 which is no longer relevant given that upgrade from v1 is no longer supported.