### PR TITLE
Fix #538

### DIFF
--- a/.github/buildomat/jobs/test-mg-lower.sh
+++ b/.github/buildomat/jobs/test-mg-lower.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#:
+#: name = "test-mg-lower"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "stable"
+
+set -x
+set -e
+
+source .github/buildomat/test-common.sh
+pushd mg-lower
+cargo nextest run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,11 +3140,13 @@ dependencies = [
  "libnet",
  "mg-common",
  "oxnet",
+ "progenitor-client 0.9.1",
  "rdb",
  "reqwest",
  "slog",
  "thiserror 1.0.69",
  "tokio",
+ "util",
 ]
 
 [[package]]
@@ -4884,6 +4886,7 @@ dependencies = [
  "ciborium",
  "itertools 0.13.0",
  "mg-common",
+ "oxnet",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde_json = "1.0.140"
 percent-encoding = "2.3.1"
 libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "main" }
 progenitor = "0.9.1"
+progenitor-client = "0.9.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 clap = { version = "4.5.40", features = ["derive", "unstable-styles", "env"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }

--- a/mg-lower/Cargo.toml
+++ b/mg-lower/Cargo.toml
@@ -3,6 +3,9 @@ name = "mg-lower"
 version = "0.1.0"
 edition = "2021"
 
+[dev-dependencies]
+util  = { path = "../util" }
+
 [dependencies]
 ddm-admin-client = { path = "../ddm-admin-client" }
 rdb = { path = "../rdb" }
@@ -16,3 +19,4 @@ http.workspace = true
 mg-common.workspace = true
 oxnet.workspace = true
 reqwest.workspace = true
+progenitor-client.workspace = true

--- a/mg-lower/src/ddm.rs
+++ b/mg-lower/src/ddm.rs
@@ -8,10 +8,12 @@ use oxnet::Ipv6Net;
 use slog::{error, info, Logger};
 use std::{net::Ipv6Addr, sync::Arc};
 
