### PR TITLE
Use `oxide-tokio-rt` rather than `#[tokio::main]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -932,6 +932,7 @@ dependencies = [
  "ddm",
  "ddm-admin-client",
  "mg-common",
+ "oxide-tokio-rt",
  "oxnet",
  "slog",
  "slog-async",
@@ -953,6 +954,7 @@ dependencies = [
  "hostname 0.3.1",
  "libnet",
  "mg-common",
+ "oxide-tokio-rt",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -2476,6 +2478,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "libfalcon",
+ "oxide-tokio-rt",
  "tokio",
 ]
 
@@ -2787,6 +2790,7 @@ name = "mg-ddm-verify"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "oxide-tokio-rt",
  "reqwest",
  "serde",
  "serde_json",
@@ -2850,6 +2854,7 @@ dependencies = [
  "humantime",
  "mg-admin-client 0.1.0",
  "mg-common",
+ "oxide-tokio-rt",
  "rdb",
  "serde_json",
  "slog",
@@ -2877,6 +2882,7 @@ dependencies = [
  "mg-common",
  "mg-lower",
  "omicron-common",
+ "oxide-tokio-rt",
  "oximeter",
  "oximeter-producer",
  "rand 0.8.5",
@@ -3510,6 +3516,17 @@ name = "owo-colors"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+
+[[package]]
+name = "oxide-tokio-rt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bd87abf37c68d414e4df90a545857542140e07206f75039b8f63b244da87b8"
+dependencies = [
+ "anyhow",
+ "tokio",
+ "tokio-dtrace",
+]
 
 [[package]]
 name = "oxide-vpc"
@@ -5645,6 +5662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-dtrace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5eb4bcf85c373ff09a8beb87a477c2df185cd8842a770386a88bc3ff7ac5abb"
+dependencies = [
+ "thiserror 2.0.12",
+ "tokio",
+ "usdt",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6438,7 +6466,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ rand = "0.8.5"
 backoff = "0.4"
 mg-common = { path = "mg-common" }
 chrono = { version = "0.4.41", features = ["serde"] }
+oxide-tokio-rt = "0.1.2"
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main"}
 oxnet = { version = "0.1.2", default-features = false, features = ["schemars", "serde"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+[[disallowed-macros]]
+path = "tokio::main"
+reason = "prefer `oxide_tokio_rt` for production software"
+replacement = "oxide_tokio_rt::run"

--- a/ddmadm/Cargo.toml
+++ b/ddmadm/Cargo.toml
@@ -11,6 +11,7 @@ anstyle.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 colored.workspace = true
+oxide-tokio-rt.workspace = true
 oxnet.workspace = true
 slog-async.workspace = true
 slog-envlogger.workspace = true

--- a/ddmadm/src/main.rs
+++ b/ddmadm/src/main.rs
@@ -89,9 +89,8 @@ struct Peer {
     addr: Ipv6Addr,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    run().await
+fn main() -> Result<()> {
+    oxide_tokio_rt::run(run())
 }
 
 async fn run() -> Result<()> {

--- a/ddmd/Cargo.toml
+++ b/ddmd/Cargo.toml
@@ -9,6 +9,7 @@ mg-common = { path = "../mg-common" }
 anyhow.workspace = true
 clap.workspace = true
 libnet.workspace = true
+oxide-tokio-rt.workspace = true
 slog.workspace = true
 slog-bunyan.workspace = true
 slog-async.workspace = true

--- a/ddmd/src/main.rs
+++ b/ddmd/src/main.rs
@@ -107,8 +107,11 @@ struct Dendrite {
     port: u16,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    oxide_tokio_rt::run(run())
+}
+
+async fn run() {
     let arg = Arg::parse();
     let log = init_logger();
 

--- a/lab/Cargo.toml
+++ b/lab/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 libfalcon = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 anyhow.workspace = true
 tokio.workspace = true
+oxide-tokio-rt.workspace = true
 
 [[bin]]
 name = "solo"

--- a/lab/src/2x2/main.rs
+++ b/lab/src/2x2/main.rs
@@ -9,8 +9,11 @@ use libfalcon::error::Error;
 use libfalcon::unit::gb;
 use libfalcon::Runner;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    oxide_tokio_rt::run(main_impl())
+}
+
+async fn main_impl() -> Result<(), Error> {
     let mut d = Runner::new("mg2x2");
 
     // routers

--- a/lab/src/duo/main.rs
+++ b/lab/src/duo/main.rs
@@ -10,8 +10,11 @@ use libfalcon::error::Error;
 use libfalcon::unit::gb;
 use libfalcon::Runner;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    oxide_tokio_rt::run(main_impl())
+}
+
+async fn main_impl() -> Result<(), Error> {
     let mut d = Runner::new("duo");
 
     // nodes

--- a/lab/src/quartet/main.rs
+++ b/lab/src/quartet/main.rs
@@ -10,8 +10,11 @@ use libfalcon::error::Error;
 use libfalcon::unit::gb;
 use libfalcon::Runner;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    oxide_tokio_rt::run(main_impl())
+}
+
+async fn main_impl() -> Result<(), Error> {
     let mut d = Runner::new("quartet");
 
     // nodes

--- a/lab/src/solo/main.rs
+++ b/lab/src/solo/main.rs
@@ -9,8 +9,11 @@ use libfalcon::error::Error;
 use libfalcon::unit::gb;
 use libfalcon::Runner;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    oxide_tokio_rt::run(main_impl())
+}
+
+async fn main_impl() -> Result<(), Error> {
     let mut d = Runner::new("mgsolo");
 
     // nodes

--- a/lab/src/trio/main.rs
+++ b/lab/src/trio/main.rs
@@ -10,8 +10,11 @@ use libfalcon::error::Error;
 use libfalcon::unit::gb;
 use libfalcon::Runner;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    oxide_tokio_rt::run(main_impl())
+}
+
+async fn main_impl() -> Result<(), Error> {
     let mut d = Runner::new("trio");
 
     // nodes

--- a/mg-ddm-verify/Cargo.toml
+++ b/mg-ddm-verify/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 reqwest.workspace = true
+oxide-tokio-rt.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/mg-ddm-verify/src/main.rs
+++ b/mg-ddm-verify/src/main.rs
@@ -26,8 +26,11 @@ pub struct Sled {
     ip: String,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    oxide_tokio_rt::run(run())
+}
+
+async fn run() -> Result<()> {
     let sleds: Vec<Sled> =
         serde_json::from_str(&std::fs::read_to_string("sleds.json")?)?;
 

--- a/mgadm/Cargo.toml
+++ b/mgadm/Cargo.toml
@@ -11,6 +11,7 @@ mg-admin-client = { path = "../mg-admin-client" }
 tokio.workspace = true
 clap.workspace = true
 anyhow.workspace = true
+oxide-tokio-rt.workspace = true
 slog.workspace = true
 slog-term.workspace = true
 slog-async.workspace = true

--- a/mgadm/src/main.rs
+++ b/mgadm/src/main.rs
@@ -52,8 +52,11 @@ enum Commands {
     Bfd(bfd::Commands),
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    oxide_tokio_rt::run(run())
+}
+
+async fn run() -> Result<()> {
     let cli = Cli::parse();
     let log = init_logger();
 

--- a/mgd/Cargo.toml
+++ b/mgd/Cargo.toml
@@ -22,6 +22,7 @@ tokio.workspace = true
 http.workspace = true
 thiserror.workspace = true
 rand.workspace = true
+oxide-tokio-rt.workspace = true
 oximeter.workspace = true
 oximeter-producer.workspace = true
 chrono.workspace = true

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -85,11 +85,10 @@ struct RunArgs {
     sled_uuid: Option<Uuid>,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args = Cli::parse();
     match args.command {
-        Commands::Run(run_args) => run(run_args).await,
+        Commands::Run(run_args) => oxide_tokio_rt::run(run(run_args)),
         Commands::Apigen => admin::apigen(),
     }
 }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -6,6 +6,11 @@ use anyhow::Result;
 use omicron_zone_package::package::BuildConfig;
 use std::fs::create_dir_all;
 
+#[expect(
+    clippy::disallowed_macros,
+    reason = "using `#[tokio::main]` to avoid an extra dependency \
+     is worth more than a prod-like configuration in a build tool"
+)]
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = omicron_zone_package::config::parse("package-manifest.toml")?;


