### PR TITLE
bgp: don't call send_all() upon single peer events

### DIFF
--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -1259,7 +1259,6 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             for p in originated {
                 update.nlri.push(p.into());
             }
-            read_lock!(self.fanout).send_all(&update);
             if let Err(e) =
                 self.send_update(update, &pc.conn, ShaperApplication::Current)
             {
@@ -2019,7 +2018,6 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             for p in originated {
                 update.nlri.push(p.into());
             }
-            read_lock!(self.fanout).send_all(&update);
             self.send_update(update, &pc.conn, ShaperApplication::Current)?;
         }
         Ok(())


### PR DESCRIPTION
Both session_setup() and handle_refresh() are methods that are specific to a single peer.  These should not be calling send_all(), since that results in an update being sent to all peers (including the one we're already about to call send_update() for).

Fixes: #403