### PR TITLE
update oxnet, omicron, dendrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -119,12 +119,12 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -159,9 +159,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -170,24 +170,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
  "rand",
@@ -296,7 +296,7 @@ dependencies = [
  "mg-common",
  "nom",
  "num_enum 0.7.3",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty-hex 0.4.1",
  "pretty_assertions",
  "rdb",
@@ -306,13 +306,13 @@ dependencies = [
  "sled",
  "slog",
  "socket2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4ba9c33817c89d5d48b96e037a64421fb7a026e2#4ba9c33817c89d5d48b96e037a64421fb7a026e2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=4ba9c33817c89d5d48b96e037a64421fb7a026e2#4ba9c33817c89d5d48b96e037a64421fb7a026e2"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "libc",
  "strum",
@@ -387,9 +387,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 dependencies = [
  "serde",
 ]
@@ -515,7 +515,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -527,12 +527,14 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "atomicwrites",
  "camino",
  "camino-tempfile",
+ "chrono",
+ "daft",
  "derive_more",
  "expectorate",
  "itertools 0.13.0",
@@ -569,12 +571,12 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite?branch=main#4cdc7d7e18a25833843686d76b95a9ca4a5dfab0"
+source = "git+https://github.com/oxidecomputer/dendrite?branch=main#18ed558cc9627baa7cb16e649d2f7a8107688dc8"
 dependencies = [
  "anyhow",
  "chrono",
  "oximeter",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "schemars",
  "serde",
@@ -583,7 +585,8 @@ dependencies = [
  "slog-async",
  "slog-bunyan",
  "slog-term",
- "thiserror",
+ "smf 0.10.0 (git+https://github.com/illumos/smf-rs)",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -615,7 +618,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -674,7 +677,7 @@ source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e8647943
 dependencies = [
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.7.8",
 ]
 
@@ -730,13 +733,13 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=74286f952a2953cd08512015076f0947050deba7#74286f952a2953cd08512015076f0947050deba7"
+source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
  "num-derive 0.4.2",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -772,6 +775,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "daft"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/daft?branch=main#9e7b55349f61bded974cba9c1727a70a62586a37"
+dependencies = [
+ "daft-derive",
+ "newtype-uuid",
+ "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
+ "paste",
+ "uuid",
+]
+
+[[package]]
+name = "daft-derive"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/daft?branch=main#9e7b55349f61bded974cba9c1727a70a62586a37"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,7 +817,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -803,7 +828,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -820,7 +845,7 @@ dependencies = [
  "chrono",
  "common",
  "dpd-client",
- "dropshot",
+ "dropshot 0.12.0",
  "hostname 0.3.1",
  "http-body-util",
  "hyper 1.5.1",
@@ -833,7 +858,7 @@ dependencies = [
  "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
  "oximeter",
  "oximeter-producer",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions",
  "reqwest 0.12.9",
  "schemars",
@@ -843,7 +868,7 @@ dependencies = [
  "sled",
  "slog",
  "socket2",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -852,7 +877,7 @@ dependencies = [
 name = "ddm-admin-client"
 version = "0.1.0"
 dependencies = [
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding",
  "progenitor 0.8.0",
  "reqwest 0.12.9",
@@ -887,7 +912,7 @@ dependencies = [
  "ddm",
  "ddm-admin-client 0.1.0",
  "mg-common",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -911,7 +936,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-bunyan",
- "smf 0.10.0",
+ "smf 0.10.0 (git+https://github.com/illumos/smf-rs?branch=main)",
  "tokio",
  "uuid",
 ]
@@ -942,7 +967,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -951,7 +976,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -972,7 +997,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -985,7 +1010,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1035,25 +1060,8 @@ dependencies = [
  "libdlpi-sys",
  "num_enum 0.5.11",
  "pretty-hex 0.2.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
-]
-
-[[package]]
-name = "dns-service-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
-dependencies = [
- "anyhow",
- "chrono",
- "expectorate",
- "http 1.2.0",
- "omicron-workspace-hack",
- "progenitor 0.8.0",
- "reqwest 0.12.9",
- "schemars",
- "serde",
- "slog",
 ]
 
 [[package]]
@@ -1066,14 +1074,14 @@ dependencies = [
  "pretty-hex 0.4.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "dpd-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite?branch=main#4cdc7d7e18a25833843686d76b95a9ca4a5dfab0"
+source = "git+https://github.com/oxidecomputer/dendrite?branch=main#18ed558cc9627baa7cb16e649d2f7a8107688dc8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,15 +1089,16 @@ dependencies = [
  "crc8",
  "futures",
  "http 1.2.0",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "progenitor 0.8.0",
- "regress 0.9.1",
+ "regress 0.10.1",
  "reqwest 0.12.9",
  "schemars",
  "serde",
  "serde_json",
  "slog",
  "tokio",
+ "transceiver-decode",
  "uuid",
 ]
 
@@ -1106,7 +1115,7 @@ dependencies = [
  "camino",
  "chrono",
  "debug-ignore",
- "dropshot_endpoint",
+ "dropshot_endpoint 0.12.0",
  "form_urlencoded",
  "futures",
  "hostname 0.4.0",
@@ -1114,7 +1123,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.1",
  "hyper-util",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "multer",
  "openapiv3",
  "paste",
@@ -1143,6 +1152,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "dropshot"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84e9c34a06ac21fefe60cf9e5cc321eac9f3d3e2d693e030da3709cf4275479"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "camino",
+ "chrono",
+ "debug-ignore",
+ "dropshot_endpoint 0.15.1",
+ "form_urlencoded",
+ "futures",
+ "hostname 0.4.0",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "indexmap 2.7.1",
+ "multer",
+ "openapiv3",
+ "paste",
+ "percent-encoding",
+ "rustls 0.22.4",
+ "rustls-pemfile 2.1.3",
+ "schemars",
+ "scopeguard",
+ "semver 1.0.25",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "slog",
+ "slog-async",
+ "slog-bunyan",
+ "slog-json",
+ "slog-term",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "toml 0.8.19",
+ "usdt",
+ "uuid",
+ "version_check",
+ "waitgroup",
+]
+
+[[package]]
 name = "dropshot_endpoint"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,7 +1213,22 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream",
- "syn 2.0.87",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "dropshot_endpoint"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4c7e4e96bfedd670ecbaffc1848ab28dd5892b214003517d9667e7a5b465ce"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "semver 1.0.25",
+ "serde",
+ "serde_tokenstream",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1164,7 +1239,7 @@ checksum = "71734e3eb68cd4df338d04dffdcc024f89eb0b238150cc95b826fbfad756452b"
 dependencies = [
  "pest",
  "pest_derive",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1215,7 +1290,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1318,7 +1393,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1354,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1369,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1379,15 +1454,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1396,38 +1471,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1453,13 +1528,13 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "gateway-messages",
  "omicron-workspace-hack",
- "progenitor 0.8.0",
+ "progenitor 0.9.1",
  "rand",
  "reqwest 0.12.9",
  "schemars",
@@ -1503,7 +1578,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1535,7 +1622,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1554,7 +1641,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1595,6 +1682,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heapless"
@@ -1665,7 +1758,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1674,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "dcf287bde7b776e85d7188e6e5db7cf410a2f9531fe82817eb87feed034c8d14"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1688,7 +1781,7 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -1998,12 +2091,12 @@ source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653#76878de67229ea113d70503c441eab47ac5dc653"
+source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e#b56afeeb14e0042cbd7bda85b166ed86ee17820e"
 
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2013,22 +2106,26 @@ dependencies = [
  "camino-tempfile",
  "cfg-if",
  "crucible-smf",
+ "dropshot 0.15.1",
  "futures",
+ "http 1.2.0",
  "ipnetwork",
+ "itertools 0.13.0",
  "libc",
  "macaddr",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
+ "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
  "oxlog",
- "oxnet",
+ "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
  "schemars",
  "serde",
  "slog",
+ "slog-error-chain",
  "smf 0.2.3",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
  "whoami",
@@ -2054,12 +2151,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -2077,6 +2174,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ingot"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
+dependencies = [
+ "bitflags 2.6.0",
+ "ingot-macros",
+ "ingot-types",
+ "macaddr",
+ "serde",
+ "zerocopy 0.8.17",
+]
+
+[[package]]
+name = "ingot-macros"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
+dependencies = [
+ "darling",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "ingot-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
+dependencies = [
+ "ingot-macros",
+ "macaddr",
+ "zerocopy 0.8.17",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,23 +2219,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "internal-dns"
+name = "internal-dns-resolver"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
+dependencies = [
+ "futures",
+ "hickory-resolver",
+ "internal-dns-types",
+ "omicron-common",
+ "omicron-workspace-hack",
+ "qorb",
+ "reqwest 0.12.9",
+ "slog",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "internal-dns-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "chrono",
- "dns-service-client",
- "futures",
- "hickory-resolver",
- "hyper 1.5.1",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "reqwest 0.12.9",
- "slog",
- "thiserror",
- "uuid",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -2206,16 +2349,16 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653#76878de67229ea113d70503c441eab47ac5dc653"
+source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e#b56afeeb14e0042cbd7bda85b166ed86ee17820e"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2235,9 +2378,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libdlpi-sys"
@@ -2247,7 +2390,7 @@ source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0
 [[package]]
 name = "libfalcon"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/falcon?branch=main#d8c38f890040f90cdc467e23f3f06b6372a9921c"
+source = "git+https://github.com/oxidecomputer/falcon?branch=main#f3fe0542198c08bbb82d16f168e6482db9bec5b9"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2271,7 +2414,7 @@ dependencies = [
  "slog-term",
  "smf 0.2.3",
  "tabwriter",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "toml 0.7.8",
@@ -2289,7 +2432,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "libnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#e07ad76458eb50601e0da4f9da16dbc942bfc2ba"
+source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#f4eae3d8070760922da93b9edd56ca4103b4c390"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2299,11 +2442,11 @@ dependencies = [
  "num_enum 0.5.11",
  "nvpair",
  "nvpair-sys",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "rusty-doors",
  "socket2",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "winnow 0.6.18",
 ]
@@ -2311,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "libnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys#e07ad76458eb50601e0da4f9da16dbc942bfc2ba"
+source = "git+https://github.com/oxidecomputer/netadm-sys#f4eae3d8070760922da93b9edd56ca4103b4c390"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2321,11 +2464,11 @@ dependencies = [
  "num_enum 0.5.11",
  "nvpair",
  "nvpair-sys",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "rusty-doors",
  "socket2",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "winnow 0.6.18",
 ]
@@ -2345,6 +2488,17 @@ dependencies = [
 name = "libscf-sys"
 version = "1.0.0"
 source = "git+https://github.com/illumos/libscf-sys.git#bb0b82c32cff5eee65efc4f214924c3daf7edc93"
+dependencies = [
+ "libc",
+ "num-derive 0.3.3",
+ "num-traits",
+]
+
+[[package]]
+name = "libscf-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f02d0eda38e8cc453c5ec5d49945545d8d9eb0e59cb2ce4152ba6518f373e7"
 dependencies = [
  "libc",
  "num-derive 0.3.3",
@@ -2478,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "mg-admin-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/maghemite?branch=hyper-v1-no-merge#b13b5b240f3967de753fd589b1036745d2770b52"
+source = "git+https://github.com/oxidecomputer/maghemite?rev=93cd0d642cf1b58f9f4528275e2a2aa758e9feb3#93cd0d642cf1b58f9f4528275e2a2aa758e9feb3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2499,19 +2653,18 @@ dependencies = [
  "anyhow",
  "backoff",
  "clap",
- "internal-dns",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "omicron-common",
  "oximeter",
  "oximeter-producer",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "serde",
  "slog",
  "slog-async",
  "slog-bunyan",
- "smf 0.10.0",
- "thiserror",
+ "smf 0.10.0 (git+https://github.com/illumos/smf-rs?branch=main)",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -2538,11 +2691,11 @@ dependencies = [
  "http 1.2.0",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
  "mg-common",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdb",
  "reqwest 0.12.9",
  "slog",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -2593,7 +2746,7 @@ dependencies = [
  "slog-envlogger",
  "slog-term",
  "tabwriter",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -2607,7 +2760,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
- "dropshot",
+ "dropshot 0.12.0",
  "hostname 0.3.1",
  "http 1.2.0",
  "mg-common",
@@ -2622,8 +2775,8 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
- "smf 0.10.0",
- "thiserror",
+ "smf 0.10.0 (git+https://github.com/illumos/smf-rs?branch=main)",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -2657,7 +2810,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2706,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "newtype-uuid"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526cb7c660872e401beaf3297f95f548ce3b4b4bdd8121b7c0713771d7c4a6e"
+checksum = "ee3224f0e8be7c2a1ebc77ef9c3eecb90f55c6594399ee825de964526b3c9056"
 dependencies = [
  "schemars",
  "serde",
@@ -2727,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "chrono",
  "futures",
@@ -2737,8 +2890,8 @@ dependencies = [
  "omicron-passwords",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "oxnet",
- "progenitor 0.8.0",
+ "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
+ "progenitor 0.9.1",
  "regress 0.9.1",
  "reqwest 0.12.9",
  "schemars",
@@ -2751,8 +2904,9 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
+ "daft",
  "illumos-utils",
  "omicron-common",
  "omicron-passwords",
@@ -2763,14 +2917,14 @@ dependencies = [
  "serde_json",
  "sled-hardware-types",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -2780,14 +2934,16 @@ dependencies = [
  "clap",
  "clickhouse-admin-types",
  "cookie",
+ "daft",
  "derive-where",
  "derive_more",
- "dns-service-client",
- "dropshot",
+ "dropshot 0.15.1",
  "futures",
  "gateway-client",
  "http 1.2.0",
  "humantime",
+ "illumos-utils",
+ "internal-dns-types",
  "ipnetwork",
  "newtype-uuid",
  "newtype_derive",
@@ -2797,7 +2953,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "openssl",
- "oxnet",
+ "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
  "oxql-types",
  "parse-display",
  "schemars",
@@ -2808,7 +2964,7 @@ dependencies = [
  "slog-error-chain",
  "steno",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "update-engine",
  "uuid",
 ]
@@ -2879,7 +3035,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2961,7 +3117,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3006,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3014,25 +3170,25 @@ dependencies = [
  "backoff",
  "camino",
  "chrono",
- "dropshot",
+ "daft",
+ "dropshot 0.15.1",
  "futures",
  "hex",
  "http 1.2.0",
  "ipnetwork",
  "macaddr",
- "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?branch=hyper-v1-no-merge)",
+ "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=93cd0d642cf1b58f9f4528275e2a2aa758e9feb3)",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "once_cell",
- "oxnet",
+ "oxnet 0.1.0 (git+https://www.github.com/oxidecomputer/oxnet?rev=7dacd265f1bcd0f8b47bd4805250c4f0812da206)",
  "parse-display",
- "progenitor 0.8.0",
- "progenitor-client 0.8.0",
+ "progenitor-client 0.9.1",
  "rand",
  "regress 0.9.1",
  "reqwest 0.12.9",
  "schemars",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_human_bytes",
  "serde_json",
@@ -3040,7 +3196,7 @@ dependencies = [
  "slog",
  "slog-error-chain",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -3048,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3056,14 +3212,15 @@ dependencies = [
  "schemars",
  "serde",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
+ "daft",
  "newtype-uuid",
  "paste",
  "schemars",
@@ -3094,13 +3251,13 @@ dependencies = [
  "hex",
  "reqwest 0.12.9",
  "ring 0.16.20",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
  "serde_json",
  "slog",
  "tar",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml 0.7.8",
  "topological-sort",
@@ -3122,7 +3279,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_json",
 ]
@@ -3150,7 +3307,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3191,13 +3348,15 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653#76878de67229ea113d70503c441eab47ac5dc653"
+source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e#b56afeeb14e0042cbd7bda85b166ed86ee17820e"
 dependencies = [
+ "bitflags 2.6.0",
  "cfg-if",
  "dyn-clone",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
- "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
- "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
+ "ingot",
+ "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
+ "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
  "postcard",
  "serde",
  "smoltcp",
@@ -3220,9 +3379,10 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653#76878de67229ea113d70503c441eab47ac5dc653"
+source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e#b56afeeb14e0042cbd7bda85b166ed86ee17820e"
 dependencies = [
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
+ "ingot",
  "ipnetwork",
  "postcard",
  "serde",
@@ -3240,21 +3400,21 @@ dependencies = [
  "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
  "postcard",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653#76878de67229ea113d70503c441eab47ac5dc653"
+source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e#b56afeeb14e0042cbd7bda85b166ed86ee17820e"
 dependencies = [
  "libc",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
  "postcard",
  "serde",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3281,22 +3441,23 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653#76878de67229ea113d70503c441eab47ac5dc653"
+source = "git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e#b56afeeb14e0042cbd7bda85b166ed86ee17820e"
 dependencies = [
  "cfg-if",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c441eab47ac5dc653)",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=b56afeeb14e0042cbd7bda85b166ed86ee17820e)",
  "poptrie",
  "serde",
  "smoltcp",
  "tabwriter",
- "zerocopy 0.7.35",
+ "uuid",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3307,7 +3468,7 @@ dependencies = [
  "oximeter-timeseries-macro",
  "oximeter-types",
  "prettyplease",
- "syn 2.0.87",
+ "syn 2.0.98",
  "toml 0.8.19",
  "uuid",
 ]
@@ -3315,22 +3476,23 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "chrono",
- "dropshot",
- "internal-dns",
+ "dropshot 0.15.1",
+ "internal-dns-resolver",
+ "internal-dns-types",
  "nexus-client",
  "omicron-common",
  "omicron-workspace-hack",
@@ -3339,7 +3501,7 @@ dependencies = [
  "serde",
  "slog",
  "slog-dtrace",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -3347,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3361,27 +3523,27 @@ dependencies = [
  "schemars",
  "serde",
  "slog-error-chain",
- "syn 2.0.87",
+ "syn 2.0.98",
  "toml 0.8.19",
 ]
 
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
  "oximeter-types",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "bytes",
  "chrono",
@@ -3389,18 +3551,19 @@ dependencies = [
  "num",
  "omicron-common",
  "omicron-workspace-hack",
+ "parse-display",
  "regex",
  "schemars",
  "serde",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "camino",
@@ -3409,6 +3572,17 @@ dependencies = [
  "omicron-workspace-hack",
  "sigpipe",
  "uuid",
+]
+
+[[package]]
+name = "oxnet"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7aba867c36df803039621068faf1630d3039eb999c2f6c3950d1064d4fbbdf"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3425,7 +3599,7 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3507,7 +3681,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3540,7 +3714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -3564,7 +3738,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3585,7 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
 ]
@@ -3676,12 +3850,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3729,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -3755,6 +3929,17 @@ dependencies = [
  "progenitor-client 0.8.0",
  "progenitor-impl 0.8.0",
  "progenitor-macro 0.8.0",
+]
+
+[[package]]
+name = "progenitor"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f54bd2506c3e7b6e45b6ab16500abef551689021264f3be260ef7e295ac327"
+dependencies = [
+ "progenitor-client 0.9.1",
+ "progenitor-impl 0.9.1",
+ "progenitor-macro 0.9.1",
 ]
 
 [[package]]
@@ -3787,13 +3972,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "progenitor-client"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdae8df95f0b2a7d6159a9c43b7380016b8d3b0fc1ece46871ecd2e0087cfaf6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
 name = "progenitor-impl"
 version = "0.7.0"
 source = "git+https://github.com/oxidecomputer/progenitor?branch=main#e0a1045aed55a0db2cd67939252ea354e284d840"
 dependencies = [
  "heck 0.5.0",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -3801,8 +4001,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.87",
- "thiserror",
+ "syn 2.0.98",
+ "thiserror 1.0.69",
  "typify 0.2.0 (git+https://github.com/oxidecomputer/typify)",
  "unicode-ident",
 ]
@@ -3815,7 +4015,7 @@ checksum = "d85934a440963a69f9f04f48507ff6e7aa2952a5b2d8f96cc37fa3dd5c270f66"
 dependencies = [
  "heck 0.5.0",
  "http 1.2.0",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -3823,9 +4023,31 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.87",
- "thiserror",
+ "syn 2.0.98",
+ "thiserror 1.0.69",
  "typify 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-ident",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37adc80a94c9cae890e82deeeecc9d8f2a5cb153256caaf1bf0f03611e537214"
+dependencies = [
+ "heck 0.5.0",
+ "http 1.2.0",
+ "indexmap 2.7.1",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn 2.0.98",
+ "thiserror 2.0.11",
+ "typify 0.3.0",
  "unicode-ident",
 ]
 
@@ -3843,7 +4065,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3861,7 +4083,25 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn 2.0.87",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3b2b9f0d5ba58375c5e8e89d5dff949108e234c1d9f22a3336d2be4daaf292"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl 0.9.1",
+ "quote",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "serde_yaml",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3879,7 +4119,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "uuid",
@@ -3893,8 +4133,29 @@ dependencies = [
  "cpuid_profile_config",
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "qorb"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac55d5c7e6acb2b6b1a248b70d08ed437613eb8c05f833de3a5c9397d368fc71"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "debug-ignore",
+ "derive-where",
+ "futures",
+ "hickory-resolver",
+ "rand",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "usdt",
 ]
 
 [[package]]
@@ -3916,7 +4177,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.13",
  "socket2",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3933,7 +4194,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.13",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tracing",
 ]
@@ -3953,9 +4214,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3987,7 +4248,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -4016,7 +4277,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-bunyan",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4043,16 +4304,16 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4062,9 +4323,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4073,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
@@ -4231,7 +4492,7 @@ checksum = "a5a11a05ee1ce44058fa3d5961d05194fdbe3ad6b40f904af764d81b86450e6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4257,7 +4518,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -4302,7 +4563,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.25",
 ]
 
 [[package]]
@@ -4476,7 +4737,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4502,7 +4763,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4546,18 +4807,18 @@ checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -4573,13 +4834,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4590,7 +4851,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4604,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -4632,7 +4893,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4653,7 +4914,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4670,15 +4931,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4688,14 +4949,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4704,7 +4965,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -4791,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "illumos-utils",
  "omicron-common",
@@ -4875,7 +5136,7 @@ source = "git+https://github.com/oxidecomputer/slog-error-chain?branch=main#15f6
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4952,7 +5213,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a491bfc47dffa70a3c267bc379e9de9f4b0a7195e474a94498189b177f8d18c"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4961,9 +5222,20 @@ version = "0.10.0"
 source = "git+https://github.com/illumos/smf-rs?branch=main#f14ff3517648206baa4b42ef522d2114ed5bcb48"
 dependencies = [
  "libc",
- "libscf-sys",
+ "libscf-sys 1.0.0",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "smf"
+version = "0.10.0"
+source = "git+https://github.com/illumos/smf-rs#72389b5161d2cca1f0e239b337af68bf31f191f4"
+dependencies = [
+ "libc",
+ "libscf-sys 1.1.0",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5031,7 +5303,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -5051,7 +5323,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5062,7 +5334,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5084,7 +5356,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5097,7 +5369,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5125,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5266,7 +5538,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -5277,7 +5558,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5383,7 +5675,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5426,6 +5718,18 @@ dependencies = [
  "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5492,7 +5796,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5505,7 +5809,7 @@ version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5543,7 +5847,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5553,6 +5857,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transceiver-decode"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/transceiver-control#1c8bddede9442db61c30783e89d86aff6d3c9251"
+dependencies = [
+ "schemars",
+ "serde",
+ "static_assertions",
+ "thiserror 2.0.11",
+ "transceiver-messages",
+]
+
+[[package]]
+name = "transceiver-messages"
+version = "0.1.1"
+source = "git+https://github.com/oxidecomputer/transceiver-control#1c8bddede9442db61c30783e89d86aff6d3c9251"
+dependencies = [
+ "bitflags 2.6.0",
+ "clap",
+ "hubpack",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -5575,7 +5903,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -5606,6 +5934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "typify"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03ba3643450cfd95a1aca2e1938fef63c1c1994489337998aff4ad771f21ef8"
+dependencies = [
+ "typify-impl 0.3.0",
+ "typify-macro 0.3.0",
+]
+
+[[package]]
 name = "typify-impl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5617,11 +5955,11 @@ dependencies = [
  "quote",
  "regress 0.10.1",
  "schemars",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_json",
- "syn 2.0.87",
- "thiserror",
+ "syn 2.0.98",
+ "thiserror 1.0.69",
  "unicode-ident",
 ]
 
@@ -5636,11 +5974,31 @@ dependencies = [
  "quote",
  "regress 0.10.1",
  "schemars",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_json",
- "syn 2.0.87",
- "thiserror",
+ "syn 2.0.98",
+ "thiserror 1.0.69",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce48219a2f3154aaa2c56cbf027728b24a3c8fe0a47ed6399781de2b3f3eeaf"
+dependencies = [
+ "heck 0.5.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress 0.10.1",
+ "schemars",
+ "semver 1.0.25",
+ "serde",
+ "serde_json",
+ "syn 2.0.98",
+ "thiserror 2.0.11",
  "unicode-ident",
 ]
 
@@ -5653,11 +6011,11 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.87",
+ "syn 2.0.98",
  "typify-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5669,12 +6027,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.87",
+ "syn 2.0.98",
  "typify-impl 0.2.0 (git+https://github.com/oxidecomputer/typify)",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b5780d745920ed73c5b7447496a9b5c42ed2681a9b70859377aec423ecf02b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver 1.0.25",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.98",
+ "typify-impl 0.3.0",
 ]
 
 [[package]]
@@ -5691,9 +6066,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -5737,7 +6112,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "update-engine"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#48125c8e00738710bde6aed65c253c606c2bdb30"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#78772eaa1d97bd7b6c438d060bd18c9eddcb0c9d"
 dependencies = [
  "anyhow",
  "cancel-safe-futures",
@@ -5747,7 +6122,7 @@ dependencies = [
  "either",
  "futures",
  "indent_write",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "libsw",
  "linear-map",
  "omicron-workspace-hack",
@@ -5801,7 +6176,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.87",
+ "syn 2.0.98",
  "usdt-impl",
 ]
 
@@ -5819,8 +6194,8 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.87",
- "thiserror",
+ "syn 2.0.98",
+ "thiserror 1.0.69",
  "thread-id",
  "version_check",
 ]
@@ -5835,7 +6210,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.87",
+ "syn 2.0.98",
  "usdt-impl",
 ]
 
@@ -5866,11 +6241,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
  "serde",
 ]
 
@@ -5921,6 +6296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5948,7 +6332,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -5982,7 +6366,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6305,6 +6689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6351,6 +6744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
+]
+
+[[package]]
 name = "zerocopy-derive"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6358,7 +6760,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6369,7 +6771,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6385,7 +6798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3596bbc963cd9dbaa69b02e349af4d061c56c41d211ba64150a2cedb2f722707"
 dependencies = [
  "itertools 0.10.5",
- "thiserror",
+ "thiserror 1.0.69",
  "zone_cfg_derive 0.1.2",
 ]
 
@@ -6396,7 +6809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62a428a79ea2224ce8ab05d6d8a21bdd7b4b68a8dbc1230511677a56e72ef22"
 dependencies = [
  "itertools 0.10.5",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "zone_cfg_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6407,7 +6820,7 @@ version = "0.3.0"
 source = "git+https://github.com/oxidecomputer/zone#7a0cb48801eaf5d1c91dfb36108528bd754e2e70"
 dependencies = [
  "itertools 0.12.1",
- "thiserror",
+ "thiserror 1.0.69",
  "zone_cfg_derive 0.3.0 (git+https://github.com/oxidecomputer/zone)",
 ]
 
@@ -6452,11 +6865,11 @@ dependencies = [
 [[package]]
 name = "ztest"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/falcon?branch=main#d8c38f890040f90cdc467e23f3f06b6372a9921c"
+source = "git+https://github.com/oxidecomputer/falcon?branch=main#f3fe0542198c08bbb82d16f168e6482db9bec5b9"
 dependencies = [
  "anyhow",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
- "oxnet",
+ "oxnet 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "zone 0.3.0 (git+https://github.com/oxidecomputer/zone)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ clap = { version = "4.5.23", features = ["derive", "unstable-styles", "env"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }
 colored = "2.1"
 ctrlc = { version = "3.4.5", features = ["termination"] }
+#ztest = { path = "../falcon/ztest" }
 ztest = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 anstyle = "1.0.10"
 nom = "7.1"
@@ -84,9 +85,8 @@ mg-common = { path = "mg-common" }
 chrono = { version = "0.4.38", features = ["serde"] }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
-oxnet = { git = "https://github.com/oxidecomputer/oxnet" }
+oxnet = { version = "0.1.0", default-features = false, features = ["schemars", "serde"] }
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
-internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
 uuid = { version = "1.8", features = ["serde", "v4"] }
 smf = { git = "https://github.com/illumos/smf-rs", branch = "main" }
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ clap = { version = "4.5.23", features = ["derive", "unstable-styles", "env"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }
 colored = "2.1"
 ctrlc = { version = "3.4.5", features = ["termination"] }
-#ztest = { path = "../falcon/ztest" }
 ztest = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 anstyle = "1.0.10"
 nom = "7.1"

--- a/ddm/src/oxstats.rs
+++ b/ddm/src/oxstats.rs
@@ -298,7 +298,7 @@ pub fn start_server(
         server_info: producer_info,
         registration_address: None,
         log: log_config,
-        request_body_max_bytes: 1024 * 1024 * 1024,
+        default_request_body_max_bytes: 1024 * 1024 * 1024,
     };
 
     Ok(tokio::spawn(async move {

--- a/mg-common/Cargo.toml
+++ b/mg-common/Cargo.toml
@@ -14,7 +14,6 @@ slog.workspace = true
 slog-bunyan.workspace = true
 slog-async.workspace = true
 omicron-common.workspace = true
-internal-dns.workspace = true
 tokio.workspace = true
 oximeter-producer.workspace = true
 oximeter.workspace = true

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -114,7 +114,7 @@ fn get_local_addrs(
     rt: &Arc<tokio::runtime::Handle>,
 ) -> Result<(BTreeSet<Ipv4Addr>, BTreeSet<Ipv6Addr>), Error> {
     let links = rt
-        .block_on(async { dpd.link_list_all().await })?
+        .block_on(async { dpd.link_list_all(None).await })?
         .into_inner();
 
     let mut v4 = BTreeSet::new();

--- a/mgd/src/oxstats.rs
+++ b/mgd/src/oxstats.rs
@@ -772,7 +772,7 @@ pub(crate) fn start_server(
         server_info: producer_info,
         registration_address: None,
         log: log_config,
-        request_body_max_bytes: 1024 * 1024 * 1024,
+        default_request_body_max_bytes: 1024 * 1024 * 1024,
     };
 
     Ok(tokio::spawn(async move {


### PR DESCRIPTION
Update oxnet to 0.1.0 from crates.io. Also update omicron and dendrite to pull
in compatibility changes.

There are a lot of changes here unfortunately. I've tried to minimize changes
(in particular I didn't also update dropshot in this repo).

Aiming to land this after r13.