### PR TITLE
RIB Priority Changes

### DIFF
--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -16,8 +16,8 @@ use crate::policy::{CheckerResult, ShaperResult};
 use crate::router::Router;
 use crate::{dbg, err, inf, to_canonical, trc, wrn};
 use mg_common::{lock, read_lock, write_lock};
-pub use rdb::DEFAULT_ROUTE_PRIORITY;
 use rdb::{Asn, BgpPathProperties, Db, ImportExportPolicy, Prefix, Prefix4};
+pub use rdb::{DEFAULT_RIB_PRIORITY_BGP, DEFAULT_ROUTE_PRIORITY};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Logger;
@@ -2070,7 +2070,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                 let path = rdb::Path {
                     nexthop: nexthop.into(),
                     shutdown: update.graceful_shutdown(),
-                    local_pref: update.local_pref(),
+                    rib_priority: DEFAULT_RIB_PRIORITY_BGP,
                     bgp: Some(BgpPathProperties {
                         origin_as: peer_as,
                         id,

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -2073,10 +2073,11 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                     local_pref: update.local_pref(),
                     bgp: Some(BgpPathProperties {
                         origin_as: peer_as,
-                        med: update.multi_exit_discriminator(),
-                        stale: None,
                         id,
+                        med: update.multi_exit_discriminator(),
+                        local_pref: update.local_pref(),
                         as_path,
+                        stale: None,
                     }),
                     vlan_id: lock!(self.session).vlan_id,
                 };

--- a/mgadm/src/bgp.rs
+++ b/mgadm/src/bgp.rs
@@ -753,7 +753,7 @@ fn print_rib(rib: Rib) {
             "{}\t{}\t{}",
             "Prefix".dimmed(),
             "Nexthop".dimmed(),
-            "Local Pref".dimmed(),
+            "RIB Priority".dimmed(),
         )
         .unwrap();
 
@@ -762,7 +762,7 @@ fn print_rib(rib: Rib) {
                 writeln!(
                     &mut tw,
                     "{}\t{}\t{:?}",
-                    prefix, path.nexthop, path.local_pref,
+                    prefix, path.nexthop, path.rib_priority,
                 )
                 .unwrap();
             }
@@ -776,9 +776,10 @@ fn print_rib(rib: Rib) {
         let mut tw = TabWriter::new(stdout());
         writeln!(
             &mut tw,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             "Prefix".dimmed(),
             "Nexthop".dimmed(),
+            "RIB Priority".dimmed(),
             "Local Pref".dimmed(),
             "Origin AS".dimmed(),
             "Peer ID".dimmed(),
@@ -793,10 +794,11 @@ fn print_rib(rib: Rib) {
                 let bgp = path.bgp.as_ref().unwrap();
                 writeln!(
                     &mut tw,
-                    "{}\t{}\t{:?}\t{}\t{}\t{:?}\t{:?}\t{:?}",
+                    "{}\t{}\t{}\t{:?}\t{}\t{}\t{:?}\t{:?}\t{:?}",
                     prefix,
                     path.nexthop,
-                    path.local_pref,
+                    path.rib_priority,
+                    bgp.local_pref,
                     bgp.origin_as,
                     Ipv4Addr::from(bgp.id),
                     bgp.med,

--- a/mgadm/src/static_routing.rs
+++ b/mgadm/src/static_routing.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 use mg_admin_client::types;
 use mg_admin_client::Client;
+use rdb::DEFAULT_RIB_PRIORITY_STATIC;
 use std::net::{AddrParseError, Ipv4Addr};
 use std::num::ParseIntError;
 use thiserror::Error;
@@ -35,8 +36,8 @@ pub struct StaticRoute4 {
     pub nexthop: Ipv4Addr,
     #[clap(long)]
     pub vlan_id: Option<u16>,
-    #[clap(long)]
-    pub local_pref: Option<u32>,
+    #[clap(long, default_value_t = DEFAULT_RIB_PRIORITY_STATIC)]
+    pub rib_priority: u8,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -77,7 +78,7 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                         },
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
-                        local_pref: route.local_pref,
+                        rib_priority: route.rib_priority,
                     }],
                 },
             };
@@ -93,7 +94,7 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                         },
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
-                        local_pref: route.local_pref,
+                        rib_priority: route.rib_priority,
                     }],
                 },
             };

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -273,7 +273,7 @@ fn initialize_static_routes(db: &rdb::Db) {
         .expect("failed to get static routes from db");
     for route in &routes {
         let path =
-            Path::for_static(route.nexthop, route.vlan_id, route.local_pref);
+            Path::for_static(route.nexthop, route.vlan_id, route.rib_priority);
         db.add_prefix_path(route.prefix, path, true)
             .unwrap_or_else(|e| {
                 panic!("failed to initialize static route {route:#?}: {e}")

--- a/mgd/src/static_admin.rs
+++ b/mgd/src/static_admin.rs
@@ -36,7 +36,7 @@ pub struct StaticRoute4 {
     pub prefix: Prefix4,
     pub nexthop: Ipv4Addr,
     pub vlan_id: Option<u16>,
-    pub local_pref: Option<u32>,
+    pub rib_priority: u8,
 }
 
 impl From<StaticRoute4> for StaticRouteKey {
@@ -45,7 +45,7 @@ impl From<StaticRoute4> for StaticRouteKey {
             prefix: val.prefix.into(),
             nexthop: val.nexthop.into(),
             vlan_id: val.vlan_id,
-            local_pref: val.local_pref,
+            rib_priority: val.rib_priority,
         }
     }
 }
@@ -69,7 +69,7 @@ pub async fn static_add_v4_route(
         .map(Into::into)
         .collect();
     for r in routes {
-        let path = Path::for_static(r.nexthop, r.vlan_id, r.local_pref);
+        let path = Path::for_static(r.nexthop, r.vlan_id, r.rib_priority);
         ctx.context()
             .db
             .add_prefix_path(r.prefix, path, true)
@@ -91,7 +91,7 @@ pub async fn static_remove_v4_route(
         .map(Into::into)
         .collect();
     for r in routes {
-        let path = Path::for_static(r.nexthop, r.vlan_id, r.local_pref);
+        let path = Path::for_static(r.nexthop, r.vlan_id, r.rib_priority);
         ctx.context()
             .db
             .remove_prefix_path(r.prefix, path, true)

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -3140,12 +3140,6 @@
       "StaticRoute4": {
         "type": "object",
         "properties": {
-          "local_pref": {
-            "nullable": true,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
           "nexthop": {
             "type": "string",
             "format": "ipv4"

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -1266,6 +1266,12 @@
             "format": "uint32",
             "minimum": 0
           },
+          "local_pref": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
           "med": {
             "nullable": true,
             "type": "integer",
@@ -2639,15 +2645,14 @@
               }
             ]
           },
-          "local_pref": {
-            "nullable": true,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
           "nexthop": {
             "type": "string",
             "format": "ip"
+          },
+          "rib_priority": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           },
           "shutdown": {
             "type": "boolean"
@@ -2661,6 +2666,7 @@
         },
         "required": [
           "nexthop",
+          "rib_priority",
           "shutdown"
         ]
       },
@@ -3147,6 +3153,11 @@
           "prefix": {
             "$ref": "#/components/schemas/Prefix4"
           },
+          "rib_priority": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "vlan_id": {
             "nullable": true,
             "type": "integer",
@@ -3156,7 +3167,8 @@
         },
         "required": [
           "nexthop",
-          "prefix"
+          "prefix",
+          "rib_priority"
         ]
       },
       "StaticRoute4List": {

--- a/rdb/src/bestpath.rs
+++ b/rdb/src/bestpath.rs
@@ -71,6 +71,7 @@ pub fn bestpaths(
         Some(ref bgp) => bgp.origin_as,
         None => 0,
     });
+
     // Filter AS groups to paths with lowest MED
     let candidates = as_groups.into_iter().flat_map(|(_asn, paths)| {
         paths.min_set_by_key(|x| match x.bgp {
@@ -88,7 +89,10 @@ mod test {
     use std::collections::BTreeSet;
 
     use super::bestpaths;
-    use crate::{db::Rib, BgpPathProperties, Path, Prefix, Prefix4};
+    use crate::{
+        db::Rib, BgpPathProperties, Path, Prefix, Prefix4,
+        DEFAULT_RIB_PRIORITY_BGP,
+    };
 
     #[test]
     fn test_bestpath() {
@@ -103,7 +107,7 @@ mod test {
         // Add one path and make sure we get it back
         let path1 = Path {
             nexthop: "203.0.113.1".parse().unwrap(),
-            local_pref: Some(100),
+            rib_priority: DEFAULT_RIB_PRIORITY_BGP,
             shutdown: false,
             bgp: Some(BgpPathProperties {
                 origin_as: 470,
@@ -124,7 +128,7 @@ mod test {
         // Add another path to the same prefix and make sure bestpath returns both
         let mut path2 = Path {
             nexthop: "203.0.113.2".parse().unwrap(),
-            local_pref: Some(100),
+            rib_priority: DEFAULT_RIB_PRIORITY_BGP,
             shutdown: false,
             bgp: Some(BgpPathProperties {
                 origin_as: 480,
@@ -148,7 +152,7 @@ mod test {
         //   - we get all three paths back wihen max is 3
         let mut path3 = Path {
             nexthop: "203.0.113.3".parse().unwrap(),
-            local_pref: Some(100),
+            rib_priority: DEFAULT_RIB_PRIORITY_BGP,
             shutdown: false,
             bgp: Some(BgpPathProperties {
                 origin_as: 490,

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -417,7 +417,7 @@ impl Db {
                 prefix,
                 nexthop: path.nexthop,
                 vlan_id: path.vlan_id,
-                local_pref: path.local_pref,
+                rib_priority: path.rib_priority,
             };
             let key = serde_json::to_string(&srk)?;
             tree.insert(key.as_str(), "")?;
@@ -533,7 +533,7 @@ impl Db {
                 prefix,
                 nexthop: path.nexthop,
                 vlan_id: path.vlan_id,
-                local_pref: path.local_pref,
+                rib_priority: path.rib_priority,
             };
             let key = serde_json::to_string(&srk)?;
             tree.remove(key.as_str())?;

--- a/rdb/src/lib.rs
+++ b/rdb/src/lib.rs
@@ -12,3 +12,9 @@ pub mod error;
 
 /// The priority routes default to.
 pub const DEFAULT_ROUTE_PRIORITY: u64 = u64::MAX;
+
+/// The default RIB Priority of BGP routes.
+pub const DEFAULT_RIB_PRIORITY_BGP: u8 = 20;
+
+/// The default RIB Priority of Static routes.
+pub const DEFAULT_RIB_PRIORITY_STATIC: u8 = 1;

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -66,6 +66,7 @@ pub struct BgpPathProperties {
     pub origin_as: u32,
     pub id: u32,
     pub med: Option<u32>,
+    pub local_pref: Option<u32>,
     pub as_path: Vec<u32>,
     pub stale: Option<DateTime<Utc>>,
 }

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 pub struct Path {
     pub nexthop: IpAddr,
     pub shutdown: bool,
-    pub local_pref: Option<u32>,
+    pub rib_priority: u8,
     pub bgp: Option<BgpPathProperties>,
     pub vlan_id: Option<u16>,
 }
@@ -38,8 +38,8 @@ impl Ord for Path {
         if self.shutdown != other.shutdown {
             return self.shutdown.cmp(&other.shutdown);
         }
-        if self.local_pref != other.local_pref {
-            return self.local_pref.cmp(&other.local_pref);
+        if self.rib_priority != other.rib_priority {
+            return self.rib_priority.cmp(&other.rib_priority);
         }
         self.bgp.cmp(&other.bgp)
     }
@@ -49,12 +49,12 @@ impl Path {
     pub fn for_static(
         nexthop: IpAddr,
         vlan_id: Option<u16>,
-        local_pref: Option<u32>,
+        rib_priority: u8,
     ) -> Self {
         Self {
             nexthop,
             vlan_id,
-            local_pref,
+            rib_priority,
             shutdown: false,
             bgp: None,
         }
@@ -108,7 +108,7 @@ pub struct StaticRouteKey {
     pub prefix: Prefix,
     pub nexthop: IpAddr,
     pub vlan_id: Option<u16>,
-    pub local_pref: Option<u32>,
+    pub rib_priority: u8,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
This primarily makes 5 changes:

1. Move BGP's `local_pref` into `BgpPathProperties` (this is a BGP-specific attribute, let's store it with the other BGP-specific attributes)
2. Rename the RIB's `local_pref` to `rib_priority` (since this is used by the RIB to prioritize certain protocols/paths over others)
3. Fixes up tests to use the new nomenclature/structure
4. Introduces new constants to represent default RIB priorities for Static and BGP protocols
5. Enables RIB priority comparison in the RIB's bestpath selection algorithm