### PR TITLE
compat between ddm exchange protocol v2/v3

### DIFF
--- a/.github/buildomat/jobs/test-ddm-trio-v2-server.sh
+++ b/.github/buildomat/jobs/test-ddm-trio-v2-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "test-ddm-trio-v1-server"
+#: name = "test-ddm-trio-v2-server"
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"
@@ -10,7 +10,7 @@
 #: access_repos = [
 #:   "oxidecomputer/dendrite",
 #: ]
-#: enable = false
+#: enable = true
 #:
 
 source .github/buildomat/test-ddm-common.sh
@@ -20,4 +20,4 @@ source .github/buildomat/test-ddm-common.sh
 #
 
 banner "trio"
-pfexec cargo test --release -p mg-tests test_trio_v1_server -- --nocapture
+pfexec cargo test --release -p mg-tests test_trio_v2_server -- --nocapture

--- a/.github/buildomat/jobs/test-ddm-trio-v2-transit.sh
+++ b/.github/buildomat/jobs/test-ddm-trio-v2-transit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "test-ddm-trio-v1-transit"
+#: name = "test-ddm-trio-v2-transit"
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"
@@ -10,7 +10,7 @@
 #: access_repos = [
 #:   "oxidecomputer/dendrite",
 #: ]
-#: enable = false
+#: enable = true
 #:
 
 source .github/buildomat/test-ddm-common.sh
@@ -20,4 +20,4 @@ source .github/buildomat/test-ddm-common.sh
 #
 
 banner "trio"
-pfexec cargo test --release -p mg-tests test_trio_v1_transit -- --nocapture
+pfexec cargo test --release -p mg-tests test_trio_v2_transit -- --nocapture

--- a/.github/buildomat/jobs/test-ddm-trio.sh
+++ b/.github/buildomat/jobs/test-ddm-trio.sh
@@ -19,4 +19,4 @@ source .github/buildomat/test-ddm-common.sh
 #
 
 banner "trio"
-pfexec cargo test --release -p mg-tests test_trio_v2 -- --nocapture
+pfexec cargo test --release -p mg-tests test_trio_v3 -- --nocapture

--- a/.github/buildomat/test-ddm-common.sh
+++ b/.github/buildomat/test-ddm-common.sh
@@ -33,16 +33,16 @@ get_artifact softnpu image 64beaff129b7f63a04a53dd5ed0ec09f012f5756 softnpu
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 libsidecar_lite.so
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 scadm
 get_artifact dendrite image 350fb25d724578dd2b127499edcd57981d4bbff2 dendrite-softnpu.tar.gz
-get_artifact maghemite release e76dc67706beb806b2f0ecfd6d51097c6c06d534 ddmd
-get_artifact maghemite release e76dc67706beb806b2f0ecfd6d51097c6c06d534 ddmadm
+get_artifact maghemite release 2bfd39000c878c45675651a7588c015c486e7f43 ddmd
+get_artifact maghemite release 2bfd39000c878c45675651a7588c015c486e7f43 ddmadm
 
 pushd download
 chmod +x softnpu
 chmod +x scadm
 chmod +x ddmadm
 chmod +x ddmd
-mv ddmadm ddmadm-v1
-mv ddmd ddmd-v1
+mv ddmadm ddmadm-v2
+mv ddmd ddmd-v2
 rm -rf zones/dendrite
 mkdir -p zones/dendrite
 tar -xzf dendrite-softnpu.tar.gz -C zones/dendrite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ddm-admin-client"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/maghemite?rev=2bfd39000c878c45675651a7588c015c486e7f43#2bfd39000c878c45675651a7588c015c486e7f43"
