### PR TITLE
Initial IPv6 Support

### DIFF
--- a/.github/buildomat/jobs/test-mgadm.sh
+++ b/.github/buildomat/jobs/test-mgadm.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#:
+#: name = "test-rdb"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "/work/*.log",
+#: ]
+#: access_repos = [
+#:   "oxidecomputer/dendrite",
+#: ]
+#:
+
+set -x
+set -e
+
+# NOTE: This version should be in sync with the recommended version in
+# .config/nextest.toml. (Maybe build an automated way to pull the recommended
+# version in the future.)
+NEXTEST_VERSION='0.9.97'
+PLATFORM='illumos'
+
+cargo --version
+rustc --version
+curl -sSfL --retry 10 https://get.nexte.st/"$NEXTEST_VERSION"/"$PLATFORM" | gunzip | tar -xvf - -C ~/.cargo/bin
+
+pushd mgadm
+
+cargo nextest run
+cp *.log /work/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,7 +2790,9 @@ name = "mg-ddm-verify"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ddm",
  "oxide-tokio-rt",
+ "oxnet",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,6 +2857,7 @@ dependencies = [
  "mg-admin-client 0.1.0",
  "mg-common",
  "oxide-tokio-rt",
+ "oxnet",
  "rdb",
  "serde_json",
  "slog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "mg-common",
  "percent-encoding",
  "progenitor",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 clap = { version = "4.5.40", features = ["derive", "unstable-styles", "env"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }
 colored = "3.0"
-ctrlc = { version = "3.4.7", features = ["termination"] }
 ztest = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 anstyle = "1.0.11"
 nom = "7.1"

--- a/bgp/src/messages.rs
+++ b/bgp/src/messages.rs
@@ -813,6 +813,15 @@ impl From<rdb::Prefix4> for Prefix {
     }
 }
 
+impl From<rdb::Prefix6> for Prefix {
+    fn from(p: rdb::Prefix6) -> Self {
+        Self {
+            value: p.value.octets().into(),
+            length: p.length,
+        }
+    }
+}
+
 /// A self-describing BGP path attribute
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PathAttribute {

--- a/bgp/src/messages.rs
+++ b/bgp/src/messages.rs
@@ -2478,6 +2478,7 @@ pub enum Safi {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mg_common::{cidr, ip, parse};
     use pretty_assertions::assert_eq;
     use pretty_hex::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -2607,11 +2608,11 @@ mod tests {
     fn prefix_within() {
         // Test IPv4 prefix containment
         let ipv4_prefixes: &[Prefix] = &[
-            "10.10.10.10/32".parse().unwrap(),
-            "10.10.10.0/24".parse().unwrap(),
-            "10.10.0.0/16".parse().unwrap(),
-            "10.0.0.0/8".parse().unwrap(),
-            "0.0.0.0/0".parse().unwrap(),
+            cidr!("10.10.10.10/32"),
+            cidr!("10.10.10.0/24"),
+            cidr!("10.10.0.0/16"),
+            cidr!("10.0.0.0/8"),
+            cidr!("0.0.0.0/0"),
         ];
 
         for i in 0..ipv4_prefixes.len() {
@@ -2627,11 +2628,11 @@ mod tests {
 
         // Test IPv6 prefix containment
         let ipv6_prefixes: &[Prefix] = &[
-            "2001:db8:1:1::1/128".parse().unwrap(),
-            "2001:db8:1:1::/64".parse().unwrap(),
-            "2001:db8:1::/48".parse().unwrap(),
-            "2001:db8::/32".parse().unwrap(),
-            "::/0".parse().unwrap(),
+            cidr!("2001:db8:1:1::1/128"),
+            cidr!("2001:db8:1:1::/64"),
+            cidr!("2001:db8:1::/48"),
+            cidr!("2001:db8::/32"),
+            cidr!("::/0"),
         ];
 
         for i in 0..ipv6_prefixes.len() {
@@ -2646,22 +2647,22 @@ mod tests {
         }
 
         // Test non-overlapping prefixes
-        let a: Prefix = "10.10.0.0/16".parse().unwrap();
-        let b: Prefix = "10.20.0.0/16".parse().unwrap();
+        let a: Prefix = cidr!("10.10.0.0/16");
+        let b: Prefix = cidr!("10.20.0.0/16");
         assert!(!a.within(&b));
-        let a: Prefix = "10.10.0.0/24".parse().unwrap();
+        let a: Prefix = cidr!("10.10.0.0/24");
         assert!(!a.within(&b));
 
-        let a: Prefix = "2001:db8:1::/48".parse().unwrap();
-        let b: Prefix = "2001:db8:2::/48".parse().unwrap();
+        let a: Prefix = cidr!("2001:db8:1::/48");
+        let b: Prefix = cidr!("2001:db8:2::/48");
         assert!(!a.within(&b));
 
         // Test default routes contain same-family prefixes
-        let ipv4_default: Prefix = "0.0.0.0/0".parse().unwrap();
-        let ipv6_default: Prefix = "::/0".parse().unwrap();
+        let ipv4_default: Prefix = cidr!("0.0.0.0/0");
+        let ipv6_default: Prefix = cidr!("::/0");
 
-        let any_ipv4: Prefix = "192.168.1.0/24".parse().unwrap();
-        let any_ipv6: Prefix = "2001:db8::/48".parse().unwrap();
+        let any_ipv4: Prefix = cidr!("192.168.1.0/24");
+        let any_ipv6: Prefix = cidr!("2001:db8::/48");
 
         assert!(any_ipv4.within(&ipv4_default));
         assert!(any_ipv6.within(&ipv6_default));
@@ -2685,56 +2686,56 @@ mod tests {
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 default route",
                 0,
-                "0.0.0.0".parse().unwrap(),
+                ip!("0.0.0.0"),
                 "0.0.0.0",
             ),
             // Input: 10.255.255.255/8 -> 10.0.0.0/8 (host bits zeroed)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 Class A with host bits",
                 8,
-                "10.255.255.255".parse().unwrap(),
+                ip!("10.255.255.255"),
                 "10.0.0.0",
             ),
             // Input: 172.31.255.255/12 -> 172.16.0.0/12 (host bits zeroed)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 large private network with host bits",
                 12,
-                "172.31.255.255".parse().unwrap(),
+                ip!("172.31.255.255"),
                 "172.16.0.0",
             ),
             // Input: 172.16.255.255/16 -> 172.16.0.0/16 (host bits zeroed)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 common allocation with host bits",
                 16,
-                "172.16.255.255".parse().unwrap(),
+                ip!("172.16.255.255"),
                 "172.16.0.0",
             ),
             // Input: 203.0.113.255/20 -> 203.0.112.0/20 (host bits zeroed)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 prefix with host bits in last 12 bits",
                 20,
-                "203.0.113.255".parse().unwrap(),
+                ip!("203.0.113.255"),
                 "203.0.112.0",
             ),
             // Input: 192.168.1.123/24 -> 192.168.1.0/24 (host bits zeroed)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 common subnet with host bits",
                 24,
-                "192.168.1.123".parse().unwrap(),
+                ip!("192.168.1.123"),
                 "192.168.1.0",
             ),
             // Input: 198.51.100.7/30 -> 198.51.100.4/30 (host bits zeroed)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 point-to-point link with host bits",
                 30,
-                "198.51.100.7".parse().unwrap(),
+                ip!("198.51.100.7"),
                 "198.51.100.4",
             ),
             // Input: 10.0.0.1/32 -> 10.0.0.1/32 (no host bits to zero)
             PrefixConversionTestCase::new_ipv4(
                 "IPv4 host route - no host bits to zero",
                 32,
-                "10.0.0.1".parse().unwrap(),
+                ip!("10.0.0.1"),
                 "10.0.0.1",
             ),
             // IPv6 test cases
@@ -2742,49 +2743,49 @@ mod tests {
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 default route",
                 0,
-                "::".parse().unwrap(),
+                ip!("::"),
                 "::",
             ),
             // Input: fd00:ffff:ffff:ffff:ffff:ffff:ffff:ffff/8 -> fd00::/8 (host bits zeroed)
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 unique local address prefix with host bits",
                 8,
-                "fd00:ffff:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap(),
+                ip!("fd00:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
                 "fd00::",
             ),
             // Input: 2001:db8:1234:5678:9abc:def0:1122:3344/32 -> 2001:db8::/32 (host bits zeroed)
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 common allocation size with host bits",
                 32,
-                "2001:db8:1234:5678:9abc:def0:1122:3344".parse().unwrap(),
+                ip!("2001:db8:1234:5678:9abc:def0:1122:3344"),
                 "2001:db8::",
             ),
             // Input: 2001:db8:1234:ffff:ffff:ffff:ffff:ffff/48 -> 2001:db8:1234::/48 (host bits zeroed)
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 site prefix with host bits in last 80 bits",
                 48,
-                "2001:db8:1234:ffff:ffff:ffff:ffff:ffff".parse().unwrap(),
+                ip!("2001:db8:1234:ffff:ffff:ffff:ffff:ffff"),
                 "2001:db8:1234::",
             ),
             // Input: 2001:db8::1234:5678:9abc:def0/64 -> 2001:db8::/64 (host bits zeroed)
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 common prefix length with host bits",
                 64,
