### PR TITLE
update ddm-admin version to drop the leading v

### DIFF
--- a/openapi/ddm-admin.json
+++ b/openapi/ddm-admin.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "DDM Admin",
-    "version": "v0.1.0"
+    "version": "0.1.0"
   },
   "paths": {
     "/disable-stats": {


### PR DESCRIPTION
Found this because the Dropshot API manager isn't able to parse the ddm-admin document currently on main.

Generated a new `ddm-admin.json` by running `ddm-apigen`.