+dependencies = [
+ "percent-encoding",
+ "progenitor",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "slog",
+ "uuid",
+]
+
+[[package]]
 name = "ddmadm"
 version = "0.1.0"
 dependencies = [
@@ -770,7 +784,7 @@ dependencies = [
  "clap",
  "colored",
  "ddm",
- "ddm-admin-client",
+ "ddm-admin-client 0.1.0",
  "mg-common",
  "oxnet 0.1.0 (git+https://github.com/oxidecomputer/oxnet)",
  "slog",
@@ -2140,7 +2154,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "common",
- "ddm-admin-client",
+ "ddm-admin-client 0.1.0",
  "dpd-client",
  "http 0.2.12",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
@@ -2167,8 +2181,10 @@ name = "mg-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ddm-admin-client",
+ "ddm-admin-client 0.1.0",
+ "ddm-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=2bfd39000c878c45675651a7588c015c486e7f43)",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "serde",
  "slog",
  "slog-async",
  "slog-envlogger",

--- a/ddm/src/discovery.rs
+++ b/ddm/src/discovery.rs
@@ -109,8 +109,8 @@ const ADVERTISE: u8 = 1 << 1;
 #[derive(Debug, Copy, Clone)]
 #[repr(u8)]
 pub enum Version {
-    V1 = 1,
     V2 = 2,
+    V3 = 3,
 }
 
 #[derive(Error, Debug)]
@@ -444,8 +444,8 @@ fn handle_advertisement(
     // changes in the discovery protocol, if we were to have changes there. So
     // we need to come up with a general way for both protocols to evolve.
     let version = match version {
-        1 => Version::V1,
         2 => Version::V2,
+        3 => Version::V3,
         x => {
             err!(
                 ctx.log,

--- a/mg-common/src/net.rs
+++ b/mg-common/src/net.rs
@@ -1,7 +1,7 @@
-use oxnet::IpNet;
+use oxnet::{IpNet, Ipv4Net, Ipv6Net};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::net::Ipv6Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
@@ -12,4 +12,77 @@ pub struct TunnelOrigin {
     pub vni: u32,
     #[serde(default)]
     pub metric: u64,
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct TunnelOriginV2 {
+    pub overlay_prefix: IpPrefix,
+    pub boundary_addr: Ipv6Addr,
+    pub vni: u32,
+    #[serde(default)]
+    pub metric: u64,
+}
+
+impl From<TunnelOriginV2> for TunnelOrigin {
+    fn from(value: TunnelOriginV2) -> Self {
+        TunnelOrigin {
+            overlay_prefix: match value.overlay_prefix {
+                IpPrefix::V4(x) => {
+                    IpNet::V4(Ipv4Net::new_unchecked(x.addr, x.len))
+                }
+                IpPrefix::V6(x) => {
+                    IpNet::V6(Ipv6Net::new_unchecked(x.addr, x.len))
+                }
+            },
+            boundary_addr: value.boundary_addr,
+            vni: value.vni,
+            metric: value.metric,
+        }
+    }
+}
+
+impl From<TunnelOrigin> for TunnelOriginV2 {
+    fn from(value: TunnelOrigin) -> Self {
+        TunnelOriginV2 {
+            overlay_prefix: match value.overlay_prefix {
+                IpNet::V4(x) => IpPrefix::V4(Ipv4Prefix {
+                    addr: x.addr(),
+                    len: x.width(),
+                }),
+                IpNet::V6(x) => IpPrefix::V6(Ipv6Prefix {
+                    addr: x.addr(),
+                    len: x.width(),
+                }),
+            },
+            boundary_addr: value.boundary_addr,
+            vni: value.vni,
+            metric: value.metric,
+        }
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct Ipv6Prefix {
+    pub addr: Ipv6Addr,
+    pub len: u8,
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub struct Ipv4Prefix {
+    pub addr: Ipv4Addr,
+    pub len: u8,
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+pub enum IpPrefix {
+    V4(Ipv4Prefix),
+    V6(Ipv6Prefix),
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 zone = { git = "https://github.com/oxidecomputer/zone" }
 ddm-admin-client = { path = "../ddm-admin-client" }
+ddm-admin-client-v2 = { package = "ddm-admin-client", git = "https://github.com/oxidecomputer/maghemite", rev = "2bfd39000c878c45675651a7588c015c486e7f43"}
 
 libnet.workspace = true
 anyhow.workspace = true
@@ -16,3 +17,5 @@ slog-async.workspace = true
 tokio.workspace = true
 ztest.workspace = true
 uuid.workspace = true
+serde.workspace = true
+


### PR DESCRIPTION
This PR provides compatibility between DDM exchange protocol versions 2 and 3. When the transition to `oxnet` data structures took place, some members of data structures in the DDM exchange API were changed. In particular, members representing IPv4 and IPv6 prefixes. Because the `oxnet` data structures (de)serialize differently than the bespoke data structures that were there before, an incompatibility across DDM versions was introduced. 

This PR brings back the basic IP prefix data structures that were in use before and provides both V2 and V3 exchange API methods. Like prior cross-compatibility between V2 and V1, the version of a peer is determined during discovery, and then the exchange protocol implementation will use the appropriate method versions and deserialization mechanisms based on the discovered version of the peer.