+use crate::platform::Ddm;
+
 pub(crate) const BOUNDARY_SERVICES_VNI: u32 = 99;
 
 fn ensure_tep_underlay_origin(
-    client: &Client,
+    client: &impl Ddm,
     tep: Ipv6Addr,
     rt: &Arc<tokio::runtime::Handle>,
     log: &Logger,
@@ -44,7 +46,7 @@ fn ensure_tep_underlay_origin(
 
 pub(crate) fn add_tunnel_routes<'a, I: Iterator<Item = &'a TunnelOrigin>>(
     tep: Ipv6Addr, // tunnel endpoint address
-    client: &Client,
+    client: &impl Ddm,
     routes: I,
     rt: &Arc<tokio::runtime::Handle>,
     log: &Logger,
@@ -62,7 +64,7 @@ pub(crate) fn add_tunnel_routes<'a, I: Iterator<Item = &'a TunnelOrigin>>(
 }
 
 pub(crate) fn remove_tunnel_routes<'a, I: Iterator<Item = &'a TunnelOrigin>>(
-    client: &Client,
+    client: &impl Ddm,
     routes: I,
     rt: &Arc<tokio::runtime::Handle>,
     log: &Logger,

--- a/mg-lower/src/dendrite.rs
+++ b/mg-lower/src/dendrite.rs
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::platform::Dpd;
+use crate::platform::SwitchZone;
 use crate::Error;
 use crate::MG_LOWER_TAG;
 use dpd_client::types;
 use dpd_client::types::LinkState;
 use dpd_client::Client as DpdClient;
-use libnet::get_route;
 use oxnet::IpNet;
 use oxnet::Ipv4Net;
 use oxnet::Ipv6Net;
@@ -55,10 +56,11 @@ impl RouteHash {
     }
 
     pub fn for_prefix_path(
+        sw: &impl SwitchZone,
         prefix: Prefix,
         path: Path,
     ) -> Result<RouteHash, Error> {
-        let (port_id, link_id) = get_port_and_link(path.nexthop)?;
+        let (port_id, link_id) = get_port_and_link(sw, path.nexthop)?;
 
         let rh = RouteHash {
             cidr: match prefix {
@@ -77,7 +79,7 @@ impl RouteHash {
 
 pub(crate) fn ensure_tep_addr(
     tep: Ipv6Addr,
-    dpd: &DpdClient,
+    dpd: &impl Dpd,
     rt: Arc<tokio::runtime::Handle>,
     log: &Logger,
 ) {
@@ -95,7 +97,7 @@ pub(crate) fn ensure_tep_addr(
 }
 
 pub(crate) fn link_is_up(
-    dpd: &DpdClient,
+    dpd: &impl Dpd,
     port_id: &types::PortId,
     link_id: &types::LinkId,
     rt: &Arc<tokio::runtime::Handle>,
@@ -107,7 +109,7 @@ pub(crate) fn link_is_up(
 }
 
 fn get_local_addrs(
-    dpd: &DpdClient,
+    dpd: &impl Dpd,
     rt: &Arc<tokio::runtime::Handle>,
 ) -> Result<(BTreeSet<Ipv4Addr>, BTreeSet<Ipv6Addr>), Error> {
     let links = rt
@@ -144,7 +146,7 @@ fn get_local_addrs(
 pub(crate) fn update_dendrite<'a, I>(
     to_add: I,
     to_del: I,
-    dpd: &DpdClient,
+    dpd: &impl Dpd,
     rt: Arc<tokio::runtime::Handle>,
     log: &Logger,
 ) -> Result<(), Error>
@@ -154,7 +156,7 @@ where
     let (local_v4_addrs, local_v6_addrs) = get_local_addrs(dpd, &rt)?;
 
     for r in to_add {
-        let tag = dpd.inner().tag.clone();
+        let tag = dpd.tag();
         let port_id = r.port_id.clone();
         let link_id = r.link_id;
         let vlan_id = r.vlan_id;
@@ -333,10 +335,11 @@ fn test_tfport_parser() {
 }
 
 fn get_port_and_link(
+    sw: &impl SwitchZone,
     nexthop: IpAddr,
 ) -> Result<(types::PortId, types::LinkId), Error> {
     let prefix = IpNet::host_net(nexthop);
-    let sys_route = get_route(prefix, Some(Duration::from_secs(1)))?;
+    let sys_route = sw.get_route(prefix, Some(Duration::from_secs(1)))?;
 
     let ifname = match sys_route.ifx {
         Some(name) => name,
@@ -364,7 +367,7 @@ fn get_port_and_link(
 }
 
 pub(crate) fn get_routes_for_prefix(
-    dpd: &DpdClient,
+    dpd: &impl Dpd,
     prefix: &Prefix,
     rt: Arc<tokio::runtime::Handle>,
     log: Logger,

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -146,8 +146,9 @@ fn full_sync(
 
     // Compute the bestpath for each prefix and synchronize the ASIC routing
     // tables with the chosen paths.
+    let loc_rib = db.loc_rib();
     for (prefix, _paths) in rib.iter() {
-        sync_prefix(tep, &db.loc_rib(), prefix, dpd, ddm, sw, log, &rt)?;
+        sync_prefix(tep, &loc_rib, prefix, dpd, ddm, sw, log, &rt)?;
     }
 
     Ok(())
@@ -165,8 +166,9 @@ fn handle_change(
     sw: &impl SwitchZone,
     rt: Arc<tokio::runtime::Handle>,
 ) -> Result<(), Error> {
+    let loc_rib = db.loc_rib();
     for prefix in notification.changed.iter() {
-        sync_prefix(tep, &db.loc_rib(), prefix, dpd, ddm, sw, log, &rt)?;
+        sync_prefix(tep, &loc_rib, prefix, dpd, ddm, sw, log, &rt)?;
     }
 
     Ok(())

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -15,10 +15,11 @@ use ddm::{
     BOUNDARY_SERVICES_VNI,
 };
 use ddm_admin_client::types::TunnelOrigin;
-use ddm_admin_client::Client as DdmClient;
 use dendrite::{ensure_tep_addr, link_is_up};
-use dpd_client::Client as DpdClient;
 use mg_common::stats::MgLowerStats as Stats;
+use platform::{
+    Ddm, Dpd, ProductionDdm, ProductionDpd, ProductionSwitchZone, SwitchZone,
+};
 use rdb::db::Rib;
 use rdb::{Db, Prefix, PrefixChangeNotification, DEFAULT_ROUTE_PRIORITY};
 use slog::{error, info, warn, Logger};
@@ -32,6 +33,10 @@ use std::time::Duration;
 mod ddm;
 mod dendrite;
 mod error;
+mod platform;
+
+#[cfg(test)]
+mod test;
 
 /// Tag used for managing both dpd and rdb elements.
 const MG_LOWER_TAG: &str = "mg-lower";
@@ -58,10 +63,15 @@ pub fn run(
         db.watch(MG_LOWER_TAG.into(), tx);
 
         // initialize the underlying router with the current state
-        let dpd = new_dpd_client(&log);
-        let ddm = new_ddm_client(&log);
+        let dpd = ProductionDpd {
+            client: new_dpd_client(&log),
+        };
+        let ddm = ProductionDdm {
+            client: new_ddm_client(&log),
+        };
+        let sw = ProductionSwitchZone {};
         if let Err(e) =
-            full_sync(tep, &db, &log, &dpd, &ddm, &stats, rt.clone())
+            full_sync(tep, &db, &log, &dpd, &ddm, &sw, &stats, rt.clone())
         {
             error!(log, "initializing failed: {e}");
             info!(log, "restarting sync loop in one second");
@@ -80,6 +90,7 @@ pub fn run(
                         &log,
                         &dpd,
                         &ddm,
+                        &sw,
                         rt.clone(),
                     ) {
                         error!(log, "handling change failed: {e}");
@@ -96,6 +107,7 @@ pub fn run(
                         &log,
                         &dpd,
                         &ddm,
+                        &sw,
                         &stats,
                         rt.clone(),
                     ) {
@@ -116,12 +128,14 @@ pub fn run(
 
 /// Synchronize the underlying platforms with a complete set of routes from the
 /// RIB.
+#[allow(clippy::too_many_arguments)]
 fn full_sync(
     tep: Ipv6Addr, // tunnel endpoint address
     db: &Db,
     log: &Logger,
-    dpd: &DpdClient,
-    ddm: &DdmClient,
+    dpd: &impl Dpd,
+    ddm: &impl Ddm,
+    sw: &impl SwitchZone,
     _stats: &Arc<Stats>, //TODO(ry)
     rt: Arc<tokio::runtime::Handle>,
 ) -> Result<(), Error> {
@@ -133,35 +147,39 @@ fn full_sync(
     // Compute the bestpath for each prefix and synchronize the ASIC routing
     // tables with the chosen paths.
     for (prefix, _paths) in rib.iter() {
-        sync_prefix(tep, &db.loc_rib(), prefix, dpd, ddm, log, &rt)?;
+        sync_prefix(tep, &db.loc_rib(), prefix, dpd, ddm, sw, log, &rt)?;
     }
 
     Ok(())
 }
 
 /// Synchronize a change set from the RIB to the underlying platform.
+#[allow(clippy::too_many_arguments)]
 fn handle_change(
     tep: Ipv6Addr, // tunnel endpoint address
     db: &Db,
     notification: PrefixChangeNotification,
     log: &Logger,
-    dpd: &DpdClient,
-    ddm: &DdmClient,
+    dpd: &impl Dpd,
+    ddm: &impl Ddm,
+    sw: &impl SwitchZone,
     rt: Arc<tokio::runtime::Handle>,
 ) -> Result<(), Error> {
     for prefix in notification.changed.iter() {
-        sync_prefix(tep, &db.loc_rib(), prefix, dpd, ddm, log, &rt)?;
+        sync_prefix(tep, &db.loc_rib(), prefix, dpd, ddm, sw, log, &rt)?;
     }
 
     Ok(())
 }
 
-fn sync_prefix(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn sync_prefix(
     tep: Ipv6Addr,
     rib_loc: &Rib,
     prefix: &Prefix,
-    dpd: &DpdClient,
-    ddm: &DdmClient,
+    dpd: &impl Dpd,
+    ddm: &impl Ddm,
+    sw: &impl SwitchZone,
     log: &Logger,
     rt: &Arc<tokio::runtime::Handle>,
 ) -> Result<(), Error> {
@@ -180,7 +198,7 @@ fn sync_prefix(
     let mut best: HashSet<RouteHash> = HashSet::new();
     if let Some(paths) = rib_loc.get(prefix) {
         for path in paths {
-            best.insert(RouteHash::for_prefix_path(*prefix, path.clone())?);
+            best.insert(RouteHash::for_prefix_path(sw, *prefix, path.clone())?);
         }
     }
 

--- a/mg-lower/src/lib.rs
+++ b/mg-lower/src/lib.rs
@@ -192,6 +192,7 @@ pub(crate) fn sync_prefix(
         .block_on(async { ddm.get_originated_tunnel_endpoints().await })?
         .into_inner()
         .into_iter()
+        .filter(|x| x.overlay_prefix == prefix)
         .collect::<HashSet<_>>();
 
     // The best routes in the RIB

--- a/mg-lower/src/platform.rs
+++ b/mg-lower/src/platform.rs
@@ -2,11 +2,13 @@
 //! platform. This is useful for testing mg-lower while not having to
 //! have a running dpd, ddmd, or switch zone.
 //!
-//! TODO: maybe there can be lest boilerplate with Dropshot API traits?
+//! TODO: maybe there can be less boilerplate with Dropshot API traits?
 
 use std::time::Duration;
 
+use ddm_admin_client::types::{Error as DdmError, *};
 use ddm_admin_client::Client as DdmClient;
+use dpd_client::types::{Error as DpdError, *};
 use dpd_client::Client as DpdClient;
 use oxnet::{IpNet, Ipv4Net, Ipv6Net};
 
@@ -16,96 +18,78 @@ pub(crate) trait Dpd {
         &self,
         cidr: &Ipv4Net,
     ) -> Result<
-        dpd_client::ResponseValue<
-            ::std::vec::Vec<dpd_client::types::Ipv4Route>,
-        >,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Vec<Ipv4Route>>,
+        progenitor_client::Error<DpdError>,
     >;
     async fn route_ipv6_get(
         &self,
         cidr: &Ipv6Net,
     ) -> Result<
-        dpd_client::ResponseValue<
-            ::std::vec::Vec<dpd_client::types::Ipv6Route>,
-        >,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Vec<Ipv6Route>>,
+        progenitor_client::Error<DpdError>,
     >;
-
     async fn link_get(
         &self,
-        port_id: &dpd_client::types::PortId,
-        link_id: &dpd_client::types::LinkId,
+        port_id: &PortId,
+        link_id: &LinkId,
     ) -> Result<
-        dpd_client::ResponseValue<dpd_client::types::Link>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Link>,
+        progenitor_client::Error<DpdError>,
     >;
-
     async fn loopback_ipv6_create(
         &self,
-        addr: &dpd_client::types::Ipv6Entry,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    >;
+        addr: &Ipv6Entry,
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>;
 
     async fn link_list_all<'a>(
         &'a self,
         filter: Option<&'a str>,
     ) -> Result<
-        dpd_client::ResponseValue<::std::vec::Vec<dpd_client::types::Link>>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Vec<Link>>,
+        progenitor_client::Error<DpdError>,
     >;
 
     async fn link_ipv4_list<'a>(
         &'a self,
-        port_id: &'a dpd_client::types::PortId,
-        link_id: &'a dpd_client::types::LinkId,
+        port_id: &'a PortId,
+        link_id: &'a LinkId,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<
-        dpd_client::ResponseValue<dpd_client::types::Ipv4EntryResultsPage>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Ipv4EntryResultsPage>,
+        progenitor_client::Error<DpdError>,
     >;
 
     async fn link_ipv6_list<'a>(
         &'a self,
-        port_id: &'a dpd_client::types::PortId,
-        link_id: &'a dpd_client::types::LinkId,
+        port_id: &'a PortId,
+        link_id: &'a LinkId,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<
-        dpd_client::ResponseValue<dpd_client::types::Ipv6EntryResultsPage>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Ipv6EntryResultsPage>,
+        progenitor_client::Error<DpdError>,
     >;
 
     fn tag(&self) -> String;
 
     async fn route_ipv4_add<'a>(
         &'a self,
-        body: &'a dpd_client::types::Ipv4RouteUpdate,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    >;
+        body: &'a Ipv4RouteUpdate,
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>;
 
     async fn route_ipv6_add<'a>(
         &'a self,
-        body: &'a dpd_client::types::Ipv6RouteUpdate,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    >;
+        body: &'a Ipv6RouteUpdate,
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>;
 
     async fn route_ipv4_delete_target<'a>(
         &'a self,
         cidr: &'a oxnet::Ipv4Net,
-        port_id: &'a dpd_client::types::PortId,
-        link_id: &'a dpd_client::types::LinkId,
+        port_id: &'a PortId,
+        link_id: &'a LinkId,
         tgt_ip: &'a std::net::Ipv4Addr,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    >;
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>;
 }
 
 /// This trait wraps the ddmd methods mg-lower uses.
@@ -113,17 +97,15 @@ pub(crate) trait Ddm {
     async fn get_originated_tunnel_endpoints(
         &self,
     ) -> Result<
-        ddm_admin_client::ResponseValue<
-            Vec<ddm_admin_client::types::TunnelOrigin>,
-        >,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        ddm_admin_client::ResponseValue<Vec<TunnelOrigin>>,
+        progenitor_client::Error<DdmError>,
     >;
 
     async fn get_originated(
         &self,
     ) -> Result<
         ddm_admin_client::ResponseValue<Vec<oxnet::Ipv6Net>>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     >;
 
     #[allow(clippy::ptr_arg)]
@@ -132,25 +114,25 @@ pub(crate) trait Ddm {
         body: &'a Vec<oxnet::Ipv6Net>,
     ) -> Result<
         ddm_admin_client::ResponseValue<()>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     >;
 
     #[allow(clippy::ptr_arg)]
     async fn advertise_tunnel_endpoints<'a>(
         &'a self,
-        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+        body: &'a Vec<TunnelOrigin>,
     ) -> Result<
         ddm_admin_client::ResponseValue<()>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     >;
 
     #[allow(clippy::ptr_arg)]
     async fn withdraw_tunnel_endpoints<'a>(
         &'a self,
-        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+        body: &'a Vec<TunnelOrigin>,
     ) -> Result<
         ddm_admin_client::ResponseValue<()>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     >;
 }
 
@@ -174,10 +156,8 @@ impl Dpd for ProductionDpd {
         &self,
         cidr: &Ipv4Net,
     ) -> Result<
-        dpd_client::ResponseValue<
-            ::std::vec::Vec<dpd_client::types::Ipv4Route>,
-        >,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Vec<Ipv4Route>>,
+        progenitor_client::Error<DpdError>,
     > {
         self.client.route_ipv4_get(cidr).await
     }
@@ -186,32 +166,28 @@ impl Dpd for ProductionDpd {
         &self,
         cidr: &Ipv6Net,
     ) -> Result<
-        dpd_client::ResponseValue<
-            ::std::vec::Vec<dpd_client::types::Ipv6Route>,
-        >,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Vec<Ipv6Route>>,
+        progenitor_client::Error<DpdError>,
     > {
         self.client.route_ipv6_get(cidr).await
     }
 
     async fn link_get(
         &self,
-        port_id: &dpd_client::types::PortId,
-        link_id: &dpd_client::types::LinkId,
+        port_id: &PortId,
+        link_id: &LinkId,
     ) -> Result<
-        dpd_client::ResponseValue<dpd_client::types::Link>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Link>,
+        progenitor_client::Error<DpdError>,
     > {
         self.client.link_get(port_id, link_id).await
     }
 
     async fn loopback_ipv6_create(
         &self,
-        addr: &dpd_client::types::Ipv6Entry,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    > {
+        addr: &Ipv6Entry,
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>
+    {
         self.client.loopback_ipv6_create(addr).await
     }
 
@@ -219,21 +195,21 @@ impl Dpd for ProductionDpd {
         &'a self,
         filter: Option<&'a str>,
     ) -> Result<
-        dpd_client::ResponseValue<::std::vec::Vec<dpd_client::types::Link>>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Vec<Link>>,
+        progenitor_client::Error<DpdError>,
     > {
         self.client.link_list_all(filter).await
     }
 
     async fn link_ipv4_list<'a>(
         &'a self,
-        port_id: &'a dpd_client::types::PortId,
-        link_id: &'a dpd_client::types::LinkId,
+        port_id: &'a PortId,
+        link_id: &'a LinkId,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<
-        dpd_client::ResponseValue<dpd_client::types::Ipv4EntryResultsPage>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Ipv4EntryResultsPage>,
+        progenitor_client::Error<DpdError>,
     > {
         self.client
             .link_ipv4_list(port_id, link_id, limit, page_token)
@@ -242,13 +218,13 @@ impl Dpd for ProductionDpd {
 
     async fn link_ipv6_list<'a>(
         &'a self,
-        port_id: &'a dpd_client::types::PortId,
-        link_id: &'a dpd_client::types::LinkId,
+        port_id: &'a PortId,
+        link_id: &'a LinkId,
         limit: Option<std::num::NonZeroU32>,
         page_token: Option<&'a str>,
     ) -> Result<
-        dpd_client::ResponseValue<dpd_client::types::Ipv6EntryResultsPage>,
-        progenitor_client::Error<dpd_client::types::Error>,
+        dpd_client::ResponseValue<Ipv6EntryResultsPage>,
+        progenitor_client::Error<DpdError>,
     > {
         self.client
             .link_ipv6_list(port_id, link_id, limit, page_token)
@@ -257,34 +233,28 @@ impl Dpd for ProductionDpd {
 
     async fn route_ipv4_add<'a>(
         &'a self,
-        body: &'a dpd_client::types::Ipv4RouteUpdate,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    > {
+        body: &'a Ipv4RouteUpdate,
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>
+    {
         self.client.route_ipv4_add(body).await
     }
 
     async fn route_ipv6_add<'a>(
         &'a self,
-        body: &'a dpd_client::types::Ipv6RouteUpdate,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    > {
+        body: &'a Ipv6RouteUpdate,
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>
+    {
         self.client.route_ipv6_add(body).await
     }
 
     async fn route_ipv4_delete_target<'a>(
         &'a self,
         cidr: &'a oxnet::Ipv4Net,
-        port_id: &'a dpd_client::types::PortId,
-        link_id: &'a dpd_client::types::LinkId,
+        port_id: &'a PortId,
+        link_id: &'a LinkId,
         tgt_ip: &'a std::net::Ipv4Addr,
-    ) -> Result<
-        dpd_client::ResponseValue<()>,
-        progenitor_client::Error<dpd_client::types::Error>,
-    > {
+    ) -> Result<dpd_client::ResponseValue<()>, progenitor_client::Error<DpdError>>
+    {
         self.client
             .route_ipv4_delete_target(cidr, port_id, link_id, tgt_ip)
             .await
@@ -304,10 +274,8 @@ impl Ddm for ProductionDdm {
     async fn get_originated_tunnel_endpoints(
         &self,
     ) -> Result<
-        ddm_admin_client::ResponseValue<
-            Vec<ddm_admin_client::types::TunnelOrigin>,
-        >,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        ddm_admin_client::ResponseValue<Vec<TunnelOrigin>>,
+        progenitor_client::Error<DdmError>,
     > {
         self.client.get_originated_tunnel_endpoints().await
     }
@@ -316,7 +284,7 @@ impl Ddm for ProductionDdm {
         &self,
     ) -> Result<
         ddm_admin_client::ResponseValue<Vec<oxnet::Ipv6Net>>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     > {
         self.client.get_originated().await
     }
@@ -326,27 +294,27 @@ impl Ddm for ProductionDdm {
         body: &'a Vec<oxnet::Ipv6Net>,
     ) -> Result<
         ddm_admin_client::ResponseValue<()>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     > {
         self.client.advertise_prefixes(body).await
     }
 
     async fn advertise_tunnel_endpoints<'a>(
         &'a self,
-        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+        body: &'a Vec<TunnelOrigin>,
     ) -> Result<
         ddm_admin_client::ResponseValue<()>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     > {
         self.client.advertise_tunnel_endpoints(body).await
     }
 
     async fn withdraw_tunnel_endpoints<'a>(
         &'a self,
-        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+        body: &'a Vec<TunnelOrigin>,
     ) -> Result<
         ddm_admin_client::ResponseValue<()>,
-        progenitor_client::Error<ddm_admin_client::types::Error>,
+        progenitor_client::Error<DdmError>,
     > {
         self.client.withdraw_tunnel_endpoints(body).await
     }
@@ -369,12 +337,9 @@ impl SwitchZone for ProductionSwitchZone {
 /// This module contains platform trait implementations for testing.
 #[cfg(test)]
 pub(crate) mod test {
-    use std::{collections::HashMap, net::IpAddr};
-
-    use dpd_client::types::Ipv6Entry;
-    use std::sync::Mutex;
-
     use super::*;
+    use std::sync::Mutex;
+    use std::{collections::HashMap, net::IpAddr};
 
     // helper macros for forming dropshot responses
     macro_rules! dpd_response_ok {
@@ -399,13 +364,11 @@ pub(crate) mod test {
     /// A stateful mock dpd implementation. Carries just enough state to be
     /// useful for tests.
     pub(crate) struct TestDpd {
-        pub(crate) links: Mutex<Vec<dpd_client::types::Link>>,
-        pub(crate) v4_routes:
-            Mutex<HashMap<Ipv4Net, Vec<dpd_client::types::Ipv4Route>>>,
-        pub(crate) v6_routes:
-            Mutex<HashMap<Ipv6Net, Vec<dpd_client::types::Ipv6Route>>>,
-        pub(crate) v4_addrs: HashMap<String, Vec<dpd_client::types::Ipv4Entry>>,
-        pub(crate) v6_addrs: HashMap<String, Vec<dpd_client::types::Ipv6Entry>>,
+        pub(crate) links: Mutex<Vec<Link>>,
+        pub(crate) v4_routes: Mutex<HashMap<Ipv4Net, Vec<Ipv4Route>>>,
+        pub(crate) v6_routes: Mutex<HashMap<Ipv6Net, Vec<Ipv6Route>>>,
+        pub(crate) v4_addrs: HashMap<String, Vec<Ipv4Entry>>,
+        pub(crate) v6_addrs: HashMap<String, Vec<Ipv6Entry>>,
         pub(crate) loopback: Mutex<Option<Ipv6Entry>>,
     }
 
@@ -425,11 +388,11 @@ pub(crate) mod test {
     impl Dpd for TestDpd {
         async fn link_get(
             &self,
-            port_id: &dpd_client::types::PortId,
-            link_id: &dpd_client::types::LinkId,
+            port_id: &PortId,
+            link_id: &LinkId,
         ) -> Result<
-            dpd_client::ResponseValue<dpd_client::types::Link>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            dpd_client::ResponseValue<Link>,
+            progenitor_client::Error<DpdError>,
         > {
             let links = self.links.lock().unwrap();
             let link = links
@@ -446,10 +409,8 @@ pub(crate) mod test {
             &self,
             cidr: &Ipv4Net,
         ) -> Result<
-            dpd_client::ResponseValue<
-                ::std::vec::Vec<dpd_client::types::Ipv4Route>,
-            >,
-            progenitor_client::Error<dpd_client::types::Error>,
+            dpd_client::ResponseValue<Vec<Ipv4Route>>,
+            progenitor_client::Error<DpdError>,
         > {
             let result = self
                 .v4_routes
@@ -465,10 +426,8 @@ pub(crate) mod test {
             &self,
             cidr: &Ipv6Net,
         ) -> Result<
-            dpd_client::ResponseValue<
-                ::std::vec::Vec<dpd_client::types::Ipv6Route>,
-            >,
-            progenitor_client::Error<dpd_client::types::Error>,
+            dpd_client::ResponseValue<Vec<Ipv6Route>>,
+            progenitor_client::Error<DpdError>,
         > {
             let result = self
                 .v6_routes
@@ -482,10 +441,10 @@ pub(crate) mod test {
 
         async fn loopback_ipv6_create(
             &self,
-            addr: &dpd_client::types::Ipv6Entry,
+            addr: &Ipv6Entry,
         ) -> Result<
             dpd_client::ResponseValue<()>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            progenitor_client::Error<DpdError>,
         > {
             self.loopback.lock().unwrap().replace(addr.clone());
             Ok(dpd_response_ok!(()))
@@ -495,8 +454,8 @@ pub(crate) mod test {
             &'a self,
             filter: Option<&'a str>,
         ) -> Result<
-            dpd_client::ResponseValue<::std::vec::Vec<dpd_client::types::Link>>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            dpd_client::ResponseValue<Vec<Link>>,
+            progenitor_client::Error<DpdError>,
         > {
             let links = self.links.lock().unwrap();
             let result = links
@@ -512,13 +471,13 @@ pub(crate) mod test {
 
         async fn link_ipv4_list<'a>(
             &'a self,
-            port_id: &'a dpd_client::types::PortId,
-            link_id: &'a dpd_client::types::LinkId,
+            port_id: &'a PortId,
+            link_id: &'a LinkId,
             _limit: Option<std::num::NonZeroU32>,
             _page_token: Option<&'a str>,
         ) -> Result<
-            dpd_client::ResponseValue<dpd_client::types::Ipv4EntryResultsPage>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            dpd_client::ResponseValue<Ipv4EntryResultsPage>,
+            progenitor_client::Error<DpdError>,
         > {
             let lnk = self.link_get(port_id, link_id).await?.into_inner();
             let addrs = self
@@ -527,7 +486,7 @@ pub(crate) mod test {
                 .cloned()
                 .unwrap_or_default();
 
-            Ok(dpd_response_ok!(dpd_client::types::Ipv4EntryResultsPage {
+            Ok(dpd_response_ok!(Ipv4EntryResultsPage {
                 items: addrs,
                 next_page: None,
             }))
@@ -535,13 +494,13 @@ pub(crate) mod test {
 
         async fn link_ipv6_list<'a>(
             &'a self,
-            port_id: &'a dpd_client::types::PortId,
-            link_id: &'a dpd_client::types::LinkId,
+            port_id: &'a PortId,
+            link_id: &'a LinkId,
             _limit: Option<std::num::NonZeroU32>,
             _page_token: Option<&'a str>,
         ) -> Result<
-            dpd_client::ResponseValue<dpd_client::types::Ipv6EntryResultsPage>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            dpd_client::ResponseValue<Ipv6EntryResultsPage>,
+            progenitor_client::Error<DpdError>,
         > {
             let lnk = self.link_get(port_id, link_id).await?.into_inner();
             let addrs = self
@@ -550,7 +509,7 @@ pub(crate) mod test {
                 .cloned()
                 .unwrap_or_default();
 
-            Ok(dpd_response_ok!(dpd_client::types::Ipv6EntryResultsPage {
+            Ok(dpd_response_ok!(Ipv6EntryResultsPage {
                 items: addrs,
                 next_page: None,
             }))
@@ -558,10 +517,10 @@ pub(crate) mod test {
 
         async fn route_ipv4_add<'a>(
             &'a self,
-            body: &'a dpd_client::types::Ipv4RouteUpdate,
+            body: &'a Ipv4RouteUpdate,
         ) -> Result<
             dpd_client::ResponseValue<()>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            progenitor_client::Error<DpdError>,
         > {
             let mut routes = self.v4_routes.lock().unwrap();
             match routes.get_mut(&body.cidr) {
@@ -577,10 +536,10 @@ pub(crate) mod test {
 
         async fn route_ipv6_add<'a>(
             &'a self,
-            body: &'a dpd_client::types::Ipv6RouteUpdate,
+            body: &'a Ipv6RouteUpdate,
         ) -> Result<
             dpd_client::ResponseValue<()>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            progenitor_client::Error<DpdError>,
         > {
             let mut routes = self.v6_routes.lock().unwrap();
             match routes.get_mut(&body.cidr) {
@@ -597,12 +556,12 @@ pub(crate) mod test {
         async fn route_ipv4_delete_target<'a>(
             &'a self,
             cidr: &'a oxnet::Ipv4Net,
-            port_id: &'a dpd_client::types::PortId,
-            link_id: &'a dpd_client::types::LinkId,
+            port_id: &'a PortId,
+            link_id: &'a LinkId,
             tgt_ip: &'a std::net::Ipv4Addr,
         ) -> Result<
             dpd_client::ResponseValue<()>,
-            progenitor_client::Error<dpd_client::types::Error>,
+            progenitor_client::Error<DpdError>,
         > {
             let mut routes = self.v4_routes.lock().unwrap();
             if let Some(targets) = routes.get_mut(cidr) {
@@ -624,8 +583,7 @@ pub(crate) mod test {
     /// A stateful mock ddm implementation. Carries just enough state to be
     /// useful for tests.
     pub(crate) struct TestDdm {
-        pub(crate) tunnel_originated:
-            Mutex<Vec<ddm_admin_client::types::TunnelOrigin>>,
+        pub(crate) tunnel_originated: Mutex<Vec<TunnelOrigin>>,
         pub(crate) originated: Mutex<Vec<oxnet::Ipv6Net>>,
     }
 
@@ -642,10 +600,8 @@ pub(crate) mod test {
         async fn get_originated_tunnel_endpoints(
             &self,
         ) -> Result<
-            ddm_admin_client::ResponseValue<
-                Vec<ddm_admin_client::types::TunnelOrigin>,
-            >,
-            progenitor_client::Error<ddm_admin_client::types::Error>,
+            ddm_admin_client::ResponseValue<Vec<TunnelOrigin>>,
+            progenitor_client::Error<DdmError>,
         > {
             Ok(ddm_response_ok!(self
                 .tunnel_originated
@@ -658,7 +614,7 @@ pub(crate) mod test {
             &self,
         ) -> Result<
             ddm_admin_client::ResponseValue<Vec<oxnet::Ipv6Net>>,
-            progenitor_client::Error<ddm_admin_client::types::Error>,
+            progenitor_client::Error<DdmError>,
         > {
             Ok(ddm_response_ok!(self.originated.lock().unwrap().clone()))
         }
@@ -668,7 +624,7 @@ pub(crate) mod test {
             body: &'a Vec<oxnet::Ipv6Net>,
         ) -> Result<
             ddm_admin_client::ResponseValue<()>,
-            progenitor_client::Error<ddm_admin_client::types::Error>,
+            progenitor_client::Error<DdmError>,
         > {
             self.originated.lock().unwrap().extend(body);
             Ok(ddm_response_ok!(()))
@@ -676,10 +632,10 @@ pub(crate) mod test {
 
         async fn advertise_tunnel_endpoints<'a>(
             &'a self,
-            body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+            body: &'a Vec<TunnelOrigin>,
         ) -> Result<
             ddm_admin_client::ResponseValue<()>,
-            progenitor_client::Error<ddm_admin_client::types::Error>,
+            progenitor_client::Error<DdmError>,
         > {
             self.tunnel_originated.lock().unwrap().extend(body.clone());
             Ok(ddm_response_ok!(()))
@@ -687,10 +643,10 @@ pub(crate) mod test {
 
         async fn withdraw_tunnel_endpoints<'a>(
             &'a self,
-            body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+            body: &'a Vec<TunnelOrigin>,
         ) -> Result<
             ddm_admin_client::ResponseValue<()>,
-            progenitor_client::Error<ddm_admin_client::types::Error>,
+            progenitor_client::Error<DdmError>,
         > {
             self.tunnel_originated
                 .lock()
@@ -700,7 +656,7 @@ pub(crate) mod test {
         }
     }
 
-    /// A mock swtich zone implementation.
+    /// A mock switch zone implementation.
     pub(crate) struct TestSwitchZone {
         pub(crate) routes: HashMap<IpNet, (Option<String>, IpAddr)>,
         pub(crate) default_ifname: Option<String>,

--- a/mg-lower/src/platform.rs
+++ b/mg-lower/src/platform.rs
@@ -1,0 +1,722 @@
+//! This crate contains traits that decouple mg-lower from the underlying
+//! platform. This is useful for testing mg-lower while not having to
+//! have a running dpd, ddmd, or switch zone.
+//!
+//! TODO: maybe there can be lest boilerplate with Dropshot API traits?
+
+use std::time::Duration;
+
+use ddm_admin_client::Client as DdmClient;
+use dpd_client::Client as DpdClient;
+use oxnet::{IpNet, Ipv4Net, Ipv6Net};
+
+/// This trait wraps the dpd methods mg-lower uses.
+pub(crate) trait Dpd {
+    async fn route_ipv4_get(
+        &self,
+        cidr: &Ipv4Net,
+    ) -> Result<
+        dpd_client::ResponseValue<
+            ::std::vec::Vec<dpd_client::types::Ipv4Route>,
+        >,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+    async fn route_ipv6_get(
+        &self,
+        cidr: &Ipv6Net,
+    ) -> Result<
+        dpd_client::ResponseValue<
+            ::std::vec::Vec<dpd_client::types::Ipv6Route>,
+        >,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn link_get(
+        &self,
+        port_id: &dpd_client::types::PortId,
+        link_id: &dpd_client::types::LinkId,
+    ) -> Result<
+        dpd_client::ResponseValue<dpd_client::types::Link>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn loopback_ipv6_create(
+        &self,
+        addr: &dpd_client::types::Ipv6Entry,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn link_list_all<'a>(
+        &'a self,
+        filter: Option<&'a str>,
+    ) -> Result<
+        dpd_client::ResponseValue<::std::vec::Vec<dpd_client::types::Link>>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn link_ipv4_list<'a>(
+        &'a self,
+        port_id: &'a dpd_client::types::PortId,
+        link_id: &'a dpd_client::types::LinkId,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&'a str>,
+    ) -> Result<
+        dpd_client::ResponseValue<dpd_client::types::Ipv4EntryResultsPage>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn link_ipv6_list<'a>(
+        &'a self,
+        port_id: &'a dpd_client::types::PortId,
+        link_id: &'a dpd_client::types::LinkId,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&'a str>,
+    ) -> Result<
+        dpd_client::ResponseValue<dpd_client::types::Ipv6EntryResultsPage>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    fn tag(&self) -> String;
+
+    async fn route_ipv4_add<'a>(
+        &'a self,
+        body: &'a dpd_client::types::Ipv4RouteUpdate,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn route_ipv6_add<'a>(
+        &'a self,
+        body: &'a dpd_client::types::Ipv6RouteUpdate,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+
+    async fn route_ipv4_delete_target<'a>(
+        &'a self,
+        cidr: &'a oxnet::Ipv4Net,
+        port_id: &'a dpd_client::types::PortId,
+        link_id: &'a dpd_client::types::LinkId,
+        tgt_ip: &'a std::net::Ipv4Addr,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    >;
+}
+
+/// This trait wraps the ddmd methods mg-lower uses.
+pub(crate) trait Ddm {
+    async fn get_originated_tunnel_endpoints(
+        &self,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<
+            Vec<ddm_admin_client::types::TunnelOrigin>,
+        >,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    >;
+
+    async fn get_originated(
+        &self,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<Vec<oxnet::Ipv6Net>>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    >;
+
+    #[allow(clippy::ptr_arg)]
+    async fn advertise_prefixes<'a>(
+        &'a self,
+        body: &'a Vec<oxnet::Ipv6Net>,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<()>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    >;
+
+    #[allow(clippy::ptr_arg)]
+    async fn advertise_tunnel_endpoints<'a>(
+        &'a self,
+        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<()>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    >;
+
+    #[allow(clippy::ptr_arg)]
+    async fn withdraw_tunnel_endpoints<'a>(
+        &'a self,
+        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<()>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    >;
+}
+
+/// This trait wraps the methods that have expectations about switch zone
+/// setup.
+pub(crate) trait SwitchZone {
+    fn get_route(
+        &self,
+        dst: IpNet,
+        timeout: Option<Duration>,
+    ) -> Result<libnet::route::Route, libnet::route::Error>;
+}
+
+/// Production dpd trait that simply passes through calls to a dpd client.
+pub(crate) struct ProductionDpd {
+    pub(crate) client: DpdClient,
+}
+
+impl Dpd for ProductionDpd {
+    async fn route_ipv4_get(
+        &self,
+        cidr: &Ipv4Net,
+    ) -> Result<
+        dpd_client::ResponseValue<
+            ::std::vec::Vec<dpd_client::types::Ipv4Route>,
+        >,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.route_ipv4_get(cidr).await
+    }
+
+    async fn route_ipv6_get(
+        &self,
+        cidr: &Ipv6Net,
+    ) -> Result<
+        dpd_client::ResponseValue<
+            ::std::vec::Vec<dpd_client::types::Ipv6Route>,
+        >,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.route_ipv6_get(cidr).await
+    }
+
+    async fn link_get(
+        &self,
+        port_id: &dpd_client::types::PortId,
+        link_id: &dpd_client::types::LinkId,
+    ) -> Result<
+        dpd_client::ResponseValue<dpd_client::types::Link>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.link_get(port_id, link_id).await
+    }
+
+    async fn loopback_ipv6_create(
+        &self,
+        addr: &dpd_client::types::Ipv6Entry,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.loopback_ipv6_create(addr).await
+    }
+
+    async fn link_list_all<'a>(
+        &'a self,
+        filter: Option<&'a str>,
+    ) -> Result<
+        dpd_client::ResponseValue<::std::vec::Vec<dpd_client::types::Link>>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.link_list_all(filter).await
+    }
+
+    async fn link_ipv4_list<'a>(
+        &'a self,
+        port_id: &'a dpd_client::types::PortId,
+        link_id: &'a dpd_client::types::LinkId,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&'a str>,
+    ) -> Result<
+        dpd_client::ResponseValue<dpd_client::types::Ipv4EntryResultsPage>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client
+            .link_ipv4_list(port_id, link_id, limit, page_token)
+            .await
+    }
+
+    async fn link_ipv6_list<'a>(
+        &'a self,
+        port_id: &'a dpd_client::types::PortId,
+        link_id: &'a dpd_client::types::LinkId,
+        limit: Option<std::num::NonZeroU32>,
+        page_token: Option<&'a str>,
+    ) -> Result<
+        dpd_client::ResponseValue<dpd_client::types::Ipv6EntryResultsPage>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client
+            .link_ipv6_list(port_id, link_id, limit, page_token)
+            .await
+    }
+
+    async fn route_ipv4_add<'a>(
+        &'a self,
+        body: &'a dpd_client::types::Ipv4RouteUpdate,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.route_ipv4_add(body).await
+    }
+
+    async fn route_ipv6_add<'a>(
+        &'a self,
+        body: &'a dpd_client::types::Ipv6RouteUpdate,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client.route_ipv6_add(body).await
+    }
+
+    async fn route_ipv4_delete_target<'a>(
+        &'a self,
+        cidr: &'a oxnet::Ipv4Net,
+        port_id: &'a dpd_client::types::PortId,
+        link_id: &'a dpd_client::types::LinkId,
+        tgt_ip: &'a std::net::Ipv4Addr,
+    ) -> Result<
+        dpd_client::ResponseValue<()>,
+        progenitor_client::Error<dpd_client::types::Error>,
+    > {
+        self.client
+            .route_ipv4_delete_target(cidr, port_id, link_id, tgt_ip)
+            .await
+    }
+
+    fn tag(&self) -> String {
+        self.client.inner().tag.clone()
+    }
+}
+
+/// Production ddm trait that simply passes through calls to a ddm client.
+pub(crate) struct ProductionDdm {
+    pub(crate) client: DdmClient,
+}
+
+impl Ddm for ProductionDdm {
+    async fn get_originated_tunnel_endpoints(
+        &self,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<
+            Vec<ddm_admin_client::types::TunnelOrigin>,
+        >,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    > {
+        self.client.get_originated_tunnel_endpoints().await
+    }
+
+    async fn get_originated(
+        &self,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<Vec<oxnet::Ipv6Net>>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    > {
+        self.client.get_originated().await
+    }
+
+    async fn advertise_prefixes<'a>(
+        &'a self,
+        body: &'a Vec<oxnet::Ipv6Net>,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<()>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    > {
+        self.client.advertise_prefixes(body).await
+    }
+
+    async fn advertise_tunnel_endpoints<'a>(
+        &'a self,
+        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<()>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    > {
+        self.client.advertise_tunnel_endpoints(body).await
+    }
+
+    async fn withdraw_tunnel_endpoints<'a>(
+        &'a self,
+        body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+    ) -> Result<
+        ddm_admin_client::ResponseValue<()>,
+        progenitor_client::Error<ddm_admin_client::types::Error>,
+    > {
+        self.client.withdraw_tunnel_endpoints(body).await
+    }
+}
+
+/// Production dpd trait that simply passes through calls to underlying os
+/// interfaces such as libnet.
+pub(crate) struct ProductionSwitchZone {}
+
+impl SwitchZone for ProductionSwitchZone {
+    fn get_route(
+        &self,
+        dst: IpNet,
+        timeout: Option<Duration>,
+    ) -> Result<libnet::route::Route, libnet::route::Error> {
+        libnet::get_route(dst, timeout)
+    }
+}
+
+/// This module contains platform trait implementations for testing.
+#[cfg(test)]
+pub(crate) mod test {
+    use std::{collections::HashMap, net::IpAddr};
+
+    use dpd_client::types::Ipv6Entry;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    // helper macros for forming dropshot responses
+    macro_rules! dpd_response_ok {
+        ($x:expr) => {
+            dpd_client::ResponseValue::new(
+                $x,
+                reqwest::StatusCode::OK,
+                reqwest::header::HeaderMap::default(),
+            )
+        };
+    }
+    macro_rules! ddm_response_ok {
+        ($x:expr) => {
+            ddm_admin_client::ResponseValue::new(
+                $x,
+                reqwest::StatusCode::OK,
+                reqwest::header::HeaderMap::default(),
+            )
+        };
+    }
+
+    /// A stateful mock dpd implementation. Carries just enough state to be
+    /// useful for tests.
+    pub(crate) struct TestDpd {
+        pub(crate) links: Mutex<Vec<dpd_client::types::Link>>,
+        pub(crate) v4_routes:
+            Mutex<HashMap<Ipv4Net, Vec<dpd_client::types::Ipv4Route>>>,
+        pub(crate) v6_routes:
+            Mutex<HashMap<Ipv6Net, Vec<dpd_client::types::Ipv6Route>>>,
+        pub(crate) v4_addrs: HashMap<String, Vec<dpd_client::types::Ipv4Entry>>,
+        pub(crate) v6_addrs: HashMap<String, Vec<dpd_client::types::Ipv6Entry>>,
+        pub(crate) loopback: Mutex<Option<Ipv6Entry>>,
+    }
+
+    impl Default for TestDpd {
+        fn default() -> Self {
+            Self {
+                links: Mutex::new(Vec::default()),
+                v4_routes: Mutex::new(HashMap::default()),
+                v6_routes: Mutex::new(HashMap::default()),
+                v4_addrs: HashMap::default(),
+                v6_addrs: HashMap::default(),
+                loopback: Mutex::new(None),
+            }
+        }
+    }
+
+    impl Dpd for TestDpd {
+        async fn link_get(
+            &self,
+            port_id: &dpd_client::types::PortId,
+            link_id: &dpd_client::types::LinkId,
+        ) -> Result<
+            dpd_client::ResponseValue<dpd_client::types::Link>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let links = self.links.lock().unwrap();
+            let link = links
+                .iter()
+                .find(|x| &x.port_id == port_id && &x.link_id == link_id);
+
+            match link {
+                Some(l) => Ok(dpd_response_ok!(l.clone())),
+                None => todo!("dpd errors for link get"),
+            }
+        }
+
+        async fn route_ipv4_get(
+            &self,
+            cidr: &Ipv4Net,
+        ) -> Result<
+            dpd_client::ResponseValue<
+                ::std::vec::Vec<dpd_client::types::Ipv4Route>,
+            >,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let result = self
+                .v4_routes
+                .lock()
+                .unwrap()
+                .get(cidr)
+                .cloned()
+                .unwrap_or(Vec::default());
+            Ok(dpd_response_ok!(result))
+        }
+
+        async fn route_ipv6_get(
+            &self,
+            cidr: &Ipv6Net,
+        ) -> Result<
+            dpd_client::ResponseValue<
+                ::std::vec::Vec<dpd_client::types::Ipv6Route>,
+            >,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let result = self
+                .v6_routes
+                .lock()
+                .unwrap()
+                .get(cidr)
+                .cloned()
+                .unwrap_or(Vec::default());
+            Ok(dpd_response_ok!(result))
+        }
+
+        async fn loopback_ipv6_create(
+            &self,
+            addr: &dpd_client::types::Ipv6Entry,
+        ) -> Result<
+            dpd_client::ResponseValue<()>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            self.loopback.lock().unwrap().replace(addr.clone());
+            Ok(dpd_response_ok!(()))
+        }
+
+        async fn link_list_all<'a>(
+            &'a self,
+            filter: Option<&'a str>,
+        ) -> Result<
+            dpd_client::ResponseValue<::std::vec::Vec<dpd_client::types::Link>>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let links = self.links.lock().unwrap();
+            let result = links
+                .iter()
+                .filter(|x| match filter {
+                    Some(f) => x.to_string().contains(f),
+                    None => true,
+                })
+                .cloned()
+                .collect();
+            Ok(dpd_response_ok!(result))
+        }
+
+        async fn link_ipv4_list<'a>(
+            &'a self,
+            port_id: &'a dpd_client::types::PortId,
+            link_id: &'a dpd_client::types::LinkId,
+            _limit: Option<std::num::NonZeroU32>,
+            _page_token: Option<&'a str>,
+        ) -> Result<
+            dpd_client::ResponseValue<dpd_client::types::Ipv4EntryResultsPage>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let lnk = self.link_get(port_id, link_id).await?.into_inner();
+            let addrs = self
+                .v4_addrs
+                .get(&lnk.to_string())
+                .cloned()
+                .unwrap_or_default();
+
+            Ok(dpd_response_ok!(dpd_client::types::Ipv4EntryResultsPage {
+                items: addrs,
+                next_page: None,
+            }))
+        }
+
+        async fn link_ipv6_list<'a>(
+            &'a self,
+            port_id: &'a dpd_client::types::PortId,
+            link_id: &'a dpd_client::types::LinkId,
+            _limit: Option<std::num::NonZeroU32>,
+            _page_token: Option<&'a str>,
+        ) -> Result<
+            dpd_client::ResponseValue<dpd_client::types::Ipv6EntryResultsPage>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let lnk = self.link_get(port_id, link_id).await?.into_inner();
+            let addrs = self
+                .v6_addrs
+                .get(&lnk.to_string())
+                .cloned()
+                .unwrap_or_default();
+
+            Ok(dpd_response_ok!(dpd_client::types::Ipv6EntryResultsPage {
+                items: addrs,
+                next_page: None,
+            }))
+        }
+
+        async fn route_ipv4_add<'a>(
+            &'a self,
+            body: &'a dpd_client::types::Ipv4RouteUpdate,
+        ) -> Result<
+            dpd_client::ResponseValue<()>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let mut routes = self.v4_routes.lock().unwrap();
+            match routes.get_mut(&body.cidr) {
+                Some(targets) => {
+                    targets.push(body.target.clone());
+                }
+                None => {
+                    routes.insert(body.cidr, vec![body.target.clone()]);
+                }
+            }
+            Ok(dpd_response_ok!(()))
+        }
+
+        async fn route_ipv6_add<'a>(
+            &'a self,
+            body: &'a dpd_client::types::Ipv6RouteUpdate,
+        ) -> Result<
+            dpd_client::ResponseValue<()>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let mut routes = self.v6_routes.lock().unwrap();
+            match routes.get_mut(&body.cidr) {
+                Some(targets) => {
+                    targets.push(body.target.clone());
+                }
+                None => {
+                    routes.insert(body.cidr, vec![body.target.clone()]);
+                }
+            }
+            Ok(dpd_response_ok!(()))
+        }
+
+        async fn route_ipv4_delete_target<'a>(
+            &'a self,
+            cidr: &'a oxnet::Ipv4Net,
+            port_id: &'a dpd_client::types::PortId,
+            link_id: &'a dpd_client::types::LinkId,
+            tgt_ip: &'a std::net::Ipv4Addr,
+        ) -> Result<
+            dpd_client::ResponseValue<()>,
+            progenitor_client::Error<dpd_client::types::Error>,
+        > {
+            let mut routes = self.v4_routes.lock().unwrap();
+            if let Some(targets) = routes.get_mut(cidr) {
+                targets.retain(|x| {
+                    !(x.tgt_ip == *tgt_ip
+                        && x.link_id == *link_id
+                        && x.port_id == *port_id)
+                });
+            }
+            Ok(dpd_response_ok!(()))
+        }
+
+        fn tag(&self) -> String {
+            String::from("mg_lower_test")
+        }
+    }
+
+    /// A stateful mock ddm implementation. Carries just enough state to be
+    /// useful for tests.
+    pub(crate) struct TestDdm {
+        pub(crate) tunnel_originated:
+            Mutex<Vec<ddm_admin_client::types::TunnelOrigin>>,
+        pub(crate) originated: Mutex<Vec<oxnet::Ipv6Net>>,
+    }
+
+    impl Default for TestDdm {
+        fn default() -> Self {
+            Self {
+                tunnel_originated: Mutex::new(Vec::default()),
+                originated: Mutex::new(Vec::default()),
+            }
+        }
+    }
+
+    impl Ddm for TestDdm {
+        async fn get_originated_tunnel_endpoints(
+            &self,
+        ) -> Result<
+            ddm_admin_client::ResponseValue<
+                Vec<ddm_admin_client::types::TunnelOrigin>,
+            >,
+            progenitor_client::Error<ddm_admin_client::types::Error>,
+        > {
+            Ok(ddm_response_ok!(self
+                .tunnel_originated
+                .lock()
+                .unwrap()
+                .clone()))
+        }
+
+        async fn get_originated(
+            &self,
+        ) -> Result<
+            ddm_admin_client::ResponseValue<Vec<oxnet::Ipv6Net>>,
+            progenitor_client::Error<ddm_admin_client::types::Error>,
+        > {
+            Ok(ddm_response_ok!(self.originated.lock().unwrap().clone()))
+        }
+
+        async fn advertise_prefixes<'a>(
+            &'a self,
+            body: &'a Vec<oxnet::Ipv6Net>,
+        ) -> Result<
+            ddm_admin_client::ResponseValue<()>,
+            progenitor_client::Error<ddm_admin_client::types::Error>,
+        > {
+            self.originated.lock().unwrap().extend(body);
+            Ok(ddm_response_ok!(()))
+        }
+
+        async fn advertise_tunnel_endpoints<'a>(
+            &'a self,
+            body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+        ) -> Result<
+            ddm_admin_client::ResponseValue<()>,
+            progenitor_client::Error<ddm_admin_client::types::Error>,
+        > {
+            self.tunnel_originated.lock().unwrap().extend(body.clone());
+            Ok(ddm_response_ok!(()))
+        }
+
+        async fn withdraw_tunnel_endpoints<'a>(
+            &'a self,
+            body: &'a Vec<ddm_admin_client::types::TunnelOrigin>,
+        ) -> Result<
+            ddm_admin_client::ResponseValue<()>,
+            progenitor_client::Error<ddm_admin_client::types::Error>,
+        > {
+            self.tunnel_originated
+                .lock()
+                .unwrap()
+                .retain(|x| !body.contains(x));
+            Ok(ddm_response_ok!(()))
+        }
+    }
+
+    /// A mock swtich zone implementation.
+    pub(crate) struct TestSwitchZone {
+        pub(crate) ifname: Option<String>,
+        pub(crate) gw: IpAddr,
+    }
+    impl SwitchZone for TestSwitchZone {
+        fn get_route(
+            &self,
+            dst: IpNet,
+            _timeout: Option<Duration>,
+        ) -> Result<libnet::route::Route, libnet::route::Error> {
+            Ok(libnet::route::Route {
+                dest: dst.addr(),
+                mask: dst.width().into(),
+                gw: self.gw,
+                delay: 0,
+                ifx: self.ifname.clone(),
+            })
+        }
+    }
+}

--- a/mg-lower/src/test.rs
+++ b/mg-lower/src/test.rs
@@ -1,4 +1,4 @@
-use std::{net::Ipv6Addr, sync::Arc};
+use std::{collections::HashMap, net::Ipv6Addr, sync::Arc};
 
 use ddm_admin_client::types::TunnelOrigin;
 use dpd_client::types::{
@@ -17,123 +17,15 @@ async fn sync_prefix_test() {
         let dpd = TestDpd::default();
         let ddm = TestDdm::default();
         let sw = TestSwitchZone {
-            ifname: Some(String::from("tfportqsfp0_0")),
-            gw: "1.2.3.4".parse().unwrap(),
+            routes: HashMap::default(),
+            default_ifname: Some(String::from("tfportqsfp0_0")),
+            default_gw: "1.2.3.4".parse().unwrap(),
         };
         let tep: Ipv6Addr = "fd00:a:b:c::d".parse().unwrap();
 
-        // Set up dpd links
-        dpd.links.lock().unwrap().push(dpd_client::types::Link {
-            address: dpd_client::types::MacAddr {
-                a: [1, 1, 1, 1, 1, 1],
-            },
-            asic_id: 3,
-            autoneg: false,
-            enabled: true,
-            fec: None,
-            fsm_state: String::default(),
-            ipv6_enabled: false,
-            kr: false,
-            link_id: LinkId(0),
-            link_state: LinkState::Up,
-            media: PortMedia::Optical,
-            port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
-            prbs: PortPrbsMode::Mission,
-            presence: true,
-            speed: PortSpeed::Speed100G,
-            tofino_connector: 5,
-        });
-
-        // Add three initial prefixes to dpd
-        dpd.v4_routes.lock().unwrap().insert(
-            "1.0.0.0/24".parse().unwrap(),
-            vec![Ipv4Route {
-                link_id: LinkId(0),
-                port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
-                tag: String::from("mg_lower_test"),
-                tgt_ip: "1.0.0.1".parse().unwrap(),
-                vlan_id: None,
-            }],
-        );
-        dpd.v4_routes.lock().unwrap().insert(
-            "2.0.0.0/24".parse().unwrap(),
-            vec![Ipv4Route {
-                link_id: LinkId(0),
-                port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
-                tag: String::from("mg_lower_test"),
-                tgt_ip: "2.0.0.1".parse().unwrap(),
-                vlan_id: None,
-            }],
-        );
-        dpd.v4_routes.lock().unwrap().insert(
-            "3.0.0.0/24".parse().unwrap(),
-            vec![Ipv4Route {
-                link_id: LinkId(0),
-                port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
-                tag: String::from("mg_lower_test"),
-                tgt_ip: "3.0.0.1".parse().unwrap(),
-                vlan_id: None,
-            }],
-        );
-
-        // Add three initial prefixes to ddm
-        ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
-            boundary_addr: tep,
-            metric: 0,
-            overlay_prefix: "1.0.0.0/24".parse().unwrap(),
-            vni: 1701,
-        });
-        ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
-            boundary_addr: tep,
-            metric: 0,
-            overlay_prefix: "2.0.0.0/24".parse().unwrap(),
-            vni: 1701,
-        });
-        ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
-            boundary_addr: tep,
-            metric: 0,
-            overlay_prefix: "3.0.0.0/24".parse().unwrap(),
-            vni: 1701,
-        });
-
-        // Add three initial prefixes to rib
         let mut rib = Rib::default();
-        rib.insert(
-            "1.0.0.0/24".parse::<Prefix4>().unwrap().into(),
-            vec![Path {
-                nexthop: "1.0.0.1".parse().unwrap(),
-                shutdown: false,
-                rib_priority: 10,
-                bgp: None,
-                vlan_id: None,
-            }]
-            .into_iter()
-            .collect(),
-        );
-        rib.insert(
-            "2.0.0.0/24".parse::<Prefix4>().unwrap().into(),
-            vec![Path {
-                nexthop: "2.0.0.1".parse().unwrap(),
-                shutdown: false,
-                rib_priority: 10,
-                bgp: None,
-                vlan_id: None,
-            }]
-            .into_iter()
-            .collect(),
-        );
-        rib.insert(
-            "3.0.0.0/24".parse::<Prefix4>().unwrap().into(),
-            vec![Path {
-                nexthop: "3.0.0.1".parse().unwrap(),
-                shutdown: false,
-                rib_priority: 10,
-                bgp: None,
-                vlan_id: None,
-            }]
-            .into_iter()
-            .collect(),
-        );
+
+        test_setup(tep, &dpd, &ddm, &mut rib);
 
         // extra prefix should get picked up by tunnel routing
         rib.insert(
@@ -169,4 +61,194 @@ async fn sync_prefix_test() {
 
     // There are four lights!
     assert_eq!(rx.recv().unwrap(), 4);
+}
+
+#[tokio::test]
+async fn sync_link_down_test() {
+    let rt = Arc::new(tokio::runtime::Handle::current());
+    let (tx, rx) = std::sync::mpsc::channel::<(usize, usize)>();
+
+    std::thread::spawn(move || {
+        let dpd = TestDpd::default();
+        let ddm = TestDdm::default();
+        let sw = TestSwitchZone {
+            routes: vec![(
+                "3.0.0.1/32".parse().unwrap(),
+                (
+                    Some(String::from("tfportqsfp1_0")),
+                    "3.0.0.254".parse().unwrap(),
+                ),
+            )]
+            .into_iter()
+            .collect(),
+            default_ifname: Some(String::from("tfportqsfp0_0")),
+            default_gw: "1.2.3.4".parse().unwrap(),
+        };
+        let tep: Ipv6Addr = "fd00:a:b:c::d".parse().unwrap();
+
+        let mut rib = Rib::default();
+
+        test_setup(tep, &dpd, &ddm, &mut rib);
+
+        // Take down a link
+        dpd.links.lock().unwrap().get_mut(1).unwrap().link_state =
+            LinkState::Down;
+
+        let log = util::test::logger();
+
+        crate::sync_prefix(
+            tep,
+            &rib,
+            &"3.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+            &dpd,
+            &ddm,
+            &sw,
+            &log,
+            &rt,
+        )
+        .expect("sync prefix run");
+
+        tx.send((
+            ddm.tunnel_originated.lock().unwrap().len(),
+            dpd.v4_routes.lock().unwrap().len(),
+        ))
+        .unwrap();
+    });
+
+    // There are two lights?
+    assert_eq!(rx.recv().unwrap(), (2, 2));
+}
+
+fn test_setup(tep: Ipv6Addr, dpd: &TestDpd, ddm: &TestDdm, rib: &mut Rib) {
+    // Set up dpd links
+    dpd.links.lock().unwrap().push(dpd_client::types::Link {
+        address: dpd_client::types::MacAddr {
+            a: [1, 1, 1, 1, 1, 1],
+        },
+        asic_id: 3,
+        autoneg: false,
+        enabled: true,
+        fec: None,
+        fsm_state: String::default(),
+        ipv6_enabled: false,
+        kr: false,
+        link_id: LinkId(0),
+        link_state: LinkState::Up,
+        media: PortMedia::Optical,
+        port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+        prbs: PortPrbsMode::Mission,
+        presence: true,
+        speed: PortSpeed::Speed100G,
+        tofino_connector: 5,
+    });
+    dpd.links.lock().unwrap().push(dpd_client::types::Link {
+        address: dpd_client::types::MacAddr {
+            a: [2, 2, 2, 2, 2, 2],
+        },
+        asic_id: 4,
+        autoneg: false,
+        enabled: true,
+        fec: None,
+        fsm_state: String::default(),
+        ipv6_enabled: false,
+        kr: false,
+        link_id: LinkId(0),
+        link_state: LinkState::Up,
+        media: PortMedia::Optical,
+        port_id: PortId::Qsfp("qsfp1".parse().unwrap()),
+        prbs: PortPrbsMode::Mission,
+        presence: true,
+        speed: PortSpeed::Speed100G,
+        tofino_connector: 6,
+    });
+
+    // Add three initial prefixes to dpd
+    dpd.v4_routes.lock().unwrap().insert(
+        "1.0.0.0/24".parse().unwrap(),
+        vec![Ipv4Route {
+            link_id: LinkId(0),
+            port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+            tag: String::from("mg_lower_test"),
+            tgt_ip: "1.0.0.1".parse().unwrap(),
+            vlan_id: None,
+        }],
+    );
+    dpd.v4_routes.lock().unwrap().insert(
+        "2.0.0.0/24".parse().unwrap(),
+        vec![Ipv4Route {
+            link_id: LinkId(0),
+            port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+            tag: String::from("mg_lower_test"),
+            tgt_ip: "2.0.0.1".parse().unwrap(),
+            vlan_id: None,
+        }],
+    );
+    dpd.v4_routes.lock().unwrap().insert(
+        "3.0.0.0/24".parse().unwrap(),
+        vec![Ipv4Route {
+            link_id: LinkId(0),
+            port_id: PortId::Qsfp("qsfp1".parse().unwrap()),
+            tag: String::from("mg_lower_test"),
+            tgt_ip: "3.0.0.1".parse().unwrap(),
+            vlan_id: None,
+        }],
+    );
+
+    // Add three initial prefixes to ddm
+    ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
+        boundary_addr: tep,
+        metric: 0,
+        overlay_prefix: "1.0.0.0/24".parse().unwrap(),
+        vni: 1701,
+    });
+    ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
+        boundary_addr: tep,
+        metric: 0,
+        overlay_prefix: "2.0.0.0/24".parse().unwrap(),
+        vni: 1701,
+    });
+    ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
+        boundary_addr: tep,
+        metric: 0,
+        overlay_prefix: "3.0.0.0/24".parse().unwrap(),
+        vni: 1701,
+    });
+
+    // Add three initial prefixes to rib
+    rib.insert(
+        "1.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+        vec![Path {
+            nexthop: "1.0.0.1".parse().unwrap(),
+            shutdown: false,
+            rib_priority: 10,
+            bgp: None,
+            vlan_id: None,
+        }]
+        .into_iter()
+        .collect(),
+    );
+    rib.insert(
+        "2.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+        vec![Path {
+            nexthop: "2.0.0.1".parse().unwrap(),
+            shutdown: false,
+            rib_priority: 10,
+            bgp: None,
+            vlan_id: None,
+        }]
+        .into_iter()
+        .collect(),
+    );
+    rib.insert(
+        "3.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+        vec![Path {
+            nexthop: "3.0.0.1".parse().unwrap(),
+            shutdown: false,
+            rib_priority: 10,
+            bgp: None,
+            vlan_id: None,
+        }]
+        .into_iter()
+        .collect(),
+    );
 }

--- a/mg-lower/src/test.rs
+++ b/mg-lower/src/test.rs
@@ -1,0 +1,172 @@
+use std::{net::Ipv6Addr, sync::Arc};
+
+use ddm_admin_client::types::TunnelOrigin;
+use dpd_client::types::{
+    Ipv4Route, LinkId, LinkState, PortId, PortMedia, PortPrbsMode, PortSpeed,
+};
+use rdb::{db::Rib, Path, Prefix4};
+
+use crate::platform::test::{TestDdm, TestDpd, TestSwitchZone};
+
+#[tokio::test]
+async fn sync_prefix_test() {
+    let rt = Arc::new(tokio::runtime::Handle::current());
+    let (tx, rx) = std::sync::mpsc::channel::<usize>();
+
+    std::thread::spawn(move || {
+        let dpd = TestDpd::default();
+        let ddm = TestDdm::default();
+        let sw = TestSwitchZone {
+            ifname: Some(String::from("tfportqsfp0_0")),
+            gw: "1.2.3.4".parse().unwrap(),
+        };
+        let tep: Ipv6Addr = "fd00:a:b:c::d".parse().unwrap();
+
+        // Set up dpd links
+        dpd.links.lock().unwrap().push(dpd_client::types::Link {
+            address: dpd_client::types::MacAddr {
+                a: [1, 1, 1, 1, 1, 1],
+            },
+            asic_id: 3,
+            autoneg: false,
+            enabled: true,
+            fec: None,
+            fsm_state: String::default(),
+            ipv6_enabled: false,
+            kr: false,
+            link_id: LinkId(0),
+            link_state: LinkState::Up,
+            media: PortMedia::Optical,
+            port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+            prbs: PortPrbsMode::Mission,
+            presence: true,
+            speed: PortSpeed::Speed100G,
+            tofino_connector: 5,
+        });
+
+        // Add three initial prefixes to dpd
+        dpd.v4_routes.lock().unwrap().insert(
+            "1.0.0.0/24".parse().unwrap(),
+            vec![Ipv4Route {
+                link_id: LinkId(0),
+                port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+                tag: String::from("mg_lower_test"),
+                tgt_ip: "1.0.0.1".parse().unwrap(),
+                vlan_id: None,
+            }],
+        );
+        dpd.v4_routes.lock().unwrap().insert(
+            "2.0.0.0/24".parse().unwrap(),
+            vec![Ipv4Route {
+                link_id: LinkId(0),
+                port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+                tag: String::from("mg_lower_test"),
+                tgt_ip: "2.0.0.1".parse().unwrap(),
+                vlan_id: None,
+            }],
+        );
+        dpd.v4_routes.lock().unwrap().insert(
+            "3.0.0.0/24".parse().unwrap(),
+            vec![Ipv4Route {
+                link_id: LinkId(0),
+                port_id: PortId::Qsfp("qsfp0".parse().unwrap()),
+                tag: String::from("mg_lower_test"),
+                tgt_ip: "3.0.0.1".parse().unwrap(),
+                vlan_id: None,
+            }],
+        );
+
+        // Add three initial prefixes to ddm
+        ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
+            boundary_addr: tep,
+            metric: 0,
+            overlay_prefix: "1.0.0.0/24".parse().unwrap(),
+            vni: 1701,
+        });
+        ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
+            boundary_addr: tep,
+            metric: 0,
+            overlay_prefix: "2.0.0.0/24".parse().unwrap(),
+            vni: 1701,
+        });
+        ddm.tunnel_originated.lock().unwrap().push(TunnelOrigin {
+            boundary_addr: tep,
+            metric: 0,
+            overlay_prefix: "3.0.0.0/24".parse().unwrap(),
+            vni: 1701,
+        });
+
+        // Add three initial prefixes to rib
+        let mut rib = Rib::default();
+        rib.insert(
+            "1.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+            vec![Path {
+                nexthop: "1.0.0.1".parse().unwrap(),
+                shutdown: false,
+                rib_priority: 10,
+                bgp: None,
+                vlan_id: None,
+            }]
+            .into_iter()
+            .collect(),
+        );
+        rib.insert(
+            "2.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+            vec![Path {
+                nexthop: "2.0.0.1".parse().unwrap(),
+                shutdown: false,
+                rib_priority: 10,
+                bgp: None,
+                vlan_id: None,
+            }]
+            .into_iter()
+            .collect(),
+        );
+        rib.insert(
+            "3.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+            vec![Path {
+                nexthop: "3.0.0.1".parse().unwrap(),
+                shutdown: false,
+                rib_priority: 10,
+                bgp: None,
+                vlan_id: None,
+            }]
+            .into_iter()
+            .collect(),
+        );
+
+        // extra prefix should get picked up by tunnel routing
+        rib.insert(
+            "4.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+            vec![Path {
+                nexthop: "3.0.0.1".parse().unwrap(),
+                shutdown: false,
+                rib_priority: 10,
+                bgp: None,
+                vlan_id: None,
+            }]
+            .into_iter()
+            .collect(),
+        );
+
+        let log = util::test::logger();
+
+        crate::sync_prefix(
+            tep,
+            &rib,
+            &"4.0.0.0/24".parse::<Prefix4>().unwrap().into(),
+            &dpd,
+            &ddm,
+            &sw,
+            &log,
+            &rt,
+        )
+        .expect("sync prefix run");
+
+        tx.send(ddm.tunnel_originated.lock().unwrap().len())
+            .unwrap();
+    });
+
+    // There are four lights!
+    assert_eq!(rx.recv().unwrap(), 4);
+}

--- a/rdb/Cargo.toml
+++ b/rdb/Cargo.toml
@@ -17,3 +17,4 @@ slog-async.workspace = true
 mg-common.workspace = true
 itertools.workspace = true
 chrono.workspace = true
+oxnet.workspace = true

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -290,6 +290,20 @@ pub enum Prefix {
     V6(Prefix6),
 }
 
+impl PartialEq<&Prefix> for oxnet::IpNet {
+    fn eq(&self, other: &&Prefix) -> bool {
+        match (self, other) {
+            (Self::V4(a), Prefix::V4(b)) => {
+                a.addr() == b.value && a.width() == b.length
+            }
+            (Self::V6(a), Prefix::V6(b)) => {
+                a.addr() == b.value && a.width() == b.length
+            }
+            _ => false,
+        }
+    }
+}
+
 impl std::fmt::Display for Prefix {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {


### PR DESCRIPTION
This PR fixes the bug described in #538.

The fix itself is the single line commit b90fabd7ce6fab43e052fa1a1a471a6824445382.

All of the other code in this PR is testing infrastructure in service of catching this kind of bug in CI. A series of traits are added that allow dpd, mgd and certain aspects of switch zones to be mocked up for testing. Mg-lower functions that previously used dropshot clients for dpd, ddm and the libnet interface directly now take trait impls. Production implementations of these trait impls simply pass calls through to dropshot clients or system interfaces. Testing implementations of these traits implement mock ups of these underlying subsystems.

A regression test has been added that captures #538 and is demonstrated in CI [here](https://github.com/oxidecomputer/maghemite/runs/49663852665).