### PR TITLE
Bump dendrite

### DIFF
--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -9,7 +9,7 @@
 #:   "/work/release/*",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 #: [[publish]]

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -8,7 +8,7 @@
 #:   "/out/*",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 #: [[publish]]

--- a/.github/buildomat/jobs/linux.sh
+++ b/.github/buildomat/jobs/linux.sh
@@ -9,7 +9,7 @@
 #:   "/work/release/*",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 #: [[publish]]

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -10,7 +10,7 @@
 #: ]
 #:
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 #: [[publish]]

--- a/.github/buildomat/jobs/test-bfd.sh
+++ b/.github/buildomat/jobs/test-bfd.sh
@@ -8,7 +8,7 @@
 #:   "/work/*.log",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 

--- a/.github/buildomat/jobs/test-bgp.sh
+++ b/.github/buildomat/jobs/test-bgp.sh
@@ -8,7 +8,7 @@
 #:   "/work/*.log",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 

--- a/.github/buildomat/jobs/test-ddm-quartet.sh
+++ b/.github/buildomat/jobs/test-ddm-quartet.sh
@@ -8,7 +8,7 @@
 #:   "/work/*.log",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 

--- a/.github/buildomat/jobs/test-ddm-trio.sh
+++ b/.github/buildomat/jobs/test-ddm-trio.sh
@@ -8,7 +8,7 @@
 #:   "/work/*.log",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 

--- a/.github/buildomat/jobs/test-rdb.sh
+++ b/.github/buildomat/jobs/test-rdb.sh
@@ -8,7 +8,7 @@
 #:   "/work/*.log",
 #: ]
 #: access_repos = [
-#:   "oxidecomputer/dendrite-os",
+#:   "oxidecomputer/dendrite",
 #: ]
 #:
 

--- a/.github/buildomat/test-ddm-common.sh
+++ b/.github/buildomat/test-ddm-common.sh
@@ -32,7 +32,7 @@ banner "collect"
 get_artifact softnpu image 64beaff129b7f63a04a53dd5ed0ec09f012f5756 softnpu
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 libsidecar_lite.so
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 scadm
-get_artifact dendrite image 350fb25d724578dd2b127499edcd57981d4bbff2 dendrite-softnpu.tar.gz
+get_artifact dendrite image ddb2c455a0e78ef1ebcaae22ba5f6ac907f21fde dendrite-softnpu.tar.gz
 get_artifact maghemite release 2bfd39000c878c45675651a7588c015c486e7f43 ddmd
 get_artifact maghemite release 2bfd39000c878c45675651a7588c015c486e7f43 ddmadm
 

--- a/.github/buildomat/test-ddm-common.sh
+++ b/.github/buildomat/test-ddm-common.sh
@@ -32,7 +32,7 @@ banner "collect"
 get_artifact softnpu image 64beaff129b7f63a04a53dd5ed0ec09f012f5756 softnpu
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 libsidecar_lite.so
 get_artifact sidecar-lite release d815d8e2b310de8a7461241d9f9f1b5c762e1e65 scadm
-get_artifact dendrite image ddb2c455a0e78ef1ebcaae22ba5f6ac907f21fde dendrite-softnpu.tar.gz
+get_artifact dendrite image 270dc8eb421b8514bf1ed00ab956025dc326b9df dendrite-softnpu.tar.gz
 get_artifact maghemite release 2bfd39000c878c45675651a7588c015c486e7f43 ddmd
 get_artifact maghemite release 2bfd39000c878c45675651a7588c015c486e7f43 ddmadm
 

--- a/.github/buildomat/test-ddm-common.sh
+++ b/.github/buildomat/test-ddm-common.sh
@@ -46,6 +46,10 @@ mv ddmd ddmd-v2
 rm -rf zones/dendrite
 mkdir -p zones/dendrite
 tar -xzf dendrite-softnpu.tar.gz -C zones/dendrite
+sed -i  "s#<service_fmri value='svc:/oxide/zone-network-setup:default' />##g" \
+    zones/dendrite/root/var/svc/manifest/site/dendrite/manifest.xml
+sed -i  "s#<service_fmri value='svc:/oxide/.*setup:default' />##g" \
+    zones/dendrite/root/var/svc/manifest/site/tfport/manifest.xml
 popd
 
 banner "install"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite-os?branch=main#668f1a2e35e7c76b22ab83fe6c2242d3454e2803"