-                "2001:db8::1234:5678:9abc:def0".parse().unwrap(),
+                ip!("2001:db8::1234:5678:9abc:def0"),
                 "2001:db8::",
             ),
             // Input: 2001:db8::ff/120 -> 2001:db8::/120 (host bits zeroed)
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 leaves only 8 host bits",
                 120,
-                "2001:db8::ff".parse().unwrap(),
+                ip!("2001:db8::ff"),
                 "2001:db8::",
             ),
             // Input: 2001:db8::1/128 -> 2001:db8::1/128 (no host bits to zero)
             PrefixConversionTestCase::new_ipv6(
                 "IPv6 host route - no host bits to zero",
                 128,
-                "2001:db8::1".parse().unwrap(),
+                ip!("2001:db8::1"),
                 "2001:db8::1",
             ),
         ];

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -1926,7 +1926,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         write_lock!(self.fanout).remove_egress(self.neighbor.host.ip());
 
         // remove peer prefixes from db
-        self.db.remove_bgp_peer_prefixes(&pc.conn.peer().ip());
+        self.db.remove_bgp_prefixes_from_peer(&pc.conn.peer().ip());
 
         FsmState::Idle
     }

--- a/bgp/src/test.rs
+++ b/bgp/src/test.rs
@@ -5,59 +5,16 @@
 use crate::config::{PeerConfig, RouterConfig};
 use crate::connection_channel::{BgpConnectionChannel, BgpListenerChannel};
 use crate::session::{FsmStateKind, SessionInfo};
+use mg_common::{cidr, ip, parse, sockaddr, wait_for_eq};
 use rdb::{Asn, Prefix};
 use std::collections::BTreeMap;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
-use std::thread::sleep;
 use std::thread::spawn;
-use std::time::Duration;
 
 type Router = crate::router::Router<BgpConnectionChannel>;
 type Dispatcher = crate::dispatcher::Dispatcher<BgpConnectionChannel>;
 type FsmEvent = crate::session::FsmEvent<BgpConnectionChannel>;
-
-macro_rules! wait_for_eq {
-    ($lhs:expr, $rhs:expr, $period:expr, $count:expr) => {
-        let mut ok = false;
-        for _ in 0..$count {
-            if $lhs == $rhs {
-                ok = true;
-                break;
-            }
-            sleep(Duration::from_secs($period));
-        }
-        if !ok {
-            assert_eq!($lhs, $rhs);
-        }
-    };
-    ($lhs:expr, $rhs:expr) => {
-        wait_for_eq!($lhs, $rhs, 1, 30);
-    };
-}
-
-macro_rules! parse {
-    ($x:expr, $err:expr) => {
-        $x.parse().expect($err)
-    };
-}
-macro_rules! ip {
-    ($x:expr) => {
-        parse!($x, "ip address")
-    };
-}
-
-macro_rules! cidr {
-    ($x:expr) => {
-        parse!($x, "ip cidr")
-    };
-}
-
-macro_rules! sockaddr {
-    ($x:expr) => {
-        parse!($x, "socket address")
-    };
-}
 
 #[test]
 fn test_basic_peering() {

--- a/ddm/src/exchange.rs
+++ b/ddm/src/exchange.rs
@@ -34,7 +34,7 @@ use http_body_util::BodyExt;
 use hyper::body::Bytes;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
-use mg_common::net::{Ipv6Prefix, TunnelOrigin, TunnelOriginV2};
+use mg_common::net::{TunnelOrigin, TunnelOriginV2};
 use oxnet::Ipv6Net;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -186,17 +186,14 @@ pub struct PathVector {
     Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema,
 )]
 pub struct PathVectorV2 {
-    pub destination: Ipv6Prefix,
+    pub destination: Ipv6Net,
     pub path: Vec<String>,
 }
 
 impl From<PathVectorV2> for PathVector {
     fn from(value: PathVectorV2) -> Self {
         PathVector {
-            destination: Ipv6Net::new_unchecked(
-                value.destination.addr,
-                value.destination.len,
-            ),
+            destination: value.destination,
             path: value.path,
         }
     }
@@ -205,10 +202,7 @@ impl From<PathVectorV2> for PathVector {
 impl From<PathVector> for PathVectorV2 {
     fn from(value: PathVector) -> Self {
         PathVectorV2 {
-            destination: Ipv6Prefix {
-                addr: value.destination.addr(),
-                len: value.destination.width(),
-            },
+            destination: value.destination,
             path: value.path,
         }
     }

--- a/ddm/src/lib.rs
+++ b/ddm/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod admin;
 pub mod db;
 pub mod discovery;
-mod exchange;
+pub mod exchange;
 pub mod oxstats;
 pub mod sm;
 pub mod sys;

--- a/mg-admin-client/Cargo.toml
+++ b/mg-admin-client/Cargo.toml
@@ -13,3 +13,4 @@ reqwest.workspace = true
 progenitor.workspace = true
 schemars.workspace = true
 chrono.workspace = true
+mg-common.workspace = true

--- a/mg-admin-client/src/lib.rs
+++ b/mg-admin-client/src/lib.rs
@@ -52,3 +52,21 @@ impl std::str::FromStr for types::Prefix4 {
         })
     }
 }
