### PR TITLE
[metrics] add switch info/meta to ddmd/mgd related timeseries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ cargo-bay
 out
 download
 tags
+
+# rdb
+rdb/*.log
+rdb/*.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "api_identity"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "omicron-workspace-hack",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +323,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
+source = "git+https://github.com/oxidecomputer/propolis?rev=95d6a559890c94e3aa62c8adcd7c4e123ec4c6dc#95d6a559890c94e3aa62c8adcd7c4e123ec4c6dc"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -322,7 +333,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
+source = "git+https://github.com/oxidecomputer/propolis?rev=95d6a559890c94e3aa62c8adcd7c4e123ec4c6dc#95d6a559890c94e3aa62c8adcd7c4e123ec4c6dc"
 dependencies = [
  "libc",
  "strum",
@@ -527,7 +538,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -538,7 +549,7 @@ dependencies = [
  "derive_more",
  "expectorate",
  "itertools 0.13.0",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -575,7 +586,7 @@ source = "git+https://github.com/oxidecomputer/dendrite?branch=main#18ed558cc962
 dependencies = [
  "anyhow",
  "chrono",
- "oximeter",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "schemars",
@@ -733,7 +744,7 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
+source = "git+https://github.com/oxidecomputer/crucible?rev=d2d8f8ad449df7e2befb7ee2723a442dd74b9b72#d2d8f8ad449df7e2befb7ee2723a442dd74b9b72"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -853,10 +864,10 @@ dependencies = [
  "ispf",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "mg-common",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
  "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "oximeter",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "oximeter-producer",
  "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions",
@@ -933,6 +944,7 @@ dependencies = [
  "hostname 0.3.1",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "mg-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -1528,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2096,7 +2108,7 @@ source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2113,8 +2125,8 @@ dependencies = [
  "itertools 0.13.0",
  "libc",
  "macaddr",
- "omicron-common",
- "omicron-uuid-kinds",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
  "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
@@ -2221,12 +2233,12 @@ dependencies = [
 [[package]]
 name = "internal-dns-resolver"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "futures",
  "hickory-resolver",
  "internal-dns-types",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "qorb",
  "reqwest 0.12.9",
@@ -2237,12 +2249,12 @@ dependencies = [
 [[package]]
 name = "internal-dns-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
  "chrono",
- "omicron-common",
- "omicron-uuid-kinds",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -2653,9 +2665,10 @@ dependencies = [
  "anyhow",
  "backoff",
  "clap",
+ "dpd-client",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
- "omicron-common",
- "oximeter",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "oximeter-producer",
  "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
@@ -2760,13 +2773,14 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "dpd-client",
  "dropshot 0.12.0",
  "hostname 0.3.1",
  "http 1.2.0",
  "mg-common",
  "mg-lower",
- "omicron-common",
- "oximeter",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "oximeter-producer",
  "rand",
  "rdb",
@@ -2880,15 +2894,15 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "chrono",
  "futures",
  "nexus-sled-agent-shared",
  "nexus-types",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-passwords",
- "omicron-uuid-kinds",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
  "progenitor 0.9.1",
@@ -2904,13 +2918,13 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "daft",
  "illumos-utils",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-passwords",
- "omicron-uuid-kinds",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -2924,10 +2938,10 @@ dependencies = [
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
- "api_identity",
+ "api_identity 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -2948,9 +2962,9 @@ dependencies = [
  "newtype-uuid",
  "newtype_derive",
  "nexus-sled-agent-shared",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-passwords",
- "omicron-uuid-kinds",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "openssl",
  "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
@@ -3165,7 +3179,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
- "api_identity",
+ "api_identity 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "async-trait",
  "backoff",
  "camino",
@@ -3178,7 +3192,49 @@ dependencies = [
  "ipnetwork",
  "macaddr",
  "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=93cd0d642cf1b58f9f4528275e2a2aa758e9feb3)",
- "omicron-uuid-kinds",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "omicron-workspace-hack",
+ "once_cell",
+ "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
+ "parse-display",
+ "progenitor-client 0.9.1",
+ "rand",
+ "regress 0.9.1",
+ "reqwest 0.12.9",
+ "schemars",
+ "semver 1.0.25",
+ "serde",
+ "serde_human_bytes",
+ "serde_json",
+ "serde_with",
+ "slog",
+ "slog-error-chain",
+ "strum",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "omicron-common"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "anyhow",
+ "api_identity 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "async-trait",
+ "backoff",
+ "camino",
+ "chrono",
+ "daft",
+ "dropshot 0.15.1",
+ "futures",
+ "hex",
+ "http 1.2.0",
+ "ipnetwork",
+ "macaddr",
+ "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=93cd0d642cf1b58f9f4528275e2a2aa758e9feb3)",
+ "omicron-uuid-kinds 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "once_cell",
  "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
@@ -3204,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3219,6 +3275,17 @@ dependencies = [
 name = "omicron-uuid-kinds"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+dependencies = [
+ "daft",
+ "newtype-uuid",
+ "paste",
+ "schemars",
+]
+
+[[package]]
+name = "omicron-uuid-kinds"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "daft",
  "newtype-uuid",
@@ -3463,10 +3530,29 @@ dependencies = [
  "chrono",
  "clap",
  "omicron-workspace-hack",
- "oximeter-macro-impl",
- "oximeter-schema",
- "oximeter-timeseries-macro",
- "oximeter-types",
+ "oximeter-macro-impl 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-schema 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-timeseries-macro 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "prettyplease",
+ "syn 2.0.98",
+ "toml 0.8.19",
+ "uuid",
+]
+
+[[package]]
+name = "oximeter"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "omicron-workspace-hack",
+ "oximeter-macro-impl 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "oximeter-schema 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "oximeter-timeseries-macro 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "prettyplease",
  "syn 2.0.98",
  "toml 0.8.19",
@@ -3485,18 +3571,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "oximeter-macro-impl"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "omicron-workspace-hack",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "chrono",
  "dropshot 0.15.1",
  "internal-dns-resolver",
  "internal-dns-types",
  "nexus-client",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
- "oximeter",
+ "oximeter 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "schemars",
  "serde",
  "slog",
@@ -3516,7 +3613,28 @@ dependencies = [
  "clap",
  "heck 0.5.0",
  "omicron-workspace-hack",
- "oximeter-types",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "serde",
+ "slog-error-chain",
+ "syn 2.0.98",
+ "toml 0.8.19",
+]
+
+[[package]]
+name = "oximeter-schema"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "heck 0.5.0",
+ "omicron-workspace-hack",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -3533,8 +3651,21 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "omicron-workspace-hack",
- "oximeter-schema",
- "oximeter-types",
+ "oximeter-schema 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "oximeter-timeseries-macro"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "omicron-workspace-hack",
+ "oximeter-schema 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -3549,7 +3680,27 @@ dependencies = [
  "chrono",
  "float-ord",
  "num",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "omicron-workspace-hack",
+ "parse-display",
+ "regex",
+ "schemars",
+ "serde",
+ "strum",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "oximeter-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
+dependencies = [
+ "bytes",
+ "chrono",
+ "float-ord",
+ "num",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "parse-display",
  "regex",
@@ -3563,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
  "camino",
@@ -3599,14 +3750,14 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
  "chrono",
  "highway",
  "num",
  "omicron-workspace-hack",
- "oximeter-types",
+ "oximeter-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "schemars",
  "serde",
 ]
@@ -5052,10 +5203,10 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "illumos-utils",
- "omicron-common",
+ "omicron-common 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta)",
  "omicron-workspace-hack",
  "schemars",
  "serde",
@@ -6112,7 +6263,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "update-engine"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl%2Fmgd-ddm-meta#a68d462d189a3dce27231a88bd140b959fe693e4"
 dependencies = [
  "anyhow",
  "cancel-safe-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,10 @@ rand = "0.8.5"
 backoff = "0.4"
 mg-common = { path = "mg-common" }
 chrono = { version = "0.4.38", features = ["serde"] }
-oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
-oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
+oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/mgd-ddm-meta"}
+oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/mgd-ddm-meta"}
 oxnet = { version = "0.1.0", default-features = false, features = ["schemars", "serde"] }
-omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
+omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/mgd-ddm-meta"}
 uuid = { version = "1.8", features = ["serde", "v4"] }
 smf = { git = "https://github.com/illumos/smf-rs", branch = "main" }
 libc = "0.2"

--- a/ddm/src/admin.rs
+++ b/ddm/src/admin.rs
@@ -19,6 +19,7 @@ use dropshot::TypedBody;
 use dropshot::{endpoint, ApiDescriptionRegisterError};
 use mg_common::lock;
 use mg_common::net::TunnelOrigin;
+use omicron_common::api::internal::shared::SledIdentifiers;
 use oxnet::Ipv6Net;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -369,14 +370,20 @@ async fn enable_stats(
             .expect("failed to get hostname")
             .to_string_lossy()
             .to_string();
+        let sled_idents = SledIdentifiers {
+            rack_id: rq.rack_id,
+            sled_id: rq.sled_id,
+            model: String::default(),
+            revision: 0,
+            serial: String::default(),
+        };
         *jh = Some(
             crate::oxstats::start_server(
                 DDM_STATS_PORT,
                 ctx.peers.clone(),
                 ctx.stats.clone(),
                 hostname,
-                rq.rack_id,
-                rq.sled_id,
+                sled_idents,
                 ctx.log.clone(),
             )
             .map_err(|e| {

--- a/ddmd/Cargo.toml
+++ b/ddmd/Cargo.toml
@@ -15,6 +15,7 @@ slog-async.workspace = true
 tokio.workspace = true
 hostname.workspace = true
 dpd-client.workspace = true
+omicron-common.workspace = true
 anstyle.workspace = true
 uuid.workspace = true
 smf.workspace = true

--- a/ddmd/src/smf.rs
+++ b/ddmd/src/smf.rs
@@ -69,8 +69,7 @@ fn refresh_stats_server(
             context.peers.clone(),
             context.stats.clone(),
             hostname,
-            props.rack_uuid,
-            props.sled_uuid,
+            props.sled_idents,
             log.clone(),
         ) {
             Ok(h) => {

--- a/mg-common/Cargo.toml
+++ b/mg-common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap.workspace = true
 anyhow.workspace = true
 anstyle.workspace = true
+dpd-client.workspace = true
 serde.workspace = true
 schemars.workspace = true
 thiserror.workspace = true

--- a/mg-common/src/dpd.rs
+++ b/mg-common/src/dpd.rs
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use dpd_client::{types, Client, ClientState};
+use std::time::Duration;
+
+/// Create a new Dendrite/dpd client. The lower half always runs on the same
+/// host/zone as the underlying platform.
+pub fn new_client(log: &slog::Logger, tag: &str) -> Client {
+    let client_state = ClientState {
+        tag: tag.to_string(),
+        log: log.clone(),
+    };
+    Client::new(
+        &format!("http://localhost:{}", dpd_client::default_port()),
+        client_state,
+    )
+}
+
+/// Fetches the switch identifiers from the dpd client (API) in
+/// relation to stats.
+///
+/// This spins indefinitely until the information is extracted.
+pub async fn fetch_switch_identifiers(
+    client: &Client,
+    log: &slog::Logger,
+) -> types::SwitchIdentifiers {
+    loop {
+        match client.switch_identifiers().await {
+            Ok(resp) => {
+                let idents = resp.into_inner();
+                return idents;
+            }
+            Err(e) => {
+                slog::error!(log,
+                    "failed to fetch switch identifiers from dpd-client: {e:?}, will retry",
+                )
+            }
+        }
+        // Poll after a delay of 1 second
+        const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
+}

--- a/mg-common/src/dpd.rs
+++ b/mg-common/src/dpd.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use dpd_client::{types, Client, ClientState};
+use slog::error;
 use std::time::Duration;
 
 /// Create a new Dendrite/dpd client. The lower half always runs on the same
@@ -33,7 +34,7 @@ pub async fn fetch_switch_identifiers(
                 return idents;
             }
             Err(e) => {
-                slog::error!(log,
+                error!(log,
                     "failed to fetch switch identifiers from dpd-client: {e:?}, will retry",
                 )
             }

--- a/mg-common/src/lib.rs
+++ b/mg-common/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 pub mod cli;
+pub mod dpd;
 pub mod log;
 pub mod net;
 pub mod nexus;

--- a/mg-common/src/smf.rs
+++ b/mg-common/src/smf.rs
@@ -5,8 +5,8 @@
 use std::net::IpAddr;
 
 use anyhow::anyhow;
+use omicron_common::api::internal::shared::SledIdentifiers;
 use smf::PropertyGroup;
-use uuid::Uuid;
 
 pub fn get_string_prop(
     name: &str,
@@ -62,26 +62,35 @@ pub fn get_string_list_prop(
 
 pub struct StatsServerProps {
     pub admin_addr: IpAddr,
-    pub rack_uuid: Uuid,
-    pub sled_uuid: Uuid,
+    pub sled_idents: SledIdentifiers,
 }
 
 pub fn get_stats_server_props(
     pg: PropertyGroup<'_>,
 ) -> anyhow::Result<StatsServerProps> {
     let admin_addr = get_string_prop("admin_host", &pg)?;
-    let rack_uuid = get_string_prop("rack_uuid", &pg)?;
-    let sled_uuid = get_string_prop("sled_uuid", &pg)?;
+    let rack_id = get_string_prop("rack_id", &pg)?;
+    let sled_id = get_string_prop("sled_id", &pg)?;
+    let sled_model = get_string_prop("sled_model", &pg)?;
+    let sled_revision = get_string_prop("sled_revision", &pg)?;
+    let sled_serial = get_string_prop("sled_serial", &pg)?;
 
     Ok(StatsServerProps {
         admin_addr: admin_addr
             .parse()
             .map_err(|e| anyhow!("parse admin addr: {e}"))?,
-        rack_uuid: rack_uuid
-            .parse()
-            .map_err(|e| anyhow!("parse rack uuid {rack_uuid}: {e}"))?,
-        sled_uuid: sled_uuid
-            .parse()
-            .map_err(|e| anyhow!("parse rack uuid {rack_uuid}: {e}"))?,
+        sled_idents: SledIdentifiers {
+            rack_id: rack_id
+                .parse()
+                .map_err(|e| anyhow!("parse rack id {rack_id}: {e}"))?,
+            sled_id: sled_id
+                .parse()
+                .map_err(|e| anyhow!("parse sled id {sled_id}: {e}"))?,
+            model: sled_model,
+            revision: sled_revision.parse().map_err(|e| {
+                anyhow!("parse sled revision {sled_revision}: {e}")
+            })?,
+            serial: sled_serial,
+        },
     })
 }

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -453,16 +453,3 @@ pub(crate) fn get_routes_for_prefix(
     };
     Ok(result)
 }
-
-/// Create a new Dendrite/dpd client. The lower half always runs on the same
-/// host/zone as the underlying platform.
-pub(crate) fn new_dpd_client(log: &Logger) -> DpdClient {
-    let client_state = dpd_client::ClientState {
-        tag: MG_LOWER_TAG.into(),
-        log: log.clone(),
-    };
-    DpdClient::new(
-        &format!("http://localhost:{}", dpd_client::default_port()),
-        client_state,
-    )
-}

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -6,9 +6,7 @@
 //! synchronizing information in a routing information base onto an underlying
 //! routing platform. The only platform currently supported is Dendrite.
 
-use crate::dendrite::{
-    get_routes_for_prefix, new_dpd_client, update_dendrite, RouteHash,
-};
+use crate::dendrite::{get_routes_for_prefix, update_dendrite, RouteHash};
 use crate::error::Error;
 use ddm::{
     add_tunnel_routes, new_ddm_client, remove_tunnel_routes,
@@ -57,7 +55,7 @@ pub fn run(
         db.watch(MG_LOWER_TAG.into(), tx);
 
         // initialize the underlying router with the current state
-        let dpd = new_dpd_client(&log);
+        let dpd = mg_common::dpd::new_client(&log, MG_LOWER_TAG);
         let ddm = new_ddm_client(&log);
         if let Err(e) =
             full_sync(tep, &db, &log, &dpd, &ddm, &stats, rt.clone())

--- a/mgd/Cargo.toml
+++ b/mgd/Cargo.toml
@@ -12,6 +12,7 @@ rdb = { path = "../rdb" }
 anyhow.workspace = true
 clap.workspace = true
 colored.workspace = true
+dpd-client.workspace = true
 dropshot.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/mgd/src/smf.rs
+++ b/mgd/src/smf.rs
@@ -52,22 +52,21 @@ fn refresh_stats_server(
         .to_string_lossy()
         .to_string();
 
-    let props = match get_stats_server_props(pg) {
-        Ok(props) => props,
-        Err(e) => {
-            info!(log, "stats server not running on refresh: {e}");
-            return Ok(());
-        }
-    };
-
     let mut is_running = lock!(ctx.stats_server_running);
     if !*is_running {
+        let props = match get_stats_server_props(pg) {
+            Ok(props) => props,
+            Err(e) => {
+                info!(log, "stats server not running on refresh: {e}");
+                return Ok(());
+            }
+        };
+
         info!(log, "starting stats server on smf refresh");
         match crate::oxstats::start_server(
             ctx.clone(),
             hostname,
-            props.rack_uuid,
-            props.sled_uuid,
+            props.sled_idents,
             log.clone(),
         ) {
             Ok(_) => {

--- a/smf/ddm/manifest.xml
+++ b/smf/ddm/manifest.xml
@@ -27,8 +27,11 @@
      <propval name='dpd_port' type='astring' value='' />
      <propval name='log' type='astring' value='info' />
      <propval name='dns_servers' type='astring' value='unknown' />
-     <propval name='rack_uuid' type='astring' value='unknown' />
-     <propval name='sled_uuid' type='astring' value='unknown' />
+     <propval name='rack_id' type='astring' value='unknown' />
+     <propval name='sled_id' type='astring' value='unknown' />
+     <propval name='sled_model' type='astring' value='unknown' />
+     <propval name='sled_revision' type='astring' value='unknown' />
+     <propval name='sled_serial' type='astring' value='unknown' />
      <property name='interfaces' type='astring'>
      </property>
    </property_group>

--- a/smf/ddm_method_script.sh
+++ b/smf/ddm_method_script.sh
@@ -34,15 +34,15 @@ if [[ "$val" != '""' ]]; then
     export RUST_LOG="$val"
 fi
 
-val=$(svcprop -c -p config/rack_uuid "${SMF_FMRI}")
+val=$(svcprop -c -p config/rack_id "${SMF_FMRI}")
 if [[ "$val" != 'unknown' ]]; then
-    args+=( '--rack-uuid' )
+    args+=( '--rack-id' )
     args+=( "$val" )
 fi
 
-val=$(svcprop -c -p config/sled_uuid "${SMF_FMRI}")
+val=$(svcprop -c -p config/sled_id "${SMF_FMRI}")
 if [[ "$val" != 'unknown' ]]; then
-    args+=( '--sled-uuid' )
+    args+=( '--sled-id' )
     args+=( "$val" )
 fi
 

--- a/smf/mgd/manifest.xml
+++ b/smf/mgd/manifest.xml
@@ -22,8 +22,11 @@
      <propval name='admin_host' type='astring' value='::' />
      <propval name='admin_port' type='count' value='4676' />
      <propval name='dns_servers' type='astring' value='unknown' />
-     <propval name='rack_uuid' type='astring' value='unknown' />
-     <propval name='sled_uuid' type='astring' value='unknown' />
+     <propval name='rack_id' type='astring' value='unknown' />
+     <propval name='sled_id' type='astring' value='unknown' />
+     <propval name='sled_model' type='astring' value='unknown' />
+     <propval name='sled_revision' type='astring' value='unknown' />
+     <propval name='sled_serial' type='astring' value='unknown' />
    </property_group>
 
   <property_group name='startd' type='framework'>

--- a/smf/mgd_method_script.sh
+++ b/smf/mgd_method_script.sh
@@ -10,15 +10,15 @@ args=(
     --admin-addr "$(svcprop -c -p config/admin_host "${SMF_FMRI}")"
 )
 
-val=$(svcprop -c -p config/rack_uuid "${SMF_FMRI}")
+val=$(svcprop -c -p config/rack_id "${SMF_FMRI}")
 if [[ "$val" != 'unknown' ]]; then
-    args+=( '--rack-uuid' )
+    args+=( '--rack-id' )
     args+=( "$val" )
 fi
 
-val=$(svcprop -c -p config/sled_uuid "${SMF_FMRI}")
+val=$(svcprop -c -p config/sled_id "${SMF_FMRI}")
 if [[ "$val" != 'unknown' ]]; then
-    args+=( '--sled-uuid' )
+    args+=( '--sled-id' )
     args+=( "$val" )
 fi
 

--- a/tests/src/ddm.rs
+++ b/tests/src/ddm.rs
@@ -172,7 +172,7 @@ impl<'a> RouterZone<'a> {
             String::new()
         } else {
             format!(
-                "--rack-uuid {} --sled-uuid {}",
+                "--rack-id {} --sled-id {}",
                 uuid::Uuid::new_v4(),
                 uuid::Uuid::new_v4(),
             )


### PR DESCRIPTION
Add additional switch and sled metadata to bfd/bgp/routing/ddm timeseries. 

Related:

- https://github.com/oxidecomputer/dendrite/pull/1033
- https://github.com/oxidecomputer/omicron/pull/6955