+source = "git+https://github.com/oxidecomputer/dendrite?branch=port#ddb2c455a0e78ef1ebcaae22ba5f6ac907f21fde"
 dependencies = [
  "anyhow",
  "chrono",
@@ -680,16 +680,6 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -882,7 +872,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "common",
  "dpd-client",
  "dropshot",
  "hostname 0.3.1",
@@ -1118,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "dpd-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite-os?branch=main#668f1a2e35e7c76b22ab83fe6c2242d3454e2803"
+source = "git+https://github.com/oxidecomputer/dendrite?branch=port#ddb2c455a0e78ef1ebcaae22ba5f6ac907f21fde"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1887,22 +1876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,12 +2619,12 @@ dependencies = [
 [[package]]
 name = "mg-admin-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/maghemite?rev=caafd889f31faacfaa51e02902990c220c20ef60#caafd889f31faacfaa51e02902990c220c20ef60"
+source = "git+https://github.com/oxidecomputer/maghemite?rev=5a0d6edd0ecc7f26225a5bf3849d8508956682d0#5a0d6edd0ecc7f26225a5bf3849d8508956682d0"
 dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor 0.8.0",
+ "progenitor 0.9.1",
  "reqwest",
  "schemars",
  "serde",
@@ -2699,7 +2672,6 @@ name = "mg-lower"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "common",
  "ddm-admin-client",
  "dpd-client",
  "http",
@@ -2842,23 +2814,6 @@ dependencies = [
  "mime",
  "spin 0.9.8",
  "version_check",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3170,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3185,7 +3140,7 @@ dependencies = [
  "http",
  "ipnetwork",
  "macaddr",
- "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=caafd889f31faacfaa51e02902990c220c20ef60)",
+ "mg-admin-client 0.1.0 (git+https://github.com/oxidecomputer/maghemite?rev=5a0d6edd0ecc7f26225a5bf3849d8508956682d0)",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
@@ -3226,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "daft",
  "newtype-uuid",
@@ -3319,12 +3274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3426,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -3459,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3480,7 +3429,7 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -3493,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#5fd1c3588a45adfba0d8c59ff847487b28e6968b"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0dad016506a8676135cd3a1144b70a65feb0a5c3"
 dependencies = [
  "bytes",
  "chrono",
@@ -4332,22 +4281,18 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4359,9 +4304,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower",
@@ -4616,15 +4559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4676,29 +4610,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5329,27 +5240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tabled"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5610,16 +5500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5858,7 +5738,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tufaceous-artifact"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#b813aa819b7a1bd42a7295ba6bc71f06f51ccbb9"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#0ae289102f0fe2605781afcb4c5395652a9c842b"
 dependencies = [
  "daft",
  "parse-display",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite?branch=port#ddb2c455a0e78ef1ebcaae22ba5f6ac907f21fde"
+source = "git+https://github.com/oxidecomputer/dendrite?branch=main#270dc8eb421b8514bf1ed00ab956025dc326b9df"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "dpd-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dendrite?branch=port#ddb2c455a0e78ef1ebcaae22ba5f6ac907f21fde"
+source = "git+https://github.com/oxidecomputer/dendrite?branch=main#270dc8eb421b8514bf1ed00ab956025dc326b9df"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,11 +102,6 @@ git = "https://github.com/oxidecomputer/opte"
 rev = "cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [workspace.dependencies.dpd-client]
-git = "https://github.com/oxidecomputer/dendrite-os"
-branch = "main"
+git = "https://github.com/oxidecomputer/dendrite"
+branch = "port"
 package = "dpd-client"
-
-[workspace.dependencies.dendrite-common]
-git = "https://github.com/oxidecomputer/dendrite-os"
-branch = "main"
-package = "common"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,5 +103,5 @@ rev = "cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"
-branch = "port"
+branch = "main"
 package = "dpd-client"

--- a/ddm/Cargo.toml
+++ b/ddm/Cargo.toml
@@ -24,7 +24,6 @@ http-body-util.workspace = true
 serde_json.workspace = true
 libnet.workspace = true
 dpd-client.workspace = true
-dendrite-common.workspace = true
 opte-ioctl.workspace = true
 oxide-vpc.workspace = true
 sled.workspace = true

--- a/ddm/src/sys.rs
+++ b/ddm/src/sys.rs
@@ -190,10 +190,11 @@ pub fn add_routes_dendrite(
 
         // TODO this assumes ddm only operates on rear ports, which will not be
         // true for multi-rack deployments.
-        let port_id = match types::Rear::try_from(egress_port_num.to_string()) {
+        let port_name = format!("rear{}", egress_port_num);
+        let port_id = match types::Rear::try_from(&port_name) {
             Ok(rear) => PortId::Rear(rear),
             Err(e) => {
-                err!(log, ifname, "bad port name: {e}");
+                err!(log, ifname, "bad port name ({port_name}): {e}");
                 continue;
             }
         };

--- a/mg-lower/Cargo.toml
+++ b/mg-lower/Cargo.toml
@@ -8,7 +8,6 @@ ddm-admin-client = { path = "../ddm-admin-client" }
 rdb = { path = "../rdb" }
 anyhow.workspace = true
 dpd-client.workspace = true
-dendrite-common.workspace = true
 slog.workspace = true
 libnet.workspace = true
 tokio.workspace = true

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -4,10 +4,7 @@
 
 use crate::Error;
 use crate::MG_LOWER_TAG;
-use dendrite_common::ports::PortId;
-use dendrite_common::ports::QsfpPort;
 use dpd_client::types;
-use dpd_client::types::LinkId;
 use dpd_client::types::LinkState;
 use dpd_client::Client as DpdClient;
 use libnet::get_route;
@@ -26,10 +23,10 @@ use std::time::Duration;
 
 const TFPORT_QSFP_DEVICE_PREFIX: &str = "tfportqsfp";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct RouteHash {
     pub(crate) cidr: IpNet,
-    pub(crate) port_id: PortId,
+    pub(crate) port_id: types::PortId,
     pub(crate) link_id: types::LinkId,
     pub(crate) nexthop: IpAddr,
     pub(crate) vlan_id: Option<u16>,
@@ -38,7 +35,7 @@ pub(crate) struct RouteHash {
 impl RouteHash {
     pub fn new(
         cidr: IpNet,
-        port_id: PortId,
+        port_id: types::PortId,
         link_id: types::LinkId,
         nexthop: IpAddr,
         vlan_id: Option<u16>,
@@ -99,8 +96,8 @@ pub(crate) fn ensure_tep_addr(
 
 pub(crate) fn link_is_up(
     dpd: &DpdClient,
-    port_id: PortId,
-    link_id: LinkId,
+    port_id: &types::PortId,
+    link_id: &types::LinkId,
     rt: &Arc<tokio::runtime::Handle>,
 ) -> Result<bool, Error> {
     let link_info =
@@ -159,7 +156,7 @@ where
     for r in to_add {
         let cidr = r.cidr;
         let tag = dpd.inner().tag.clone();
-        let port_id = r.port_id;
+        let port_id = r.port_id.clone();
         let link_id = r.link_id;
         let vlan_id = r.vlan_id;
 
@@ -234,7 +231,7 @@ where
         }
     }
     for r in to_del {
-        let port_id = r.port_id;
+        let port_id = r.port_id.clone();
         let link_id = r.link_id;
 
         let cidr = match r.cidr {
@@ -322,7 +319,7 @@ fn test_tfport_parser() {
 
 fn get_port_and_link(
     nexthop: IpAddr,
-) -> Result<(PortId, types::LinkId), Error> {
+) -> Result<(types::PortId, types::LinkId), Error> {
     let prefix = IpNet::host_net(nexthop);
     let sys_route = get_route(prefix, Some(Duration::from_secs(1)))?;
 
@@ -337,10 +334,9 @@ fn get_port_and_link(
     };
 
     let (port, link, _vlan) = parse_tfport_name(&ifname)?;
-    let port_id = match QsfpPort::try_from(port) {
-        Ok(qsfp) => PortId::Qsfp(qsfp),
-        Err(e) => return Err(Error::Tfport(format!("bad port name: {e}"))),
-    };
+    let port_id = types::Qsfp::try_from(port.to_string())
+        .map(types::PortId::Qsfp)
+        .map_err(|e| Error::Tfport(format!("bad port name: {e}")))?;
 
     // TODO breakout considerations
     let link_id = dpd_client::types::LinkId(link);
@@ -373,7 +369,7 @@ pub(crate) fn get_routes_for_prefix(
                 if r.tag != MG_LOWER_TAG {
                     continue;
                 }
-                match link_is_up(dpd, r.port_id, r.link_id, &rt) {
+                match link_is_up(dpd, &r.port_id, &r.link_id, &rt) {
                     Err(e) => {
                         error!(
                             log,
@@ -400,8 +396,8 @@ pub(crate) fn get_routes_for_prefix(
                 }
                 match RouteHash::new(
                     cidr.into(),
-                    r.port_id,
-                    r.link_id,
+                    r.port_id.clone(),
+                    r.link_id.clone(),
                     r.tgt_ip.into(),
                     r.vlan_id,
                 ) {
@@ -421,8 +417,8 @@ pub(crate) fn get_routes_for_prefix(
                 .map(|r| {
                     RouteHash::new(
                         cidr.into(),
-                        r.port_id,
-                        r.link_id,
+                        r.port_id.clone(),
+                        r.link_id.clone(),
                         r.tgt_ip.into(),
                         r.vlan_id,
                     )
@@ -441,8 +437,8 @@ pub(crate) fn get_routes_for_prefix(
                 .map(|r| {
                     RouteHash::new(
                         cidr.into(),
-                        r.port_id,
-                        r.link_id,
+                        r.port_id.clone(),
+                        r.link_id.clone(),
                         r.tgt_ip.into(),
                         r.vlan_id,
                     )

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -101,7 +101,7 @@ pub(crate) fn link_is_up(
     rt: &Arc<tokio::runtime::Handle>,
 ) -> Result<bool, Error> {
     let link_info =
-        rt.block_on(async { dpd.link_get(&port_id, &link_id).await })?;
+        rt.block_on(async { dpd.link_get(port_id, link_id).await })?;
 
     Ok(link_info.link_state == LinkState::Up)
 }
@@ -397,7 +397,7 @@ pub(crate) fn get_routes_for_prefix(
                 match RouteHash::new(
                     cidr.into(),
                     r.port_id.clone(),
-                    r.link_id.clone(),
+                    r.link_id,
                     r.tgt_ip.into(),
                     r.vlan_id,
                 ) {
@@ -418,7 +418,7 @@ pub(crate) fn get_routes_for_prefix(
                     RouteHash::new(
                         cidr.into(),
                         r.port_id.clone(),
-                        r.link_id.clone(),
+                        r.link_id,
                         r.tgt_ip.into(),
                         r.vlan_id,
                     )
@@ -438,7 +438,7 @@ pub(crate) fn get_routes_for_prefix(
                     RouteHash::new(
                         cidr.into(),
                         r.port_id.clone(),
-                        r.link_id.clone(),
+                        r.link_id,
                         r.tgt_ip.into(),
                         r.vlan_id,
                     )

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -334,12 +334,17 @@ fn get_port_and_link(
     };
 
     let (port, link, _vlan) = parse_tfport_name(&ifname)?;
-    let port_id = types::Qsfp::try_from(port.to_string())
+    let port_name = format!("qsfp{port}");
+    let port_id = types::Qsfp::try_from(&port_name)
         .map(types::PortId::Qsfp)
-        .map_err(|e| Error::Tfport(format!("bad port name: {e}")))?;
+        .map_err(|e| {
+            Error::Tfport(format!(
+                "bad port name ifname: {ifname}  port name: {port_name}: {e}"
+            ))
+        })?;
 
     // TODO breakout considerations
-    let link_id = dpd_client::types::LinkId(link);
+    let link_id = types::LinkId(link);
     Ok((port_id, link_id))
 }
 

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -179,10 +179,10 @@ fn sync_prefix(
     }
 
     // Routes that are in the best set but not on the asic should be added.
-    let add: HashSet<RouteHash> = best.difference(&current).copied().collect();
+    let add: HashSet<RouteHash> = best.difference(&current).cloned().collect();
 
     // Routes that are on the asic but not in the best set should be removed.
-    let del: HashSet<RouteHash> = current.difference(&best).copied().collect();
+    let del: HashSet<RouteHash> = current.difference(&best).cloned().collect();
 
     // Update DDM tunnel routing
     add_tunnel_routes(tep, ddm, &add, rt.clone(), log);


### PR DESCRIPTION
Use the exported `types::PortId` rather than dendite's internal `common::ports::PortId`.
Update the dendrite commit used for testing, and adapt to the new dendrite/smf interaction.