### PR TITLE
Add bestpath fanout config capabilities

### DIFF
--- a/mgadm/src/bestpath.rs
+++ b/mgadm/src/bestpath.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::num::NonZeroU8;
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use mg_admin_client::types;
+use mg_admin_client::Client;
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Fanout configuration commands.
+    Fanout(FanoutCommand),
+}
+
+#[derive(Debug, Args)]
+pub struct FanoutCommand {
+    #[command(subcommand)]
+    command: FanoutCmd,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum FanoutCmd {
+    /// Read the current fanout setting.
+    Read,
+
+    /// Update the fanout setting.
+    Update {
+        /// Maximum number of equal-cost paths for ECMP forwarding
+        fanout: NonZeroU8,
+    },
+}
+
+pub async fn commands(command: Commands, c: Client) -> Result<()> {
+    match command {
+        Commands::Fanout(fanout_cmd) => match fanout_cmd.command {
+            FanoutCmd::Read => read_bestpath_fanout(c).await?,
+            FanoutCmd::Update { fanout } => {
+                update_bestpath_fanout(fanout, c).await?
+            }
+        },
+    }
+    Ok(())
+}
+
+async fn read_bestpath_fanout(c: Client) -> Result<()> {
+    let result = c.read_bestpath_fanout().await?;
+    println!("{}", result.into_inner().fanout);
+    Ok(())
+}
+
+async fn update_bestpath_fanout(fanout: NonZeroU8, c: Client) -> Result<()> {
+    c.update_bestpath_fanout(&types::BestpathFanoutRequest { fanout })
+        .await?;
+    println!("Updated bestpath fanout to: {}", fanout);
+    Ok(())
+}

--- a/mgadm/src/main.rs
+++ b/mgadm/src/main.rs
@@ -12,6 +12,7 @@ use slog::Drain;
 use slog::Logger;
 use std::net::{IpAddr, SocketAddr};
 
+mod bestpath;
 mod bfd;
 mod bgp;
 mod static_routing;
@@ -50,6 +51,10 @@ enum Commands {
     /// Bidirectional forwarding detection protocol management
     #[command(subcommand)]
     Bfd(bfd::Commands),
+
+    /// Bestpath configuration commands.
+    #[command(subcommand)]
+    Bestpath(bestpath::Commands),
 }
 
 fn main() -> Result<()> {
@@ -71,6 +76,9 @@ async fn run() -> Result<()> {
             static_routing::commands(command, client).await?
         }
         Commands::Bfd(command) => bfd::commands(command, client).await?,
+        Commands::Bestpath(command) => {
+            bestpath::commands(command, client).await?
+        }
     }
     Ok(())
 }

--- a/mgd/src/bgp_param.rs
+++ b/mgd/src/bgp_param.rs
@@ -8,6 +8,7 @@ use rdb::{ImportExportPolicy, Path, PolicyAction, Prefix4};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
+use std::num::NonZeroU8;
 use std::time::Duration;
 use std::{
     collections::BTreeMap,
@@ -213,6 +214,18 @@ pub struct GracefulShutdownRequest {
 pub struct GetOriginated4Request {
     /// ASN of the router to get originated prefixes from.
     pub asn: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct BestpathFanoutRequest {
+    /// Maximum number of equal-cost paths for ECMP forwarding
+    pub fanout: NonZeroU8,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct BestpathFanoutResponse {
+    /// Current maximum number of equal-cost paths for ECMP forwarding
+    pub fanout: NonZeroU8,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -5,6 +5,53 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/bestpath/config/fanout": {
+      "get": {
+        "operationId": "read_bestpath_fanout",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BestpathFanoutResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "post": {
+        "operationId": "update_bestpath_fanout",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BestpathFanoutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/bfd/peers": {
       "get": {
         "summary": "Get all the peers and their associated BFD state. Peers are identified by IP",
@@ -1184,6 +1231,34 @@
         },
         "required": [
           "asn"
+        ]
+      },
+      "BestpathFanoutRequest": {
+        "type": "object",
+        "properties": {
+          "fanout": {
+            "description": "Maximum number of equal-cost paths for ECMP forwarding",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "fanout"
+        ]
+      },
+      "BestpathFanoutResponse": {
+        "type": "object",
+        "properties": {
+          "fanout": {
+            "description": "Current maximum number of equal-cost paths for ECMP forwarding",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "fanout"
         ]
       },
       "BfdPeerConfig": {

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -653,7 +653,12 @@ impl Db {
         let fan = match tree.get(BESTPATH_FANOUT)? {
             // fanout was not in db
             None => DEFAULT_BESTPATH_FANOUT,
-            Some(value) => value[0],
+            Some(value) => {
+                let value: [u8; 1] = (*value).try_into().map_err(|_| {
+                    Error::DbKey("invalid bestpath_fanout value in db".into())
+                })?;
+                value[0]
+            }
         };
 
         Ok(match NonZeroU8::new(fan) {

--- a/rdb/src/error.rs
+++ b/rdb/src/error.rs
@@ -21,4 +21,7 @@ pub enum Error {
 
     #[error("Conflict {0}")]
     Conflict(String),
+
+    #[error("Parsing error {0}")]
+    Parsing(String),
 }


### PR DESCRIPTION
Adds an API endpoint for /bestpath/fanout and methods to get/set the fanout value.  This defines the maximum number of ECMP paths that can be selected by the RIB during bestpath calculation.

Fixes: #400