### PR TITLE
Chore: Bump OPTE to `88adb1a`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,8 +897,8 @@ dependencies = [
  "libnet",
  "mg-common",
  "omicron-common",
- "opte-ioctl",
- "oxide-vpc",
+ "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
  "oximeter",
  "oximeter-producer",
  "oxnet",
@@ -2095,6 +2095,14 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "illumos-sys-hdrs"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [[package]]
@@ -2121,8 +2129,8 @@ dependencies = [
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
- "opte-ioctl",
- "oxide-vpc",
+ "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "oxlog",
  "oxnet",
  "schemars",
@@ -2388,6 +2396,15 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstat-macro"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3345,15 +3362,34 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "dyn-clone",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "ingot",
+ "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "postcard",
+ "serde",
+ "smoltcp",
+ "tabwriter",
+ "version_check",
+]
+
+[[package]]
+name = "opte"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
  "dyn-clone",
- "illumos-sys-hdrs",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "ingot",
- "kstat-macro",
- "opte-api",
+ "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "postcard",
  "serde",
  "smoltcp",
@@ -3364,9 +3400,22 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "ingot",
+ "ipnetwork",
+ "postcard",
+ "serde",
+ "smoltcp",
+]
+
+[[package]]
+name = "opte-api"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
- "illumos-sys-hdrs",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "ingot",
  "ipnetwork",
  "postcard",
@@ -3377,12 +3426,26 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "libc",
+ "libnet",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "postcard",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "opte-ioctl"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "libc",
  "libnet",
- "opte",
- "oxide-vpc",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "postcard",
  "serde",
  "thiserror 2.0.12",
@@ -3397,11 +3460,27 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "cfg-if",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "poptrie",
+ "serde",
+ "smoltcp",
+ "tabwriter",
+ "uuid",
+ "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "oxide-vpc"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "cfg-if",
- "illumos-sys-hdrs",
- "opte",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "poptrie",
  "serde",
  "smoltcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,11 @@ semver = "1.0"
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"
-rev = "cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+rev = "88adb1a5df689b3e2daddab9325ee94047f6ffad"
 
 [workspace.dependencies.oxide-vpc]
 git = "https://github.com/oxidecomputer/opte"
-rev = "cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+rev = "88adb1a5df689b3e2daddab9325ee94047f6ffad"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"

--- a/ddm/src/exchange.rs
+++ b/ddm/src/exchange.rs
@@ -398,8 +398,7 @@ pub(crate) fn announce_tunnel(
     rt: Arc<tokio::runtime::Handle>,
     log: Logger,
 ) -> Result<(), ExchangeError> {
-    let update =
-        TunnelUpdate::announce(endpoints.into_iter().map(Into::into).collect());
+    let update = TunnelUpdate::announce(endpoints.into_iter().collect());
     send_update(ctx, config, update.into(), addr, version, rt, log)
 }
 
@@ -425,8 +424,7 @@ pub(crate) fn withdraw_tunnel(
     rt: Arc<tokio::runtime::Handle>,
     log: Logger,
 ) -> Result<(), ExchangeError> {
-    let update =
-        TunnelUpdate::withdraw(endpoints.into_iter().map(Into::into).collect());
+    let update = TunnelUpdate::withdraw(endpoints.into_iter().collect());
     send_update(ctx, config, update.into(), addr, version, rt, log)
 }
 

--- a/rdb/src/bestpath.rs
+++ b/rdb/src/bestpath.rs
@@ -34,10 +34,7 @@ pub fn bestpaths(
     rib: &Rib,
     max: usize,
 ) -> Option<BTreeSet<Path>> {
-    let candidates = match rib.get(&prefix) {
-        Some(cs) => cs,
-        None => return None,
-    };
+    let candidates = rib.get(&prefix)?;
 
     // Partition the choice space on whether routes are shutdown or not. If we
     // only have shutdown routes then use those. Otherwise use active routes

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-channel = "1.81.0"
+channel = "1.86.0"
 profile = "default"

--- a/tests/src/ddm.rs
+++ b/tests/src/ddm.rs
@@ -74,7 +74,7 @@ impl<'a> SoftnpuZone<'a> {
     }
 }
 
-impl<'a> Drop for SoftnpuZone<'a> {
+impl Drop for SoftnpuZone<'_> {
     fn drop(&mut self) {
         if let Err(e) = self.zone.zexec("pkill softnpu") {
             eprintln!("failed to stop softnpu: {}", e);
@@ -271,14 +271,14 @@ impl<'a> RouterZone<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for RouterZone<'a> {
+impl std::ops::Deref for RouterZone<'_> {
     type Target = Zone;
     fn deref(&self) -> &Zone {
         &self.zone
     }
 }
 
-impl<'a> Drop for RouterZone<'a> {
+impl Drop for RouterZone<'_> {
     fn drop(&mut self) {
         if let Err(e) = self.zone.zexec("pkill ddmd") {
             eprintln!("failed to stop ddmd: {}", e);


### PR DESCRIPTION
Brings us up to OPTE v0.35.x, and is part of bringing tunnelled LSO into use by omicron.

An extra point is that I needed to bump the rust version used in this repo, since OPTE is on the 2024 rust edition. Renovate has opened a PR for this at some point, but it has languished for some time.