+
+impl types::Prefix4 {
+    pub fn new(ip: std::net::Ipv4Addr, length: u8) -> Self {
+        Self {
+            value: mg_common::net::zero_host_bits_v4(ip, length),
+            length,
+        }
+    }
+}
+
+impl types::Prefix6 {
+    pub fn new(ip: std::net::Ipv6Addr, length: u8) -> Self {
+        Self {
+            value: mg_common::net::zero_host_bits_v6(ip, length),
+            length,
+        }
+    }
+}

--- a/mg-admin-client/src/lib.rs
+++ b/mg-admin-client/src/lib.rs
@@ -56,7 +56,7 @@ impl std::str::FromStr for types::Prefix4 {
 impl types::Prefix4 {
     pub fn new(ip: std::net::Ipv4Addr, length: u8) -> Self {
         Self {
-            value: mg_common::net::zero_host_bits_v4(ip, length),
+            value: mg_common::net::zero_ipv4_addr_host_bits(ip, length),
             length,
         }
     }
@@ -65,7 +65,7 @@ impl types::Prefix4 {
 impl types::Prefix6 {
     pub fn new(ip: std::net::Ipv6Addr, length: u8) -> Self {
         Self {
-            value: mg_common::net::zero_host_bits_v6(ip, length),
+            value: mg_common::net::zero_ipv6_addr_host_bits(ip, length),
             length,
         }
     }

--- a/mg-common/src/lib.rs
+++ b/mg-common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod net;
 pub mod nexus;
 pub mod smf;
 pub mod stats;
+pub mod test;
 
 #[macro_export]
 macro_rules! lock {

--- a/mg-common/src/net.rs
+++ b/mg-common/src/net.rs
@@ -1,7 +1,7 @@
 use oxnet::IpNet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::net::Ipv6Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
@@ -45,4 +45,22 @@ impl From<TunnelOrigin> for TunnelOriginV2 {
             metric: value.metric,
         }
     }
+}
+
+pub fn zero_host_bits_v4(ip: Ipv4Addr, length: u8) -> Ipv4Addr {
+    let mask = match length {
+        0 => 0,
+        _ => (!0u32) << (32 - length),
+    };
+
+    Ipv4Addr::from_bits(ip.to_bits() & mask)
+}
+
+pub fn zero_host_bits_v6(ip: Ipv6Addr, length: u8) -> Ipv6Addr {
+    let mask = match length {
+        0 => 0,
+        _ => (!0u128) << (128 - length),
+    };
+
+    Ipv6Addr::from_bits(ip.to_bits() & mask)
 }

--- a/mg-common/src/net.rs
+++ b/mg-common/src/net.rs
@@ -47,7 +47,7 @@ impl From<TunnelOrigin> for TunnelOriginV2 {
     }
 }
 
-pub fn zero_host_bits_v4(ip: Ipv4Addr, length: u8) -> Ipv4Addr {
+pub fn zero_ipv4_addr_host_bits(ip: Ipv4Addr, length: u8) -> Ipv4Addr {
     let mask = match length {
         0 => 0,
         _ => (!0u32) << (32 - length),
@@ -56,7 +56,7 @@ pub fn zero_host_bits_v4(ip: Ipv4Addr, length: u8) -> Ipv4Addr {
     Ipv4Addr::from_bits(ip.to_bits() & mask)
 }
 
-pub fn zero_host_bits_v6(ip: Ipv6Addr, length: u8) -> Ipv6Addr {
+pub fn zero_ipv6_addr_host_bits(ip: Ipv6Addr, length: u8) -> Ipv6Addr {
     let mask = match length {
         0 => 0,
         _ => (!0u128) << (128 - length),

--- a/mg-common/src/net.rs
+++ b/mg-common/src/net.rs
@@ -1,7 +1,7 @@
-use oxnet::{IpNet, Ipv4Net, Ipv6Net};
+use oxnet::IpNet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv6Addr;
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
@@ -18,7 +18,7 @@ pub struct TunnelOrigin {
     Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
 )]
 pub struct TunnelOriginV2 {
-    pub overlay_prefix: IpPrefix,
+    pub overlay_prefix: IpNet,
     pub boundary_addr: Ipv6Addr,
     pub vni: u32,
     #[serde(default)]
@@ -28,14 +28,7 @@ pub struct TunnelOriginV2 {
 impl From<TunnelOriginV2> for TunnelOrigin {
     fn from(value: TunnelOriginV2) -> Self {
         TunnelOrigin {
-            overlay_prefix: match value.overlay_prefix {
-                IpPrefix::V4(x) => {
-                    IpNet::V4(Ipv4Net::new_unchecked(x.addr, x.len))
-                }
-                IpPrefix::V6(x) => {
-                    IpNet::V6(Ipv6Net::new_unchecked(x.addr, x.len))
-                }
-            },
+            overlay_prefix: value.overlay_prefix,
             boundary_addr: value.boundary_addr,
             vni: value.vni,
             metric: value.metric,
@@ -46,43 +39,10 @@ impl From<TunnelOriginV2> for TunnelOrigin {
 impl From<TunnelOrigin> for TunnelOriginV2 {
     fn from(value: TunnelOrigin) -> Self {
         TunnelOriginV2 {
-            overlay_prefix: match value.overlay_prefix {
-                IpNet::V4(x) => IpPrefix::V4(Ipv4Prefix {
-                    addr: x.addr(),
-                    len: x.width(),
-                }),
-                IpNet::V6(x) => IpPrefix::V6(Ipv6Prefix {
-                    addr: x.addr(),
-                    len: x.width(),
-                }),
-            },
+            overlay_prefix: value.overlay_prefix,
             boundary_addr: value.boundary_addr,
             vni: value.vni,
             metric: value.metric,
         }
     }
-}
-
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
-)]
-pub struct Ipv6Prefix {
-    pub addr: Ipv6Addr,
-    pub len: u8,
-}
-
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
-)]
-pub struct Ipv4Prefix {
-    pub addr: Ipv4Addr,
-    pub len: u8,
-}
-
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
-)]
-pub enum IpPrefix {
-    V4(Ipv4Prefix),
-    V6(Ipv6Prefix),
 }

--- a/mg-common/src/test.rs
+++ b/mg-common/src/test.rs
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Test utilities and macros for use across multiple crates.
+
+#[macro_export]
+macro_rules! wait_for_eq {
+    ($lhs:expr, $rhs:expr, $period:expr, $count:expr) => {
+        let mut ok = false;
+        for _ in 0..$count {
+            if $lhs == $rhs {
+                ok = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs($period));
+        }
+        if !ok {
+            assert_eq!($lhs, $rhs);
+        }
+    };
+    ($lhs:expr, $rhs:expr) => {
+        wait_for_eq!($lhs, $rhs, 1, 30);
+    };
+}
+
+#[macro_export]
+macro_rules! parse {
+    ($x:expr, $err:expr) => {
+        $x.parse().expect($err)
+    };
+}
+
+#[macro_export]
+macro_rules! ip {
+    ($x:expr) => {
+        parse!($x, "ip address")
+    };
+}
+
+#[macro_export]
+macro_rules! cidr {
+    ($x:expr) => {
+        parse!($x, "ip cidr")
+    };
+}
+
+#[macro_export]
+macro_rules! sockaddr {
+    ($x:expr) => {
+        parse!($x, "socket address")
+    };
+}

--- a/mg-common/src/test.rs
+++ b/mg-common/src/test.rs
@@ -7,9 +7,29 @@
 #[macro_export]
 macro_rules! wait_for_eq {
     ($lhs:expr, $rhs:expr, $period:expr, $count:expr) => {
+        wait_for!($lhs, ==, $rhs, $period, $count);
+    };
+    ($lhs:expr, $rhs:expr) => {
+        wait_for!($lhs, ==, $rhs, 1, 30);
+    };
+}
+
+#[macro_export]
+macro_rules! wait_for_neq {
+    ($lhs:expr, $rhs:expr, $period:expr, $count:expr) => {
+        wait_for!($lhs, !=, $rhs, $period, $count);
+    };
+    ($lhs:expr, $rhs:expr) => {
+        wait_for!($lhs, !=, $rhs, 1, 30);
+    };
+}
+
+#[macro_export]
+macro_rules! wait_for {
+    ($lhs:expr, $op:tt, $rhs:expr, $period:expr, $count:expr) => {
         let mut ok = false;
         for _ in 0..$count {
-            if $lhs == $rhs {
+            if $lhs $op $rhs {
                 ok = true;
                 break;
             }
@@ -19,8 +39,8 @@ macro_rules! wait_for_eq {
             assert_eq!($lhs, $rhs);
         }
     };
-    ($lhs:expr, $rhs:expr) => {
-        wait_for_eq!($lhs, $rhs, 1, 30);
+    ($lhs:expr, $op:tt, $rhs:expr) => {
+        wait_for!($lhs, $op, $rhs, 1, 30);
     };
 }
 

--- a/mg-common/src/test.rs
+++ b/mg-common/src/test.rs
@@ -4,13 +4,16 @@
 
 //! Test utilities and macros for use across multiple crates.
 
+pub const DEFAULT_INTERVAL: u64 = 1;
+pub const DEFAULT_ITERATIONS: u64 = 30;
+
 #[macro_export]
 macro_rules! wait_for_eq {
     ($lhs:expr, $rhs:expr, $period:expr, $count:expr) => {
         wait_for!($lhs, ==, $rhs, $period, $count);
     };
     ($lhs:expr, $rhs:expr) => {
-        wait_for!($lhs, ==, $rhs, 1, 30);
+        wait_for!($lhs, ==, $rhs, mg_common::test::DEFAULT_INTERVAL, mg_common::test::DEFAULT_ITERATIONS);
     };
 }
 
@@ -20,7 +23,7 @@ macro_rules! wait_for_neq {
         wait_for!($lhs, !=, $rhs, $period, $count);
     };
     ($lhs:expr, $rhs:expr) => {
-        wait_for!($lhs, !=, $rhs, 1, 30);
+        wait_for!($lhs, !=, $rhs, mg_common::test::DEFAULT_INTERVAL, mg_common::test::DEFAULT_ITERATIONS);
     };
 }
 
@@ -40,7 +43,7 @@ macro_rules! wait_for {
         }
     };
     ($lhs:expr, $op:tt, $rhs:expr) => {
-        wait_for!($lhs, $op, $rhs, 1, 30);
+        wait_for!($lhs, $op, $rhs, mg_common::test::DEFAULT_INTERVAL, mg_common::test::DEFAULT_ITERATIONS);
     };
 }
 

--- a/mg-ddm-verify/Cargo.toml
+++ b/mg-ddm-verify/Cargo.toml
@@ -12,3 +12,5 @@ oxide-tokio-rt.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+ddm = { version = "0.1.0", path = "../ddm" }
+oxnet.workspace = true

--- a/mgadm/Cargo.toml
+++ b/mgadm/Cargo.toml
@@ -21,3 +21,4 @@ colored.workspace = true
 humantime.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+oxnet.workspace = true

--- a/mgadm/src/bgp.rs
+++ b/mgadm/src/bgp.rs
@@ -499,10 +499,9 @@ impl From<Neighbor> for types::Neighbor {
                         .clone()
                         .into_iter()
                         .map(|x| {
-                            types::Prefix::V4(types::Prefix4 {
-                                length: x.length,
-                                value: x.value,
-                            })
+                            types::Prefix::V4(types::Prefix4::new(
+                                x.value, x.length,
+                            ))
                         })
                         .collect(),
                 ),
@@ -514,10 +513,9 @@ impl From<Neighbor> for types::Neighbor {
                         .clone()
                         .into_iter()
                         .map(|x| {
-                            types::Prefix::V4(types::Prefix4 {
-                                length: x.length,
-                                value: x.value,
-                            })
+                            types::Prefix::V4(types::Prefix4::new(
+                                x.value, x.length,
+                            ))
                         })
                         .collect(),
                 ),
@@ -775,10 +773,7 @@ async fn create_origin4(originate: Originate4, c: Client) -> Result<()> {
             .prefixes
             .clone()
             .into_iter()
-            .map(|x| types::Prefix4 {
-                length: x.length,
-                value: x.value,
-            })
+            .map(|x| types::Prefix4::new(x.value, x.length))
             .collect(),
     })
     .await?;
@@ -792,10 +787,7 @@ async fn update_origin4(originate: Originate4, c: Client) -> Result<()> {
             .prefixes
             .clone()
             .into_iter()
-            .map(|x| types::Prefix4 {
-                length: x.length,
-                value: x.value,
-            })
+            .map(|x| types::Prefix4::new(x.value, x.length))
             .collect(),
     })
     .await?;

--- a/mgadm/src/static_routing.rs
+++ b/mgadm/src/static_routing.rs
@@ -50,10 +50,10 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
             let arg = types::AddStaticRoute4Request {
                 routes: types::StaticRoute4List {
                     list: vec![types::StaticRoute4 {
-                        prefix: types::Prefix4 {
-                            value: route.destination.addr(),
-                            length: route.destination.width(),
-                        },
+                        prefix: types::Prefix4::new(
+                            route.destination.addr(),
+                            route.destination.width(),
+                        ),
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
                         rib_priority: route.rib_priority,
@@ -66,10 +66,10 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
             let arg = types::DeleteStaticRoute4Request {
                 routes: types::StaticRoute4List {
                     list: vec![types::StaticRoute4 {
-                        prefix: types::Prefix4 {
-                            value: route.destination.addr(),
-                            length: route.destination.width(),
-                        },
+                        prefix: types::Prefix4::new(
+                            route.destination.addr(),
+                            route.destination.width(),
+                        ),
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
                         rib_priority: route.rib_priority,

--- a/mgadm/src/static_routing.rs
+++ b/mgadm/src/static_routing.rs
@@ -117,3 +117,66 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_route_conversion_to_api_types() {
+        // IPv4 test case
+        let route4 = StaticRoute4 {
+            destination: Ipv4Net::from_str("192.168.0.0/16").unwrap(),
+            nexthop: Ipv4Addr::from_str("10.0.0.1").unwrap(),
+            vlan_id: Some(100),
+            rib_priority: 50,
+        };
+
+        let api_route4 = types::StaticRoute4 {
+            prefix: types::Prefix4::new(
+                route4.destination.addr(),
+                route4.destination.width(),
+            ),
+            nexthop: route4.nexthop,
+            vlan_id: route4.vlan_id,
+            rib_priority: route4.rib_priority,
+        };
+
+        assert_eq!(
+            api_route4.prefix.value,
+            Ipv4Addr::from_str("192.168.0.0").unwrap()
+        );
+        assert_eq!(api_route4.prefix.length, 16);
+        assert_eq!(api_route4.nexthop, route4.nexthop);
+        assert_eq!(api_route4.vlan_id, route4.vlan_id);
+        assert_eq!(api_route4.rib_priority, route4.rib_priority);
+
+        // IPv6 test case
+        let route6 = StaticRoute6 {
+            destination: Ipv6Net::from_str("fd00::/8").unwrap(),
+            nexthop: Ipv6Addr::from_str("fe80::1").unwrap(),
+            vlan_id: Some(300),
+            rib_priority: 75,
+        };
+
+        let api_route6 = types::StaticRoute6 {
+            prefix: types::Prefix6::new(
+                route6.destination.addr(),
+                route6.destination.width(),
+            ),
+            nexthop: route6.nexthop,
+            vlan_id: route6.vlan_id,
+            rib_priority: route6.rib_priority,
+        };
+
+        assert_eq!(
+            api_route6.prefix.value,
+            Ipv6Addr::from_str("fd00::").unwrap()
+        );
+        assert_eq!(api_route6.prefix.length, 8);
+        assert_eq!(api_route6.nexthop, route6.nexthop);
+        assert_eq!(api_route6.vlan_id, route6.vlan_id);
+        assert_eq!(api_route6.rib_priority, route6.rib_priority);
+    }
+}

--- a/mgadm/src/static_routing.rs
+++ b/mgadm/src/static_routing.rs
@@ -6,10 +6,9 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 use mg_admin_client::types;
 use mg_admin_client::Client;
+use oxnet::{Ipv4Net, Ipv6Net};
 use rdb::DEFAULT_RIB_PRIORITY_STATIC;
-use std::net::{AddrParseError, Ipv4Addr, Ipv6Addr};
-use std::num::ParseIntError;
-use thiserror::Error;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -19,30 +18,6 @@ pub enum Commands {
     GetV6Routes,
     AddV6Route(StaticRoute6),
     RemoveV6Routes(StaticRoute6),
-}
-
-#[derive(Debug, Error)]
-pub enum Ipv4NetParseError {
-    #[error("expected CIDR representation <addr>/<mask>")]
-    Cidr,
-
-    #[error("address parse error: {0}")]
-    Addr(#[from] AddrParseError),
-
-    #[error("mask parse error: {0}")]
-    Mask(#[from] ParseIntError),
-}
-
-#[derive(Debug, Error)]
-pub enum Ipv6NetParseError {
-    #[error("expected CIDR representation <addr>/<mask>")]
-    Cidr,
-
-    #[error("address parse error: {0}")]
-    Addr(#[from] AddrParseError),
-
-    #[error("mask parse error: {0}")]
-    Mask(#[from] ParseIntError),
 }
 
 #[derive(Debug, Args)]
@@ -55,28 +30,6 @@ pub struct StaticRoute4 {
     pub rib_priority: u8,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct Ipv4Net {
-    pub addr: Ipv4Addr,
-    pub len: u8,
-}
-
-impl std::str::FromStr for Ipv4Net {
-    type Err = Ipv4NetParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split('/').collect();
-        if parts.len() < 2 {
-            return Err(Ipv4NetParseError::Cidr);
-        }
-
-        Ok(Ipv4Net {
-            addr: Ipv4Addr::from_str(parts[0])?,
-            len: u8::from_str(parts[1])?,
-        })
-    }
-}
-
 #[derive(Debug, Args)]
 pub struct StaticRoute6 {
     pub destination: Ipv6Net,
@@ -85,28 +38,6 @@ pub struct StaticRoute6 {
     pub vlan_id: Option<u16>,
     #[clap(long, default_value_t = DEFAULT_RIB_PRIORITY_STATIC)]
     pub rib_priority: u8,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Ipv6Net {
-    pub addr: Ipv6Addr,
-    pub len: u8,
-}
-
-impl std::str::FromStr for Ipv6Net {
-    type Err = Ipv6NetParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split('/').collect();
-        if parts.len() < 2 {
-            return Err(Ipv6NetParseError::Cidr);
-        }
-
-        Ok(Ipv6Net {
-            addr: Ipv6Addr::from_str(parts[0])?,
-            len: u8::from_str(parts[1])?,
-        })
-    }
 }
 
 pub async fn commands(command: Commands, client: Client) -> Result<()> {
@@ -120,8 +51,8 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                 routes: types::StaticRoute4List {
                     list: vec![types::StaticRoute4 {
                         prefix: types::Prefix4 {
-                            value: route.destination.addr,
-                            length: route.destination.len,
+                            value: route.destination.addr(),
+                            length: route.destination.width(),
                         },
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
@@ -136,8 +67,8 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                 routes: types::StaticRoute4List {
                     list: vec![types::StaticRoute4 {
                         prefix: types::Prefix4 {
-                            value: route.destination.addr,
-                            length: route.destination.len,
+                            value: route.destination.addr(),
+                            length: route.destination.width(),
                         },
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
@@ -156,8 +87,8 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                 routes: types::StaticRoute6List {
                     list: vec![types::StaticRoute6 {
                         prefix: types::Prefix6 {
-                            value: route.destination.addr,
-                            length: route.destination.len,
+                            value: route.destination.addr(),
+                            length: route.destination.width(),
                         },
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,
@@ -172,8 +103,8 @@ pub async fn commands(command: Commands, client: Client) -> Result<()> {
                 routes: types::StaticRoute6List {
                     list: vec![types::StaticRoute6 {
                         prefix: types::Prefix6 {
-                            value: route.destination.addr,
-                            length: route.destination.len,
+                            value: route.destination.addr(),
+                            length: route.destination.width(),
                         },
                         nexthop: route.nexthop,
                         vlan_id: route.vlan_id,

--- a/mgd/src/bgp_param.rs
+++ b/mgd/src/bgp_param.rs
@@ -4,7 +4,7 @@
 
 use bgp::config::PeerConfig;
 use bgp::session::{FsmStateKind, MessageHistory};
-use rdb::{ImportExportPolicy, Path, PolicyAction, Prefix4};
+use rdb::{ImportExportPolicy, Path, PolicyAction, Prefix4, Prefix6};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
@@ -185,6 +185,15 @@ pub struct Origin4 {
 
     /// Set of prefixes to originate.
     pub prefixes: Vec<Prefix4>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct Origin6 {
+    /// ASN of the router to originate from.
+    pub asn: u32,
+
+    /// Set of prefixes to originate.
+    pub prefixes: Vec<Prefix6>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -277,7 +277,7 @@ fn initialize_static_routes(db: &rdb::Db) {
     let (good, bad) = routes.into_iter().fold(
         (Vec::new(), Vec::new()),
         |(mut good, mut bad), srk| {
-            match srk.prefix.host_bits_are_zero() {
+            match srk.prefix.host_bits_are_unset() {
                 true => good.push(srk),
                 false => bad.push(srk),
             }

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -271,6 +271,7 @@ fn initialize_static_routes(db: &rdb::Db) {
     let routes = db
         .get_static(AddressFamily::All)
         .expect("failed to get static routes from db");
+    // XXX: remove old routes where host bits are non-zero
     db.add_static_routes(&routes).unwrap_or_else(|e| {
         panic!("failed to initialize static routes {routes:#?}: {e}")
     })

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -12,7 +12,7 @@ use mg_common::lock;
 use mg_common::log::init_logger;
 use mg_common::stats::MgLowerStats;
 use rand::Fill;
-use rdb::{BfdPeerConfig, BgpNeighborInfo, BgpRouterInfo};
+use rdb::{AddressFamily, BfdPeerConfig, BgpNeighborInfo, BgpRouterInfo};
 use signal::handle_signals;
 use slog::{error, Logger};
 use std::collections::BTreeMap;
@@ -269,7 +269,7 @@ fn start_bfd_sessions(
 
 fn initialize_static_routes(db: &rdb::Db) {
     let routes = db
-        .get_static4()
+        .get_static(AddressFamily::All)
         .expect("failed to get static routes from db");
     db.add_static_routes(&routes).unwrap_or_else(|e| {
         panic!("failed to initialize static routes {routes:#?}: {e}")

--- a/mgd/src/oxstats.rs
+++ b/mgd/src/oxstats.rs
@@ -709,7 +709,8 @@ impl Stats {
         let mut samples = Vec::new();
 
         let mut count = 0usize;
-        for (_prefix, paths) in self.db.full_rib().iter() {
+        for (_prefix, paths) in self.db.full_rib(rdb::AddressFamily::All).iter()
+        {
             count += paths.len();
         }
         samples.push(rib_quantity!(

--- a/mgd/src/static_admin.rs
+++ b/mgd/src/static_admin.rs
@@ -42,7 +42,7 @@ pub struct StaticRoute4 {
 impl From<StaticRoute4> for StaticRouteKey {
     fn from(val: StaticRoute4) -> Self {
         StaticRouteKey {
-            prefix: val.prefix.into(),
+            prefix: Prefix4::new(val.prefix.value, val.prefix.length).into(),
             nexthop: val.nexthop.into(),
             vlan_id: val.vlan_id,
             rib_priority: val.rib_priority,
@@ -76,7 +76,7 @@ pub struct StaticRoute6 {
 impl From<StaticRoute6> for StaticRouteKey {
     fn from(val: StaticRoute6) -> Self {
         StaticRouteKey {
-            prefix: val.prefix.into(),
+            prefix: Prefix6::new(val.prefix.value, val.prefix.length).into(),
             nexthop: val.nexthop.into(),
             vlan_id: val.vlan_id,
             rib_priority: val.rib_priority,

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -1084,6 +1084,85 @@
           }
         }
       }
+    },
+    "/static/route6": {
+      "get": {
+        "operationId": "static_list_v6_routes",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Map_of_Set_of_Path",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Path"
+                    },
+                    "uniqueItems": true
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "static_add_v6_route",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddStaticRoute6Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "static_remove_v6_route",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteStaticRoute6Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1122,6 +1201,17 @@
         "properties": {
           "routes": {
             "$ref": "#/components/schemas/StaticRoute4List"
+          }
+        },
+        "required": [
+          "routes"
+        ]
+      },
+      "AddStaticRoute6Request": {
+        "type": "object",
+        "properties": {
+          "routes": {
+            "$ref": "#/components/schemas/StaticRoute6List"
           }
         },
         "required": [
@@ -2018,6 +2108,17 @@
         "properties": {
           "routes": {
             "$ref": "#/components/schemas/StaticRoute4List"
+          }
+        },
+        "required": [
+          "routes"
+        ]
+      },
+      "DeleteStaticRoute6Request": {
+        "type": "object",
+        "properties": {
+          "routes": {
+            "$ref": "#/components/schemas/StaticRoute6List"
           }
         },
         "required": [
@@ -3314,6 +3415,48 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/StaticRoute4"
+            }
+          }
+        },
+        "required": [
+          "list"
+        ]
+      },
+      "StaticRoute6": {
+        "type": "object",
+        "properties": {
+          "nexthop": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "prefix": {
+            "$ref": "#/components/schemas/Prefix6"
+          },
+          "rib_priority": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "vlan_id": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "nexthop",
+          "prefix",
+          "rib_priority"
+        ]
+      },
+      "StaticRoute6List": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StaticRoute6"
             }
           }
         },

--- a/openapi/mg-admin.json
+++ b/openapi/mg-admin.json
@@ -552,6 +552,117 @@
         }
       }
     },
+    "/bgp/config/origin6": {
+      "get": {
+        "operationId": "read_origin6",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "asn",
+            "description": "ASN of the router to get imported prefixes from.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Origin6"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "create_origin6",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Origin6"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "post": {
+        "operationId": "update_origin6",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Origin6"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "delete_origin6",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "asn",
+            "description": "ASN of the router to get imported prefixes from.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/bgp/config/router": {
       "get": {
         "operationId": "read_router",
@@ -2863,6 +2974,28 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Prefix4"
+            }
+          }
+        },
+        "required": [
+          "asn",
+          "prefixes"
+        ]
+      },
+      "Origin6": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "description": "ASN of the router to originate from.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "prefixes": {
+            "description": "Set of prefixes to originate.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prefix6"
             }
           }
         },

--- a/rdb/src/bestpath.rs
+++ b/rdb/src/bestpath.rs
@@ -4,7 +4,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::{db::Rib, types::Path, Prefix};
+use crate::types::Path;
 use itertools::Itertools;
 
 /// The bestpath algorithms chooses the best set of up to `max` paths for a
@@ -29,17 +29,11 @@ use itertools::Itertools;
 /// is larger than `max`, return the first `max` entries. This is a set,
 /// so "first" has no semantic meaning, consider it to be random. If the
 /// selection group is smaller than `max`, the entire group is returned.
-pub fn bestpaths(
-    prefix: Prefix,
-    rib: &Rib,
-    max: usize,
-) -> Option<BTreeSet<Path>> {
-    let candidates = rib.get(&prefix)?;
-
+pub fn bestpaths(paths: &BTreeSet<Path>, max: usize) -> Option<BTreeSet<Path>> {
     // Partition the choice space on whether routes are shutdown or not. If we
     // only have shutdown routes then use those. Otherwise use active routes
     let (active, shutdown): (BTreeSet<&Path>, BTreeSet<&Path>) =
-        candidates.iter().partition(|x| x.shutdown);
+        paths.iter().partition(|x| x.shutdown);
     let candidates = if active.is_empty() { shutdown } else { active };
 
     // Filter down to paths with the best (lowest) RIB priority. This is a
@@ -111,23 +105,20 @@ mod test {
 
     use super::bestpaths;
     use crate::{
-        db::Rib, BgpPathProperties, Path, Prefix, Prefix4,
-        DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC,
+        BgpPathProperties, Path, DEFAULT_RIB_PRIORITY_BGP,
+        DEFAULT_RIB_PRIORITY_STATIC,
     };
 
+    // Bestpaths is purely a function of the path info itself, so we don't
+    // need a Rib or Prefix, just a set of candidate paths and a set of
+    // expected paths.
     #[test]
     fn test_bestpath() {
-        let mut rib = Rib::default();
-        let target: Prefix4 = "198.51.100.0/24".parse().unwrap();
+        let mut max: usize = 2;
         let remote_ip1 = IpAddr::from_str("203.0.113.1").unwrap();
         let remote_ip2 = IpAddr::from_str("203.0.113.2").unwrap();
         let remote_ip3 = IpAddr::from_str("203.0.113.3").unwrap();
         let remote_ip4 = IpAddr::from_str("203.0.113.4").unwrap();
-
-        // The best path for an empty RIB should be empty
-        const MAX_ECMP_FANOUT: usize = 2;
-        let result = bestpaths(target.into(), &rib, MAX_ECMP_FANOUT);
-        assert!(result.is_none());
 
         // Add one path and make sure we get it back
         let path1 = Path {
@@ -140,18 +131,20 @@ mod test {
                 id: 47,
                 med: Some(75),
                 local_pref: Some(100),
-                as_path: vec![64500, 64501, 64502],
+                as_path: vec![470, 64501, 64502],
                 stale: None,
             }),
             vlan_id: None,
         };
-        rib.insert(target.into(), BTreeSet::from([path1.clone()]));
 
-        let result = bestpaths(target.into(), &rib, MAX_ECMP_FANOUT).unwrap();
+        let mut candidates = BTreeSet::<Path>::new();
+        candidates.insert(path1.clone());
+
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result, BTreeSet::from([path1.clone()]));
 
-        // Add another path to the same prefix and make sure bestpath returns both
+        // Add path2:
         let mut path2 = Path {
             nexthop: remote_ip2,
             rib_priority: DEFAULT_RIB_PRIORITY_BGP,
@@ -162,21 +155,26 @@ mod test {
                 id: 48,
                 med: Some(75),
                 local_pref: Some(100),
-                as_path: vec![64500, 64501, 64502],
+                as_path: vec![480, 64501, 64502],
                 stale: None,
             }),
             vlan_id: None,
         };
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path2.clone());
-        let result = bestpaths(target.into(), &rib, MAX_ECMP_FANOUT).unwrap();
+
+        candidates.insert(path2.clone());
+        let result = bestpaths(&candidates, max).unwrap();
+
+        // we expect both paths to be selected because path1 and path2 have:
+        // - matching local-pref
+        // - matching as-path-len
+        // - matching med
         assert_eq!(result.len(), 2);
         assert_eq!(result, BTreeSet::from([path1.clone(), path2.clone()]));
 
-        // Add a third path and make sure that
-        //   - results are limited to 2 paths when max is 2
-        //   - we get all three paths back wihen max is 3
+        // Add path3 with:
+        // - matching local-pref
+        // - matching as-path-len
+        // - worse (higher) med
         let mut path3 = Path {
             nexthop: remote_ip3,
             rib_priority: DEFAULT_RIB_PRIORITY_BGP,
@@ -187,42 +185,41 @@ mod test {
                 id: 49,
                 med: Some(100),
                 local_pref: Some(100),
-                as_path: vec![64500, 64501, 64502],
+                as_path: vec![490, 64501, 64502],
                 stale: None,
             }),
             vlan_id: None,
         };
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path3.clone());
-        let result = bestpaths(target.into(), &rib, MAX_ECMP_FANOUT).unwrap();
+        let mut candidates = result.clone();
+        candidates.insert(path3.clone());
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 2);
         // paths 1 and 2 should always be selected since they have the lowest MED
         assert_eq!(result, BTreeSet::from([path1.clone(), path2.clone()]));
 
-        // set the med to 75 to get an ecmp group of size 3
-        rib.get_mut(&Prefix::V4(target)).unwrap().remove(&path3);
+        // increase max paths to 3
+        max = 3;
+
+        // set the med to 75 (matching path1/path2) and re-run bestpath w/
+        // max paths set to 3. path3 should now be part of the ecmp group returned.
+        let mut candidates = result.clone();
+        candidates.remove(&path3);
         path3.bgp.as_mut().unwrap().med = Some(75);
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path3.clone());
-        let result =
-            bestpaths(target.into(), &rib, MAX_ECMP_FANOUT + 1).unwrap();
+        candidates.insert(path3.clone());
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(
             result,
             BTreeSet::from([path1.clone(), path2.clone(), path3.clone()])
         );
 
-        // bump the local_pref on route 2, this should make it the singular
-        // best path
-        rib.get_mut(&Prefix::V4(target)).unwrap().remove(&path2);
+        // bump the local_pref on path2, this should make it the singular
+        // best path regardless of max paths
+        let mut candidates = result.clone();
+        candidates.remove(&path2);
         path2.bgp.as_mut().unwrap().local_pref = Some(125);
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path2.clone());
-        let result =
-            bestpaths(target.into(), &rib, MAX_ECMP_FANOUT + 1).unwrap();
+        candidates.insert(path2.clone());
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result, BTreeSet::from([path2.clone()]));
 
@@ -230,6 +227,7 @@ mod test {
         // - path 4 loses to BGP paths with higher RIB priority
         // - path 4 wins over BGP paths with lower RIB priority
         // - path 4 wins over BGP paths with equal RIB priority
+        //   > static is preferred over bgp when RIB priority matches
         let mut path4 = Path {
             nexthop: remote_ip4,
             rib_priority: u8::MAX,
@@ -237,33 +235,33 @@ mod test {
             bgp: None,
             vlan_id: None,
         };
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path4.clone());
-        let result = bestpaths(target.into(), &rib, MAX_ECMP_FANOUT).unwrap();
+        let mut candidates = result.clone();
+        candidates.insert(path4.clone());
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 1);
+        // path4 (static) has worse rib priority, path2 should win because it
+        // has the best (highest) local-pref among bgp paths (paths 1-3)
         assert_eq!(result, BTreeSet::from([path2.clone()]));
 
-        // Lower the RIB Priority to beat BGP
-        rib.get_mut(&Prefix::V4(target)).unwrap().remove(&path4);
+        // Lower the RIB Priority (better)
+        let mut candidates = result.clone();
+        candidates.remove(&path4);
         path4.rib_priority = DEFAULT_RIB_PRIORITY_STATIC;
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path4.clone());
-        let result =
-            bestpaths(target.into(), &rib, MAX_ECMP_FANOUT + 1).unwrap();
+        candidates.insert(path4.clone());
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 1);
+        // path4 (static) has the best (lower) rib priority
         assert_eq!(result, BTreeSet::from([path4.clone()]));
 
-        // Raise the RIB Priority to match BGP
-        rib.get_mut(&Prefix::V4(target)).unwrap().remove(&path4);
+        // Raise the RIB Priority equal to BGP (paths 1-3)
+        let mut candidates = result.clone();
+        candidates.remove(&path4);
         path4.rib_priority = DEFAULT_RIB_PRIORITY_BGP;
-        rib.get_mut(&Prefix::V4(target))
-            .unwrap()
-            .insert(path4.clone());
-        let result =
-            bestpaths(target.into(), &rib, MAX_ECMP_FANOUT + 1).unwrap();
+        candidates.insert(path4.clone());
+        let result = bestpaths(&candidates, max).unwrap();
         assert_eq!(result.len(), 1);
+        // path4 (static) wins due to protocol preference
+        // i.e. static > bgp when rib priority matches
         assert_eq!(result, BTreeSet::from([path4.clone()]));
     }
 }

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -808,6 +808,8 @@ impl Db {
                 };
 
                 let key = String::from_utf8_lossy(&key);
+                // XXX: figure out how to handle removal of old static routes
+                //      where the host bits aren't zeroed out
                 let rkey: StaticRouteKey = match serde_json::from_str(&key) {
                     Ok(item) => item,
                     Err(e) => {

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -311,18 +311,6 @@ impl From<Prefix6> for Prefix {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct BgpAttributes4 {
-    pub origin: Ipv4Addr,
-    pub path: Vec<Asn>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct BgpAttributes6 {
-    pub origin: Ipv4Addr,
-    pub path: Vec<Asn>,
-}
-
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Asn {
     TwoOctet(u16),
@@ -359,12 +347,6 @@ impl Asn {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub enum Status {
-    Up,
-    Down,
-}
-
 pub fn to_buf<T: ?Sized + Serialize>(value: &T) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     ciborium::into_writer(&value, &mut buf)?;
@@ -393,27 +375,6 @@ impl FromStr for PolicyAction {
 pub struct Policy {
     pub action: PolicyAction,
     pub priority: u16,
-}
-
-#[derive(Clone, Default, Debug)]
-pub struct OriginChangeSet {
-    pub added: HashSet<Prefix4>,
-    pub removed: HashSet<Prefix4>,
-}
-
-impl OriginChangeSet {
-    pub fn added<V: Into<HashSet<Prefix4>>>(v: V) -> Self {
-        Self {
-            added: v.into(),
-            ..Default::default()
-        }
-    }
-    pub fn removed<V: Into<HashSet<Prefix4>>>(v: V) -> Self {
-        Self {
-            removed: v.into(),
-            ..Default::default()
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::fmt::{self, Formatter};
 use std::hash::Hash;
@@ -465,4 +465,11 @@ impl From<Prefix6> for PrefixChangeNotification {
             changed: BTreeSet::from([value.into()]),
         }
     }
+}
+
+#[derive(Clone, Copy, Eq, Debug, Ord, PartialEq, PartialOrd)]
+pub enum AddressFamily {
+    Ipv4,
+    Ipv6,
+    All,
 }

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -5,6 +5,7 @@
 use crate::error::Error;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use mg_common::net::{zero_host_bits_v4, zero_host_bits_v6};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -200,6 +201,13 @@ impl Ord for Prefix4 {
 }
 
 impl Prefix4 {
+    pub fn new(ip: Ipv4Addr, length: u8) -> Self {
+        Self {
+            value: zero_host_bits_v4(ip, length),
+            length,
+        }
+    }
+
     pub fn db_key(&self) -> Vec<u8> {
         let mut buf: Vec<u8> = self.value.octets().into();
         buf.push(self.length);
@@ -270,6 +278,15 @@ impl Ord for Prefix6 {
 impl fmt::Display for Prefix6 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}", self.value, self.length)
+    }
+}
+
+impl Prefix6 {
+    pub fn new(ip: Ipv6Addr, length: u8) -> Self {
+        Self {
+            value: zero_host_bits_v6(ip, length),
+            length,
+        }
     }
 }
 

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -215,7 +215,7 @@ impl Ord for Prefix4 {
 impl Prefix4 {
     pub fn new(ip: Ipv4Addr, length: u8) -> Self {
         let mut new = Self { value: ip, length };
-        new.zero_host_bits();
+        new.unset_host_bits();
         new
     }
 
@@ -239,7 +239,7 @@ impl Prefix4 {
         }
     }
 
-    pub fn host_bits_are_zero(&self) -> bool {
+    pub fn host_bits_are_unset(&self) -> bool {
         let mask = match self.length {
             0 => 0,
             _ => (!0u32) << (32 - self.length),
@@ -248,7 +248,7 @@ impl Prefix4 {
         self.value.to_bits() & mask == self.value.to_bits()
     }
 
-    pub fn zero_host_bits(&mut self) {
+    pub fn unset_host_bits(&mut self) {
         let mask = match self.length {
             0 => 0,
             _ => (!0u32) << (32 - self.length),
@@ -313,11 +313,11 @@ impl fmt::Display for Prefix6 {
 impl Prefix6 {
     pub fn new(ip: Ipv6Addr, length: u8) -> Self {
         let mut new = Self { value: ip, length };
-        new.zero_host_bits();
+        new.unset_host_bits();
         new
     }
 
-    pub fn host_bits_are_zero(&self) -> bool {
+    pub fn host_bits_are_unset(&self) -> bool {
         let mask = match self.length {
             0 => 0,
             _ => (!0u128) << (128 - self.length),
@@ -326,7 +326,7 @@ impl Prefix6 {
         self.value.to_bits() & mask == self.value.to_bits()
     }
 
-    pub fn zero_host_bits(&mut self) {
+    pub fn unset_host_bits(&mut self) {
         let mask = match self.length {
             0 => 0,
             _ => (!0u128) << (128 - self.length),
@@ -382,17 +382,17 @@ impl Prefix {
         }
     }
 
-    pub fn host_bits_are_zero(&self) -> bool {
+    pub fn host_bits_are_unset(&self) -> bool {
         match self {
-            Self::V4(p4) => p4.host_bits_are_zero(),
-            Self::V6(p6) => p6.host_bits_are_zero(),
+            Self::V4(p4) => p4.host_bits_are_unset(),
+            Self::V6(p6) => p6.host_bits_are_unset(),
         }
     }
 
-    pub fn zero_host_bits(&mut self) {
+    pub fn unset_host_bits(&mut self) {
         match self {
-            Self::V4(p4) => p4.zero_host_bits(),
-            Self::V6(p6) => p6.zero_host_bits(),
+            Self::V4(p4) => p4.unset_host_bits(),
+            Self::V6(p6) => p6.unset_host_bits(),
         }
     }
 }


### PR DESCRIPTION
This PR adds initial support for IPv6 static routing in maghemite, with the very beginnings of BGP support (really just originated IPv6 prefixes).
This addresses a few bugs found along the way (e.g. #529), adds unit tests for old/new functionality, and does a good bit of code cleanup, e.g.
 - mostly standardizing on oxnet::IpNet in generic spots and rdb::Prefix in db-specific spots, rather than several unique types
 - moving common functionality into mg-common where it can be used by all other crates w/o creating circular dependencies
