### PR TITLE
Update OPTE to 0.36.374

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,8 +887,8 @@ dependencies = [
  "libnet",
  "mg-common",
  "omicron-common",
- "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
  "oximeter",
  "oximeter-producer",
  "oxnet",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2179,14 +2179,42 @@ dependencies = [
 [[package]]
 name = "ingot"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf487a5cb3a9d3346e5b7dac34193ba0b2aefe5d1c196e8caf454c19e200a04"
 dependencies = [
  "bitflags 2.9.0",
- "ingot-macros",
- "ingot-types",
+ "ingot-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ingot-types 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "macaddr",
  "serde",
  "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "ingot"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
+dependencies = [
+ "bitflags 2.9.0",
+ "ingot-macros 0.1.0 (git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906)",
+ "ingot-types 0.1.0 (git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906)",
+ "macaddr",
+ "serde",
+ "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "ingot-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f13f59bddb02b9927bdf5e20a7204c92bcff649496f54a591091c0c2cb27cbf"
+dependencies = [
+ "darling",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2205,9 +2233,20 @@ dependencies = [
 [[package]]
 name = "ingot-types"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31cffa0c771a619697bc33dff4fb4771a6f87b0f6864793a3efac4e8ee50c78"
+dependencies = [
+ "ingot-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "macaddr",
+ "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "ingot-types"
+version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
 dependencies = [
- "ingot-macros",
+ "ingot-macros 0.1.0 (git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906)",
  "macaddr",
  "zerocopy 0.8.24",
 ]
@@ -2391,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3352,20 +3391,19 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 dependencies = [
  "bitflags 2.9.0",
- "cfg-if",
  "dyn-clone",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "ingot",
- "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "ingot 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
  "postcard",
  "serde",
- "smoltcp",
  "tabwriter",
  "version_check",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3377,7 +3415,7 @@ dependencies = [
  "cfg-if",
  "dyn-clone",
  "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
- "ingot",
+ "ingot 0.1.0 (git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906)",
  "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
  "postcard",
@@ -3390,10 +3428,10 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 dependencies = [
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "ingot",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "ingot 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork",
  "postcard",
  "serde",
@@ -3406,7 +3444,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa)",
- "ingot",
+ "ingot 0.1.0 (git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906)",
  "ipnetwork",
  "postcard",
  "serde",
@@ -3416,12 +3454,12 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 dependencies = [
  "libc",
  "libnet",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
  "postcard",
  "serde",
  "thiserror 2.0.12",
@@ -3450,14 +3488,12 @@ checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 dependencies = [
  "cfg-if",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad)",
- "poptrie",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
  "serde",
- "smoltcp",
  "tabwriter",
  "uuid",
  "zerocopy 0.8.24",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,8 +887,8 @@ dependencies = [
  "libnet",
  "mg-common",
  "omicron-common",
- "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "opte-ioctl 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
  "oximeter",
  "oximeter-producer",
  "oxnet",
@@ -2085,15 +2085,15 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
-dependencies = [
- "bitflags 2.9.0",
-]
+source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e#f5560fae02ad3fc349fabc6454c321143199ca9e"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "illumos-utils"
@@ -2214,7 +2214,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
+source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e#f5560fae02ad3fc349fabc6454c321143199ca9e"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -3391,24 +3391,6 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
-dependencies = [
- "bitflags 2.9.0",
- "dyn-clone",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "ingot 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "postcard",
- "serde",
- "tabwriter",
- "version_check",
- "zerocopy 0.8.24",
-]
-
-[[package]]
-name = "opte"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
 dependencies = [
  "bitflags 2.9.0",
@@ -3426,16 +3408,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "opte-api"
+name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
+source = "git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e#f5560fae02ad3fc349fabc6454c321143199ca9e"
 dependencies = [
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "bitflags 2.9.0",
+ "dyn-clone",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
  "ingot 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipnetwork",
+ "kstat-macro 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "opte-api 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
  "postcard",
  "serde",
- "smoltcp",
+ "tabwriter",
+ "version_check",
 ]
 
 [[package]]
@@ -3452,17 +3438,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "opte-ioctl"
+name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
+source = "git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e#f5560fae02ad3fc349fabc6454c321143199ca9e"
 dependencies = [
- "libc",
- "libnet",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "ingot 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork",
  "postcard",
  "serde",
- "thiserror 2.0.12",
+ "smoltcp",
 ]
 
 [[package]]
@@ -3480,24 +3465,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "opte-ioctl"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e#f5560fae02ad3fc349fabc6454c321143199ca9e"
+dependencies = [
+ "libc",
+ "libnet",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "oxide-vpc 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "postcard",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
-
-[[package]]
-name = "oxide-vpc"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d#792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
-dependencies = [
- "cfg-if",
- "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=792ec8a3816ba8c7c4268f65cd19dbd946a9027d)",
- "serde",
- "tabwriter",
- "uuid",
- "zerocopy 0.8.24",
-]
 
 [[package]]
 name = "oxide-vpc"
@@ -3510,6 +3495,20 @@ dependencies = [
  "poptrie",
  "serde",
  "smoltcp",
+ "tabwriter",
+ "uuid",
+ "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "oxide-vpc"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e#f5560fae02ad3fc349fabc6454c321143199ca9e"
+dependencies = [
+ "cfg-if",
+ "illumos-sys-hdrs 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "opte 0.1.0 (git+https://github.com/oxidecomputer/opte?rev=f5560fae02ad3fc349fabc6454c321143199ca9e)",
+ "serde",
  "tabwriter",
  "uuid",
  "zerocopy 0.8.24",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,11 @@ semver = "1.0"
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"
-rev = "88adb1a5df689b3e2daddab9325ee94047f6ffad"
+rev = "792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 
 [workspace.dependencies.oxide-vpc]
 git = "https://github.com/oxidecomputer/opte"
-rev = "88adb1a5df689b3e2daddab9325ee94047f6ffad"
+rev = "792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,11 @@ semver = "1.0"
 
 [workspace.dependencies.opte-ioctl]
 git = "https://github.com/oxidecomputer/opte"
-rev = "792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
+rev = "f5560fae02ad3fc349fabc6454c321143199ca9e"
 
 [workspace.dependencies.oxide-vpc]
 git = "https://github.com/oxidecomputer/opte"
-rev = "792ec8a3816ba8c7c4268f65cd19dbd946a9027d"
+rev = "f5560fae02ad3fc349fabc6454c321143199ca9e"
 
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"

--- a/ddm/src/sys.rs
+++ b/ddm/src/sys.rs
@@ -277,7 +277,7 @@ pub fn add_tunnel_routes(
         IpCidr, Ipv4Cidr, Ipv4PrefixLen, Ipv6Cidr, Ipv6PrefixLen,
         SetVirt2BoundaryReq,
     };
-    let hdl = OpteHdl::open(OpteHdl::XDE_CTL).map_err(|e| e.to_string())?;
+    let hdl = OpteHdl::open().map_err(|e| e.to_string())?;
 
     for (pfx, tep) in tunnel_route_update_map(routes) {
         for t in &tep {
@@ -328,7 +328,7 @@ pub fn remove_tunnel_routes(
         ClearVirt2BoundaryReq, IpCidr, Ipv4Cidr, Ipv4PrefixLen, Ipv6Cidr,
         Ipv6PrefixLen,
     };
-    let hdl = OpteHdl::open(OpteHdl::XDE_CTL).map_err(|e| e.to_string())?;
+    let hdl = OpteHdl::open().map_err(|e| e.to_string())?;
     for (pfx, tep) in tunnel_route_update_map(routes) {
         for t in &tep {
             inf!(


### PR DESCRIPTION
Pulling this in here before omicron since we have an API version bump. The only meaningful change in maghemite is that `OpteHdl`s are constructed using a simple `::new()` now.