### PR TITLE
set `reqwest.default-features = false`; update FALCON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,7 @@ source = "git+https://github.com/oxidecomputer/dlpi-sys#1d587ea98cf2d36f1b1624b0
 [[package]]
 name = "libfalcon"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/falcon?branch=main#f3fe0542198c08bbb82d16f168e6482db9bec5b9"
+source = "git+https://github.com/oxidecomputer/falcon?branch=main#d04addf8c95cf59e1dbcc7c59c3d07692a2eae88"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -6582,7 +6582,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6993,7 +6993,7 @@ dependencies = [
 [[package]]
 name = "ztest"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/falcon?branch=main#f3fe0542198c08bbb82d16f168e6482db9bec5b9"
+source = "git+https://github.com/oxidecomputer/falcon?branch=main#d04addf8c95cf59e1dbcc7c59c3d07692a2eae88"
 dependencies = [
  "anyhow",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 serde_json = "1.0.133"
 percent-encoding = "2.3.1"
 libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "main" }
-reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 progenitor = "0.8.0"
 clap = { version = "4.5.23", features = ["derive", "unstable-styles", "env"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }


### PR DESCRIPTION
This is part of https://github.com/oxidecomputer/omicron/issues/7624.

reqwest has the unfortunate behavior of having an on-by-default feature flag that includes native-tls. Removing the default feature flags allows downstream crates to decide on those features on their own.

Other default feature flags disabled here are `encoding` (not relevant for JSON which is always UTF-8), `http2`, and `macos-system-configuration` (which automatically configures proxy settings on macOS).

FALCON is bumped to pick up https://github.com/oxidecomputer/falcon/pull/105, part of this same set of changes.