### PR TITLE
Let the oximeter producer server use DNS all the time

### DIFF
--- a/ddm/src/admin.rs
+++ b/ddm/src/admin.rs
@@ -373,7 +373,6 @@ async fn enable_stats(
                 DDM_STATS_PORT,
                 ctx.peers.clone(),
                 ctx.stats.clone(),
-                rq.dns_servers.clone(),
                 hostname,
                 rq.rack_id,
                 rq.sled_id,

--- a/ddm/src/oxstats.rs
+++ b/ddm/src/oxstats.rs
@@ -5,7 +5,7 @@
 use crate::{admin::RouterStats, sm::SmContext};
 use chrono::{DateTime, Utc};
 use dropshot::{ConfigLogging, ConfigLoggingLevel};
-use mg_common::nexus::{local_underlay_address, resolve_nexus, run_oximeter};
+use mg_common::nexus::{local_underlay_address, run_oximeter};
 use omicron_common::api::internal::nexus::{ProducerEndpoint, ProducerKind};
 use oximeter::{
     types::{Cumulative, ProducerRegistry},
@@ -267,7 +267,6 @@ pub fn start_server(
     port: u16,
     peers: Vec<SmContext>,
     router_stats: Arc<RouterStats>,
-    dns_servers: Vec<SocketAddr>,
     hostname: String,
     rack_id: Uuid,
     sled_id: Uuid,
@@ -296,15 +295,14 @@ pub fn start_server(
         address: sa,
         interval: Duration::from_secs(1),
     };
+    let config = oximeter_producer::Config {
+        server_info: producer_info,
+        registration_address: None,
+        log: log_config,
+        request_body_max_bytes: 1024 * 1024 * 1024,
+    };
 
     Ok(tokio::spawn(async move {
-        let nexus_addr = resolve_nexus(log.clone(), &dns_servers).await;
-        let config = oximeter_producer::Config {
-            server_info: producer_info,
-            registration_address: Some(nexus_addr),
-            log: log_config,
-            request_body_max_bytes: 1024 * 1024 * 1024,
-        };
-        run_oximeter(registry.clone(), config.clone(), log.clone()).await
+        run_oximeter(registry, config, log).await
     }))
 }

--- a/ddmd/src/main.rs
+++ b/ddmd/src/main.rs
@@ -9,7 +9,7 @@ use ddm::sm::{DpdConfig, SmContext, StateMachine};
 use ddm::sys::Route;
 use signal::handle_signals;
 use slog::{error, Drain, Logger};
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr};
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -187,14 +187,8 @@ async fn main() {
 
     let router_stats = Arc::new(RouterStats::default());
     let peers: Vec<SmContext> = sms.iter().map(|x| x.ctx.clone()).collect();
-    let dns_servers: Vec<SocketAddr> = arg
-        .dns_servers
-        .iter()
-        .filter(|x| x.as_str() != "unknown")
-        .map(|x| x.parse().unwrap())
-        .collect();
 
-    let stats_handler = if arg.with_stats && !dns_servers.is_empty() {
+    let stats_handler = if arg.with_stats {
         if let (Some(rack_uuid), Some(sled_uuid)) =
             (arg.rack_uuid, arg.sled_uuid)
         {
@@ -202,7 +196,6 @@ async fn main() {
                 arg.oximeter_port,
                 peers.clone(),
                 router_stats.clone(),
-                dns_servers,
                 hostname.clone(),
                 rack_uuid,
                 sled_uuid,

--- a/ddmd/src/smf.rs
+++ b/ddmd/src/smf.rs
@@ -67,7 +67,6 @@ fn refresh_stats_server(
             DDM_STATS_PORT,
             context.peers.clone(),
             context.stats.clone(),
-            props.dns_servers,
             hostname,
             props.rack_uuid,
             props.sled_uuid,

--- a/mg-common/src/nexus.rs
+++ b/mg-common/src/nexus.rs
@@ -2,55 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use internal_dns::{resolver::Resolver, ServiceName};
-use slog::{info, warn, Logger};
-use std::{
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
-use tokio::time::sleep;
-
-pub async fn resolve_nexus(
-    log: Logger,
-    dns_servers: &[SocketAddr],
-) -> SocketAddr {
-    info!(log, "resolving nexus");
-    loop {
-        let resolver = match Resolver::new_from_addrs(log.clone(), dns_servers)
-        {
-            Ok(resolver) => resolver,
-            Err(e) => {
-                warn!(log, "creating nexus resolver failed, waiting 1s: {e}");
-                sleep(Duration::from_secs(1)).await;
-                continue;
-            }
-        };
-
-        let op = || async {
-            match resolver.lookup_socket_v6(ServiceName::Nexus).await {
-                Ok(addr) => Ok(addr),
-                Err(e) => Err(e.into()),
-            }
-        };
-
-        let log_failure = |e, delay| {
-            warn!(log, "resolving nexus failed, {e} waiting {delay:?}");
-        };
-
-        match omicron_common::backoff::retry_notify(
-            omicron_common::backoff::retry_policy_internal_service_aggressive(),
-            op,
-            log_failure,
-        )
-        .await
-        {
-            Ok(addr) => return addr.into(),
-            Err(e) => {
-                warn!(log, "error resulving nexus: {e}");
-            }
-        }
-    }
-}
+use slog::{warn, Logger};
+use std::net::IpAddr;
 
 pub async fn run_oximeter(
     registry: oximeter::types::ProducerRegistry,

--- a/mg-common/src/smf.rs
+++ b/mg-common/src/smf.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 
 use anyhow::anyhow;
 use smf::PropertyGroup;
@@ -62,7 +62,6 @@ pub fn get_string_list_prop(
 
 pub struct StatsServerProps {
     pub admin_addr: IpAddr,
-    pub dns_servers: Vec<SocketAddr>,
     pub rack_uuid: Uuid,
     pub sled_uuid: Uuid,
 }
@@ -71,23 +70,13 @@ pub fn get_stats_server_props(
     pg: PropertyGroup<'_>,
 ) -> anyhow::Result<StatsServerProps> {
     let admin_addr = get_string_prop("admin_host", &pg)?;
-    let dns_servers_prop = get_string_list_prop("dns_servers", &pg)?;
     let rack_uuid = get_string_prop("rack_uuid", &pg)?;
     let sled_uuid = get_string_prop("sled_uuid", &pg)?;
-
-    let mut dns_servers = Vec::new();
-    for p in &dns_servers_prop {
-        dns_servers.push(
-            p.parse()
-                .map_err(|e| anyhow!("parse dns server {p}: {e}"))?,
-        );
-    }
 
     Ok(StatsServerProps {
         admin_addr: admin_addr
             .parse()
             .map_err(|e| anyhow!("parse admin addr: {e}"))?,
-        dns_servers,
         rack_uuid: rack_uuid
             .parse()
             .map_err(|e| anyhow!("parse rack uuid {rack_uuid}: {e}"))?,

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -15,7 +15,7 @@ use rdb::{BfdPeerConfig, BgpNeighborInfo, BgpRouterInfo, Path};
 use signal::handle_signals;
 use slog::{error, Logger};
 use std::collections::BTreeMap;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;
 use uuid::Uuid;
@@ -157,14 +157,7 @@ async fn run(args: RunArgs) {
         .to_string_lossy()
         .to_string();
 
-    let dns_servers: Vec<SocketAddr> = args
-        .dns_servers
-        .iter()
-        .filter(|x| x.as_str() != "unknown")
-        .map(|x| x.parse().unwrap())
-        .collect();
-
-    if args.with_stats && !dns_servers.is_empty() {
+    if args.with_stats {
         if let (Some(rack_uuid), Some(sled_uuid)) =
             (args.rack_uuid, args.sled_uuid)
         {
@@ -172,7 +165,6 @@ async fn run(args: RunArgs) {
             if !*is_running {
                 match oxstats::start_server(
                     context.clone(),
-                    dns_servers,
                     hostname,
                     rack_uuid,
                     sled_uuid,

--- a/mgd/src/smf.rs
+++ b/mgd/src/smf.rs
@@ -64,7 +64,6 @@ fn refresh_stats_server(
         info!(log, "starting stats server on smf refresh");
         match crate::oxstats::start_server(
             ctx.clone(),
-            props.dns_servers,
             hostname,
             props.rack_uuid,
             props.sled_uuid,


### PR DESCRIPTION
- Fixes #304
- Use the IPv6 underlay address for the producer server to resolve Nexus internally, rather than providing it or resolving it once on startup
- Some cleanup and removal of unused methods