### PR TITLE
bgp: remember to delete router from db

### DIFF
--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -199,7 +199,13 @@ pub async fn delete_router(
     request: Query<AsnSelector>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let rq = request.into_inner();
-    let mut routers = lock!(ctx.context().bgp.router);
+    let ctx = ctx.context();
+    let db = ctx.db.clone();
+
+    db.remove_bgp_router(rq.asn)
+        .map_err(|e| HttpError::for_internal_error(format!("{e}")))?;
+
+    let mut routers = lock!(ctx.bgp.router);
     if let Some(r) = routers.remove(&rq.asn) {
         r.shutdown()
     };


### PR DESCRIPTION
When the delete_router API endpoint was called, the router was not fully being deleted. "mgadm bgp config router list" would still display a router despite returning a 204 No Content indicating the operation was successful:
```
[trey@zebes:~/git/maghemite on main]
% ./target/debug/mgadm bgp config router list
[
    Router {
        asn: 1,
        graceful_shutdown: false,
        id: 1,
        listen: "[::]:179",
    },
]
[trey@zebes:~/git/maghemite on main]
% ./target/debug/mgadm bgp config router delete 1
[trey@zebes:~/git/maghemite on main]
% ./target/debug/mgadm bgp config router list
[
    Router {
        asn: 1,
        graceful_shutdown: false,
        id: 1,
        listen: "[::]:179",
    },
]
```
This is because the API handler would remove the router from the BgpContext struct, but not from the persistent sled db.

This change ensures the router is removed from the sled db, not just the in-memory BgpContext data structure. Now the router gets deleted from the sled db, and mgadm properly reflects the running state:
```
[trey@zebes:~/git/maghemite on trey/fix_router_del]
% ./target/debug/mgadm bgp config router list
[
    Router {
        asn: 1,
        graceful_shutdown: false,
        id: 1,
        listen: "[::]:179",
    },
]
[trey@zebes:~/git/maghemite on trey/fix_router_del]
% ./target/debug/mgadm bgp config router delete 1
[trey@zebes:~/git/maghemite on trey/fix_router_del]
% ./target/debug/mgadm bgp config router list
[]
```