### PR TITLE
Fix BGP route deletion and enable rdb tests in CI

### DIFF
--- a/.github/buildomat/jobs/test-rdb.sh
+++ b/.github/buildomat/jobs/test-rdb.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#:
+#: name = "test-rdb"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "/work/*.log",
+#: ]
+#: access_repos = [
+#:   "oxidecomputer/dendrite",
+#: ]
+#:
+
+set -x
+set -e
+
+cargo --version
+rustc --version
+
+cargo install cargo-nextest
+
+pushd rdb
+
+cargo nextest run
+cp *.log /work/

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -577,7 +577,7 @@ impl Db {
             self.remove_prefix_path(prefix, |rib_path: &Path| {
                 match rib_path.bgp {
                     Some(ref bgp) => bgp.id == id,
-                    None => true,
+                    None => false,
                 }
             });
             pcn.changed.insert(prefix);

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -779,8 +779,8 @@ mod test {
         let static_path1 = Path::from(static_key1);
 
         // setup
-        let log = init_file_logger("/tmp/rib.log");
-        let db_path = "/tmp/rb.db".to_string();
+        let log = init_file_logger("rib.log");
+        let db_path = "rib.db".to_string();
         let _ = std::fs::remove_dir_all(&db_path);
         let db = Db::new(&db_path, log.clone()).expect("create db");
 


### PR DESCRIPTION
The closure in remove_bgp_prefixes() was incorrectly returning false when Path.bgp was None.  This caused static route paths to be incorrectly deleted during BGP path deletion.