### PR TITLE
bgp: return BgpConnectionTcp sockets returned by Listener to nonblocking=false

### DIFF
--- a/bgp/src/connection_tcp.rs
+++ b/bgp/src/connection_tcp.rs
@@ -116,6 +116,10 @@ impl BgpListener<BgpConnectionTcp> for BgpListenerTcp {
                 "at least one address required".into(),
             ))?;
         let listener = TcpListener::bind(addr)?;
+        // We set nonblocking to true on the listener because accept() can block
+        // indefinitely and there isn't a portable way to do so with a timeout.
+        // We would have to start using poll() to accomplish this, which is a
+        // heavier lift that hasn't yet been deemed worthwhile.
         listener.set_nonblocking(true)?;
         Ok(Self {
             listener,
@@ -137,6 +141,17 @@ impl BgpListener<BgpConnectionTcp> for BgpListenerTcp {
         loop {
             match self.listener.accept() {
                 Ok((conn, mut peer)) => {
+                    // Override the nonblocking value of the parent TcpListener.
+                    // Reads and Writes use a timeout via the std API, which is
+                    // non-functional on nonblocking sockets.
+                    if let Err(e) = conn.set_nonblocking(false) {
+                        slog::error!(log,
+                            "failed to set accepted connection to blocking: {e}";
+                            "error" => format!("{e}")
+                        );
+                        return Err(e.into());
+                    }
+
                     // Get the actual socket addresses for this accepted
                     // connection. This is critical for dual-stack scenarios
                     // where the listener may bind to an IPv6 address but accept


### PR DESCRIPTION
It was observed in a customer deployment that several (16) recv loop threads were pinning the CPU due to a busy loop that was constantly handling EAGAIN.
Code analysis showed that non_blocking was set to true only for inbound connections, as the Listener<BgpConnectionTcp> was configured to be nonblocking and TCP sockets returned by accept() inherit this setting. The recv loop thread for each BgpConnectionTcp is structured in a way that depends on SO_RCVTIMEO being respected in order to rate limit the busy loop. However, when nonblocking is true SO_RCVTIMEO is ignored and EAGAIN/EWOULDBLOCK is returned immediately -- short-circuiting the timeout that rate limits the busy loop.

This explicitly sets nonblocking to false for the new sockets returned by accept(), which ensures that the timeout works to rate limit the busy loop as expected.

Fixes: #657