### PR TITLE
renovate: group opte updates together by url

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,11 @@
     "local>oxidecomputer/renovate-config",
     "local>oxidecomputer/renovate-config//rust/autocreate",
     "local>oxidecomputer/renovate-config//actions/pin"
+  ],
+  "packageRules": [
+    {
+      "matchSourceUrls": ["https://github.com/oxidecomputer/opte"],
+      "groupName": "opte"
+    }
   ]
 }


### PR DESCRIPTION
Updates the renovate config to force OPTE updates to be grouped together into a single PR if they all share the same git url.