### PR TITLE
Bump opte-ioctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "libc",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "mg-common",
  "nom",
  "num_enum 0.7.3",
@@ -880,11 +880,11 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "ispf",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "mg-common",
  "omicron-common",
- "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
+ "opte-ioctl",
+ "oxide-vpc",
  "oximeter",
  "oximeter-producer",
  "oxnet",
@@ -960,7 +960,7 @@ dependencies = [
  "ddm",
  "dpd-client",
  "hostname 0.3.1",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "mg-common",
  "slog",
  "slog-async",
@@ -2122,11 +2122,6 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
-
-[[package]]
-name = "illumos-sys-hdrs"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [[package]]
@@ -2145,15 +2140,15 @@ dependencies = [
  "dropshot 0.16.0",
  "futures",
  "http 1.2.0",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "itertools 0.14.0",
  "libc",
  "macaddr",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "opte-ioctl",
+ "oxide-vpc",
  "oxlog",
  "oxnet",
  "schemars",
@@ -2304,12 +2299,6 @@ checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-
-[[package]]
-name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
@@ -2397,15 +2386,6 @@ dependencies = [
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
-dependencies = [
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "kstat-macro"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "quote",
@@ -2451,7 +2431,7 @@ dependencies = [
  "futures",
  "indicatif",
  "libc",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "propolis-client",
  "propolis-server-config",
  "rand",
@@ -2484,28 +2464,6 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 name = "libnet"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#f4eae3d8070760922da93b9edd56ca4103b4c390"
-dependencies = [
- "anyhow",
- "cfg-if",
- "colored",
- "dlpi",
- "libc",
- "num_enum 0.5.11",
- "nvpair",
- "nvpair-sys",
- "oxnet",
- "rand",
- "rusty-doors",
- "socket2",
- "thiserror 1.0.69",
- "tracing",
- "winnow 0.6.18",
-]
-
-[[package]]
-name = "libnet"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys#f4eae3d8070760922da93b9edd56ca4103b4c390"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2723,7 +2681,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "clap",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "omicron-common",
  "oximeter",
  "oximeter-producer",
@@ -2759,7 +2717,7 @@ dependencies = [
  "ddm-admin-client 0.1.0",
  "dpd-client",
  "http 1.2.0",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "mg-common",
  "oxnet",
  "rdb",
@@ -2786,7 +2744,7 @@ dependencies = [
  "anyhow",
  "ddm-admin-client 0.1.0",
  "ddm-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=2bfd39000c878c45675651a7588c015c486e7f43)",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "serde",
  "slog",
  "slog-async",
@@ -3014,7 +2972,7 @@ dependencies = [
  "humantime",
  "illumos-utils",
  "internal-dns-types",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "newtype-uuid",
  "newtype_derive",
  "nexus-sled-agent-shared",
@@ -3259,7 +3217,7 @@ dependencies = [
  "futures",
  "hex",
  "http 1.2.0",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "macaddr",
  "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=cb2b592e890ca9e93d8193e9765e2a62459d5fa8)",
  "omicron-uuid-kinds",
@@ -3415,32 +3373,15 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
-dependencies = [
- "cfg-if",
- "dyn-clone",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "postcard",
- "serde",
- "smoltcp",
- "tabwriter",
- "version_check",
-]
-
-[[package]]
-name = "opte"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
  "dyn-clone",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "illumos-sys-hdrs",
  "ingot",
- "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
- "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "kstat-macro",
+ "opte-api",
  "postcard",
  "serde",
  "smoltcp",
@@ -3451,23 +3392,11 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
-dependencies = [
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "ipnetwork 0.20.0",
- "postcard",
- "serde",
- "smoltcp",
-]
-
-[[package]]
-name = "opte-api"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "illumos-sys-hdrs",
  "ingot",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "postcard",
  "serde",
  "smoltcp",
@@ -3476,26 +3405,12 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
-dependencies = [
- "libc",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "postcard",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opte-ioctl"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "libc",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "libnet",
+ "opte",
+ "oxide-vpc",
  "postcard",
  "serde",
  "thiserror 2.0.11",
@@ -3510,26 +3425,11 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d#3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
-dependencies = [
- "cfg-if",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d)",
- "poptrie",
- "serde",
- "smoltcp",
- "tabwriter",
- "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "oxide-vpc"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "cfg-if",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "illumos-sys-hdrs",
+ "opte",
  "poptrie",
  "serde",
  "smoltcp",
@@ -3664,7 +3564,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f58698da06f0f57b1ea4a8f1b0ca5741ee17927729d2e87dcfcb682266d21d"
 dependencies = [
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "schemars",
  "serde",
  "serde_json",
@@ -6468,7 +6368,7 @@ name = "util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -7129,7 +7029,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/falcon?branch=main#f3fe0542198c08bbb82d16f168e6482db9bec5b9"
 dependencies = [
  "anyhow",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "oxnet",
  "tokio",
  "zone 0.3.0 (git+https://github.com/oxidecomputer/zone)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,11 +94,11 @@ rhai = { version = "1", features = ["metadata", "sync"] }
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"
-rev = "3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
+rev = "cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [workspace.dependencies.oxide-vpc]
 git = "https://github.com/oxidecomputer/opte"
-rev = "3dc9a3dd8d3c623f0cf2c659c7119ce0c026a96d"
+rev = "cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"


### PR DESCRIPTION
This revision is consistent with the current omicron main (https://github.com/oxidecomputer/omicron/blob/d9f7ebbef1b8ddfe73d268d821bde0c22e986dc1/Cargo.toml#L523).