### PR TITLE
fix originate4 cli arg ordering

### DIFF
--- a/mgadm/src/bgp.rs
+++ b/mgadm/src/bgp.rs
@@ -315,12 +315,12 @@ pub struct ExportPolicy {
 
 #[derive(Args, Debug)]
 pub struct Originate4 {
-    /// Set of prefixes to originate.
-    pub prefixes: Vec<Prefix4>,
-
     /// Autonomous system number for the router to originated the prefixes from.
     #[clap(env)]
     pub asn: u32,
+
+    /// Set of prefixes to originate.
+    pub prefixes: Vec<Prefix4>,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
Hit this issue doing some debugging.

```
$ ./target/debug/mgadm bgp config origin ipv4 create
thread 'main' panicked at /home/ry/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.10/src/builder/debug_asserts.rs:638:17:
Found non-required positional argument with a lower index than a required positional argument: "prefixes" index Some(1)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Abort (core dumped)
```

This PR fixes the issue described above.