### PR TITLE
[ddm-admin] Remove now-unused parameters when starting Oximeter server

### DIFF
--- a/ddm/src/admin.rs
+++ b/ddm/src/admin.rs
@@ -347,8 +347,6 @@ async fn sync(
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct EnableStatsRequest {
-    addr: IpAddr,
-    dns_servers: Vec<SocketAddr>,
     sled_id: Uuid,
     rack_id: Uuid,
 }

--- a/openapi/ddm-admin.json
+++ b/openapi/ddm-admin.json
@@ -358,16 +358,6 @@
       "EnableStatsRequest": {
         "type": "object",
         "properties": {
-          "addr": {
-            "type": "string",
-            "format": "ip"
-          },
-          "dns_servers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "rack_id": {
             "type": "string",
             "format": "uuid"
@@ -378,8 +368,6 @@
           }
         },
         "required": [
-          "addr",
-          "dns_servers",
           "rack_id",
           "sled_id"
         ]


### PR DESCRIPTION
Small housekeeping PR: I was doing some unrelated work in sled-agent and noticed these two parameters are no longer needed to start the Oximeter server, so I think we can safely drop them. This should be backwards-compatible, since an old client sending these params is fine (we'll just ignore them), and we only receive these, never send them.