### PR DESCRIPTION
As described in [RFD 579], we are now recommending certain non-default Tokio runtime configurations in all software we deploy in production. The [`oxide-tokio-rt`] crate provides a way to easily get these common recommended configurations by using its functions to initialize the runtime rather than `#[tokio::main]`

Presently, `oxide-tokio-rt` does the following:

- Enables DTrace probes for Tokio runtime events using [`tokio-dtrace`]
- Disables the [LIFO slot optimization][lifo], which was the root cause of omicron#8334

But, we anticipate that if there are additional Tokio configurations which we want to recommend in the future, we'll add them here as well.

This commit updates `maghemite` to initialize the Tokio runtime using `oxide-tokio-rt`. I've added a Clippy config for warning on uses of `#[tokio::main]`, as well, to avoid forgetting to use `oxide-tokio-rt` if new binaries are added. All the configs we set currently in `oxide-tokio-rt` requires the `tokio_unstable` RUSTFLAGS cfg, but it looks like that's already being set, so that shouldn't be a problem.

I've changed every binary to use `oxide-tokio-rt` with the exception of `mg-package` --- it didn't seem necessary to use the production-like config there and maybe avoiding an additional dependency to fetch would make it build slightly faster, although I'm unconvinced. I did change the lab binaries to use `oxide-tokio-rt`, as I figured that the DTrace probes could come in handy there.

[RFD 579]: https://rfd.shared.oxide.computer/rfd/0579 
[`oxide-tokio-rt`]: https://github.com/oxidecomputer/oxide-tokio-rt 
[`tokio-dtrace`]: https://github.com/oxidecomputer/tokio-dtrace
[lifo]:
    https://rfd.shared.oxide.computer/rfd/0579#_disabling_the_lifo_slot_optimization