### PR TITLE
happy maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "iddqd",
  "itertools 0.14.0",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ serial_test = "3.3"
 internet-checksum = "0.2.1"
 network-interface = { git = "https://github.com/oxidecomputer/network-interface", branch = "illumos" }
 natord = "1.0"
+iddqd = "0.3"
 
 
 [workspace.dependencies.opte-ioctl]

--- a/bgp/Cargo.toml
+++ b/bgp/Cargo.toml
@@ -23,6 +23,7 @@ itertools.workspace = true
 oxnet.workspace = true
 uuid.workspace = true
 rand.workspace = true
+iddqd.workspace = true
 clap = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "illumos")'.dependencies]

--- a/bgp/src/connection.rs
+++ b/bgp/src/connection.rs
@@ -6,12 +6,12 @@ use crate::{
     clock::ConnectionClock,
     error::Error,
     messages::Message,
-    session::{FsmEvent, PeerId, SessionEndpoint, SessionInfo},
+    router::SessionMap,
+    session::{FsmEvent, SessionInfo},
     unnumbered::UnnumberedManager,
 };
 use slog::Logger;
 use std::{
-    collections::BTreeMap,
     net::{SocketAddr, ToSocketAddrs},
     sync::{Arc, Mutex, mpsc::Sender},
     thread::JoinHandle,
@@ -49,11 +49,11 @@ pub trait BgpListener<Cnx: BgpConnection> {
     /// Accept a connection. This Listener is non-blocking, so the timeout
     /// is used as a sleep between accept attempts. This function may be called
     /// multiple times, returning a new connection each time. Policy application
-    /// is handled by the Dispatcher after the peer_to_session lookup.
+    /// is handled by the Dispatcher after the session lookup.
     fn accept(
         &self,
         log: Logger,
-        peer_to_session: Arc<Mutex<BTreeMap<PeerId, SessionEndpoint<Cnx>>>>,
+        sessions: Arc<Mutex<SessionMap<Cnx>>>,
         timeout: Duration,
     ) -> Result<Cnx, Error>;
 

--- a/bgp/src/connection_channel.rs
+++ b/bgp/src/connection_channel.rs
@@ -17,15 +17,14 @@ use crate::{
     error::Error,
     log::{connection_log, connection_log_lite},
     messages::Message,
-    session::{
-        ConnectionEvent, FsmEvent, PeerId, SessionEndpoint, SessionInfo,
-    },
+    router::SessionMap,
+    session::{ConnectionEvent, FsmEvent, PeerId, SessionInfo},
     unnumbered::UnnumberedManager,
 };
 use mg_common::lock;
 use slog::{Logger, info};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     net::{SocketAddr, ToSocketAddrs},
     sync::{
         Arc, Mutex,
@@ -232,38 +231,32 @@ impl BgpListener<BgpConnectionChannel> for BgpListenerChannel {
     fn accept(
         &self,
         log: Logger,
-        peer_to_session: Arc<
-            Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-        >,
+        sessions: Arc<Mutex<SessionMap<BgpConnectionChannel>>>,
         timeout: Duration,
     ) -> Result<BgpConnectionChannel, Error> {
         let (peer, endpoint) = self.listener.accept(timeout)?;
 
-        // For channel-based test connections, we use the bind address as the local
-        // address. In a real network scenario (like TCP), we would need to get the
-        // actual connection's local address to handle dual-stack correctly, but for
-        // testing purposes with channels, the bind address is the connection address.
         let local = self.bind_addr;
 
         // Resolve peer address to appropriate PeerId (IP or Interface)
         let key = self.resolve_session_key(peer);
 
-        match lock!(peer_to_session).get(&key) {
-            Some(session_endpoint) => {
-                let config = lock!(session_endpoint.config);
-                Ok(BgpConnectionChannel::with_conn(
-                    local,
-                    peer,
-                    endpoint,
-                    session_endpoint.event_tx.clone(),
-                    IO_TIMEOUT,
-                    log,
-                    ConnectionDirection::Inbound,
-                    &config,
-                ))
-            }
-            None => Err(Error::UnknownPeer(peer.ip())),
-        }
+        let runner = lock!(sessions)
+            .get(&key)
+            .cloned()
+            .ok_or(Error::UnknownPeer(peer.ip()))?;
+
+        let config = lock!(runner.session);
+        Ok(BgpConnectionChannel::with_conn(
+            local,
+            peer,
+            endpoint,
+            runner.event_tx.clone(),
+            IO_TIMEOUT,
+            log,
+            ConnectionDirection::Inbound,
+            &config,
+        ))
     }
 
     fn apply_policy(

--- a/bgp/src/connection_tcp.rs
+++ b/bgp/src/connection_tcp.rs
@@ -20,16 +20,13 @@ use crate::{
         RouteRefreshParseErrorReason, notification_message_from_wire,
         open_message_from_wire, route_refresh_message_from_wire,
     },
-    session::{
-        ConnectionEvent, FsmEvent, PeerId, SessionEndpoint, SessionEvent,
-        SessionInfo,
-    },
+    router::SessionMap,
+    session::{ConnectionEvent, FsmEvent, PeerId, SessionEvent, SessionInfo},
     unnumbered::UnnumberedManager,
 };
 use mg_common::lock;
 use slog::{Logger, info};
 use std::{
-    collections::BTreeMap,
     io::Read,
     io::Write,
     net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs},
@@ -138,9 +135,7 @@ impl BgpListener<BgpConnectionTcp> for BgpListenerTcp {
     fn accept(
         &self,
         log: Logger,
-        peer_to_session: Arc<
-            Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionTcp>>>,
-        >,
+        sessions: Arc<Mutex<SessionMap<BgpConnectionTcp>>>,
         timeout: Duration,
     ) -> Result<BgpConnectionTcp, Error> {
         let start = Instant::now();
@@ -172,23 +167,24 @@ impl BgpListener<BgpConnectionTcp> for BgpListenerTcp {
                     // Resolve peer address to appropriate PeerId (IP or Interface)
                     let key = self.resolve_session_key(peer);
 
-                    // Check if we have a session for this peer
-                    match lock!(peer_to_session).get(&key) {
-                        Some(session_endpoint) => {
-                            let config = lock!(session_endpoint.config);
-                            return BgpConnectionTcp::with_conn(
-                                local,
-                                peer,
-                                conn,
-                                IO_TIMEOUT,
-                                session_endpoint.event_tx.clone(),
-                                log,
-                                ConnectionDirection::Inbound,
-                                &config,
-                            );
-                        }
-                        None => return Err(Error::UnknownPeer(ip)),
-                    }
+                    // Look up the session runner, clone the Arc, then release
+                    // the sessions lock before accessing session config.
+                    let runner = lock!(sessions)
+                        .get(&key)
+                        .cloned()
+                        .ok_or(Error::UnknownPeer(ip))?;
+
+                    let config = lock!(runner.session);
+                    return BgpConnectionTcp::with_conn(
+                        local,
+                        peer,
+                        conn,
+                        IO_TIMEOUT,
+                        runner.event_tx.clone(),
+                        log,
+                        ConnectionDirection::Inbound,
+                        &config,
+                    );
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // Check if we've exceeded the timeout

--- a/bgp/src/dispatcher.rs
+++ b/bgp/src/dispatcher.rs
@@ -5,13 +5,13 @@
 use crate::{
     IO_TIMEOUT,
     connection::{BgpConnection, BgpListener},
-    session::{FsmEvent, PeerId, SessionEndpoint, SessionEvent},
+    router::SessionMap,
+    session::{FsmEvent, PeerId, SessionEvent},
     unnumbered::UnnumberedManager,
 };
 use mg_common::lock;
 use slog::{Logger, debug, error, info, warn};
 use std::{
-    collections::BTreeMap,
     net::SocketAddr,
     sync::atomic::{AtomicBool, Ordering},
     sync::{Arc, Mutex},
@@ -21,10 +21,9 @@ use std::{
 
 const UNIT_DISPATCHER: &str = "dispatcher";
 
-pub struct Dispatcher<Cnx: BgpConnection> {
-    /// Session endpoint map indexed by PeerId (IP or interface name)
-    /// This unified map supports both numbered and unnumbered BGP sessions
-    pub peer_to_session: Arc<Mutex<BTreeMap<PeerId, SessionEndpoint<Cnx>>>>,
+pub struct Dispatcher<Cnx: BgpConnection + 'static> {
+    /// Session map shared with all Routers, indexed by PeerId.
+    pub sessions: Arc<Mutex<SessionMap<Cnx>>>,
 
     /// Optional unnumbered neighbor manager for link-local connection routing.
     /// When present, enables routing of IPv6 link-local connections to
@@ -38,7 +37,7 @@ pub struct Dispatcher<Cnx: BgpConnection> {
 
 impl<Cnx: BgpConnection + 'static> Dispatcher<Cnx> {
     pub fn new(
-        peer_to_session: Arc<Mutex<BTreeMap<PeerId, SessionEndpoint<Cnx>>>>,
+        sessions: Arc<Mutex<SessionMap<Cnx>>>,
         listen: String,
         log: Logger,
         unnumbered_manager: Option<Arc<dyn UnnumberedManager>>,
@@ -50,7 +49,7 @@ impl<Cnx: BgpConnection + 'static> Dispatcher<Cnx> {
         ));
 
         Self {
-            peer_to_session,
+            sessions,
             unnumbered_manager,
             listen,
             log: Mutex::new(log),
@@ -145,7 +144,7 @@ impl<Cnx: BgpConnection + 'static> Dispatcher<Cnx> {
 
                 let accepted = match listener.accept(
                     log.clone(),
-                    self.peer_to_session.clone(),
+                    self.sessions.clone(),
                     IO_TIMEOUT,
                 ) {
                     Ok(c) => {
@@ -171,41 +170,40 @@ impl<Cnx: BgpConnection + 'static> Dispatcher<Cnx> {
                     "session_key" => format!("{key:?}"),
                 ));
 
-                match lock!(self.peer_to_session).get(&key).cloned() {
-                    Some(session_endpoint) => {
-                        // Apply connection policy from the session configuration
-                        let min_ttl = lock!(session_endpoint.config).min_ttl;
-                        let md5_key =
-                            lock!(session_endpoint.config).md5_auth_key.clone();
-
-                        if let Err(e) =
-                            Listener::apply_policy(&accepted, min_ttl, md5_key)
-                        {
-                            warn!(session_log,
-                                "failed to apply policy for connection";
-                                "error" => format!("{e}")
-                            );
-                        }
-
-                        if let Err(e) =
-                            session_endpoint.event_tx.send(FsmEvent::Session(
-                                SessionEvent::TcpConnectionAcked(accepted),
-                            ))
-                        {
-                            error!(session_log,
-                                "failed to send connected event to session";
-                                "error" => format!("{e}")
-                            );
-                            continue 'listener;
-                        }
-                    }
-                    None => {
+                let (runner, min_ttl, md5_key) = {
+                    let sessions = lock!(self.sessions);
+                    let Some(runner) = sessions.get(&key).cloned() else {
                         debug!(
                             session_log,
                             "no session found for peer, dropping connection"
                         );
                         continue 'accept;
-                    }
+                    };
+                    let config = lock!(runner.session);
+                    (
+                        runner.clone(),
+                        config.min_ttl,
+                        config.md5_auth_key.clone(),
+                    )
+                };
+
+                if let Err(e) =
+                    Listener::apply_policy(&accepted, min_ttl, md5_key)
+                {
+                    warn!(session_log,
+                        "failed to apply policy for connection";
+                        "error" => format!("{e}")
+                    );
+                }
+
+                if let Err(e) = runner.event_tx.send(FsmEvent::Session(
+                    SessionEvent::TcpConnectionAcked(accepted),
+                )) {
+                    error!(session_log,
+                        "failed to send connected event to session";
+                        "error" => format!("{e}")
+                    );
+                    continue 'listener;
                 }
             }
         }
@@ -225,7 +223,7 @@ impl<Cnx: BgpConnection + 'static> Dispatcher<Cnx> {
     }
 }
 
-impl<Cnx: BgpConnection> Drop for Dispatcher<Cnx> {
+impl<Cnx: BgpConnection + 'static> Drop for Dispatcher<Cnx> {
     fn drop(&mut self) {
         debug!(lock!(self.log), "dropping dispatcher");
     }

--- a/bgp/src/router.rs
+++ b/bgp/src/router.rs
@@ -70,8 +70,13 @@ impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
         self.0.get(peer).map(|h| &h.0)
     }
 
-    pub fn insert(&mut self, session: Arc<SessionRunner<Cnx>>) {
-        self.0.insert_overwrite(SessionHandle(session));
+    /// Inserts `session`, overwriting any existing entry for the same
+    /// `PeerId`. Returns the displaced session if one was present.
+    pub fn insert_overwrite(
+        &mut self,
+        session: Arc<SessionRunner<Cnx>>,
+    ) -> Option<Arc<SessionRunner<Cnx>>> {
+        self.0.insert_overwrite(SessionHandle(session)).map(|h| h.0)
     }
 
     pub fn remove(&mut self, peer: &PeerId) -> Option<Arc<SessionRunner<Cnx>>> {
@@ -442,7 +447,7 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
             unnumbered_manager,
         ));
 
-        sessions.insert(runner.clone());
+        sessions.insert_overwrite(runner.clone());
         drop(sessions);
 
         self.spawn_session_thread(runner.clone());

--- a/bgp/src/router.rs
+++ b/bgp/src/router.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     unnumbered::UnnumberedManager,
 };
+use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
 use mg_api_types::rdb::prefix::{Prefix4, Prefix6};
 use mg_common::{lock, read_lock, write_lock};
 use rdb::{Asn, Db};
@@ -35,6 +36,80 @@ use std::{
     time::Duration,
 };
 
+/// Internal newtype for `IdOrdItem` impl — not exposed outside this module.
+struct SessionHandle<Cnx: BgpConnection + 'static>(Arc<SessionRunner<Cnx>>);
+
+impl<Cnx: BgpConnection + 'static> IdOrdItem for SessionHandle<Cnx> {
+    type Key<'a> = &'a PeerId;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.0.neighbor.peer
+    }
+
+    id_upcast!();
+}
+
+/// Ordered map of active BGP sessions, keyed by PeerId derived from each
+/// session's neighbor info. Wraps an `IdOrdMap` so the key can never
+/// diverge from the value it indexes.
+pub struct SessionMap<Cnx: BgpConnection + 'static>(
+    IdOrdMap<SessionHandle<Cnx>>,
+);
+
+impl<Cnx: BgpConnection + 'static> Default for SessionMap<Cnx> {
+    fn default() -> Self {
+        Self(IdOrdMap::default())
+    }
+}
+
+impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(
+        &self,
+        peer: &PeerId,
+    ) -> Option<&Arc<SessionRunner<Cnx>>> {
+        self.0.get(peer).map(|h| &h.0)
+    }
+
+    pub fn insert(&mut self, session: Arc<SessionRunner<Cnx>>) {
+        self.0.insert_overwrite(SessionHandle(session));
+    }
+
+    pub fn remove(
+        &mut self,
+        peer: &PeerId,
+    ) -> Option<Arc<SessionRunner<Cnx>>> {
+        self.0.remove(peer).map(|h| h.0)
+    }
+
+    pub fn contains_key(&self, peer: &PeerId) -> bool {
+        self.0.contains_key(peer)
+    }
+
+    pub fn values(
+        &self,
+    ) -> impl Iterator<Item = &Arc<SessionRunner<Cnx>>> {
+        self.0.iter().map(|h| &h.0)
+    }
+
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&PeerId, &Arc<SessionRunner<Cnx>>)> {
+        self.0.iter().map(|h| (&h.0.neighbor.peer, &h.0))
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &PeerId> {
+        self.0.iter().map(|h| &h.0.neighbor.peer)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 const UNIT_SESSION_RUNNER: &str = "session_runner";
 
 pub struct Router<Cnx: BgpConnection + 'static> {
@@ -47,7 +122,7 @@ pub struct Router<Cnx: BgpConnection + 'static> {
     pub config: RouterConfig,
 
     /// A set of BGP session runners indexed by PeerId (IP or interface).
-    pub sessions: Mutex<BTreeMap<PeerId, Arc<SessionRunner<Cnx>>>>,
+    pub sessions: Mutex<SessionMap<Cnx>>,
 
     /// Compiled policy programs.
     pub policy: Policy,
@@ -96,7 +171,7 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
             shutdown: AtomicBool::new(false),
             graceful_shutdown: AtomicBool::new(false),
             db,
-            sessions: Mutex::new(BTreeMap::new()),
+            sessions: Mutex::new(SessionMap::new()),
             fanout4: Arc::new(RwLock::new(Fanout4::default())),
             fanout6: Arc::new(RwLock::new(Fanout6::default())),
             policy: Policy::default(),
@@ -140,8 +215,8 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
     /// Also cleans up fanout entries for all stopped sessions.
     fn stop_all_sessions(&self) {
         let sessions = lock!(self.sessions);
-        for (key, s) in sessions.iter() {
-            self.remove_fanout(key.clone());
+        for (peer, s) in sessions.iter() {
+            self.remove_fanout(peer.clone());
             s.shutdown();
         }
     }
@@ -151,9 +226,9 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
     /// references, allowing BgpConnections to drop and their threads to clean up.
     fn delete_all_sessions(&self) {
         let sessions = std::mem::take(&mut *lock!(self.sessions));
-        for (key, s) in sessions {
-            lock!(self.peer_to_session).remove(&key);
-            self.remove_fanout(key.clone());
+        for (peer, s) in sessions.iter() {
+            lock!(self.peer_to_session).remove(peer);
+            self.remove_fanout(peer.clone());
             s.shutdown();
         }
         // When `sessions` drops here, Arc<SessionRunner> references are released
@@ -399,7 +474,7 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         ));
 
         self.spawn_session_thread(runner.clone());
-        lock!(self.sessions).insert(peer_id, runner.clone());
+        lock!(self.sessions).insert(runner.clone());
 
         Ok(runner)
     }

--- a/bgp/src/router.rs
+++ b/bgp/src/router.rs
@@ -14,8 +14,7 @@ use crate::{
     },
     policy::{load_checker, load_shaper},
     session::{
-        AdminEvent, FsmEvent, NeighborInfo, PeerId, SessionEndpoint,
-        SessionInfo, SessionRunner,
+        AdminEvent, FsmEvent, NeighborInfo, PeerId, SessionInfo, SessionRunner,
     },
     unnumbered::UnnumberedManager,
 };
@@ -26,7 +25,7 @@ use rdb::{Asn, Db};
 use rhai::AST;
 use slog::Logger;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     net::SocketAddr,
     sync::{
         Arc, Mutex, MutexGuard, RwLock,
@@ -67,10 +66,7 @@ impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
         Self::default()
     }
 
-    pub fn get(
-        &self,
-        peer: &PeerId,
-    ) -> Option<&Arc<SessionRunner<Cnx>>> {
+    pub fn get(&self, peer: &PeerId) -> Option<&Arc<SessionRunner<Cnx>>> {
         self.0.get(peer).map(|h| &h.0)
     }
 
@@ -78,10 +74,7 @@ impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
         self.0.insert_overwrite(SessionHandle(session));
     }
 
-    pub fn remove(
-        &mut self,
-        peer: &PeerId,
-    ) -> Option<Arc<SessionRunner<Cnx>>> {
+    pub fn remove(&mut self, peer: &PeerId) -> Option<Arc<SessionRunner<Cnx>>> {
         self.0.remove(peer).map(|h| h.0)
     }
 
@@ -89,9 +82,7 @@ impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
         self.0.contains_key(peer)
     }
 
-    pub fn values(
-        &self,
-    ) -> impl Iterator<Item = &Arc<SessionRunner<Cnx>>> {
+    pub fn values(&self) -> impl Iterator<Item = &Arc<SessionRunner<Cnx>>> {
         self.0.iter().map(|h| &h.0)
     }
 
@@ -122,7 +113,8 @@ pub struct Router<Cnx: BgpConnection + 'static> {
     pub config: RouterConfig,
 
     /// A set of BGP session runners indexed by PeerId (IP or interface).
-    pub sessions: Mutex<SessionMap<Cnx>>,
+    /// Shared with the Dispatcher for connection routing.
+    pub sessions: Arc<Mutex<SessionMap<Cnx>>>,
 
     /// Compiled policy programs.
     pub policy: Policy,
@@ -136,10 +128,6 @@ pub struct Router<Cnx: BgpConnection + 'static> {
     /// A flag indicating whether this router should initiate a
     /// graceful shutdown (RFC 8326) with its peers.
     graceful_shutdown: AtomicBool,
-
-    /// A set of event channels indexed by PeerId. These channels
-    /// are used for cross-peer session communications.
-    peer_to_session: Arc<Mutex<BTreeMap<PeerId, SessionEndpoint<Cnx>>>>,
 
     /// A fanout is used to distribute originated prefixes to all peer
     /// sessions. In the event that redistribution becomes supported this
@@ -162,18 +150,17 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         config: RouterConfig,
         log: Logger,
         db: Db,
-        peer_to_session: Arc<Mutex<BTreeMap<PeerId, SessionEndpoint<Cnx>>>>,
+        sessions: Arc<Mutex<SessionMap<Cnx>>>,
     ) -> Router<Cnx> {
         Self {
             config,
-            peer_to_session,
+            sessions,
             log,
             shutdown: AtomicBool::new(false),
             graceful_shutdown: AtomicBool::new(false),
             db,
-            sessions: Mutex::new(SessionMap::new()),
-            fanout4: Arc::new(RwLock::new(Fanout4::default())),
-            fanout6: Arc::new(RwLock::new(Fanout6::default())),
+            fanout4: Arc::new(RwLock::new(Fanout4::<Cnx>::default())),
+            fanout6: Arc::new(RwLock::new(Fanout6::<Cnx>::default())),
             policy: Policy::default(),
         }
     }
@@ -227,11 +214,9 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
     fn delete_all_sessions(&self) {
         let sessions = std::mem::take(&mut *lock!(self.sessions));
         for (peer, s) in sessions.iter() {
-            lock!(self.peer_to_session).remove(peer);
             self.remove_fanout(peer.clone());
             s.shutdown();
         }
-        // When `sessions` drops here, Arc<SessionRunner> references are released
     }
 
     pub fn shutdown(&self) {
@@ -323,16 +308,16 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         event_rx: Receiver<FsmEvent<Cnx>>,
         info: SessionInfo,
     ) -> Result<EnsureSessionResult<Cnx>, Error> {
-        let p2s = lock!(self.peer_to_session);
-        // Use PeerId::Ip for numbered sessions
+        let sessions = lock!(self.sessions);
         let key = PeerId::Ip(peer.host.ip());
-        if p2s.contains_key(&key) {
+        if sessions.contains_key(&key) {
+            drop(sessions);
             Ok(EnsureSessionResult::Updated(
                 self.update_session(peer, info)?,
             ))
         } else {
             Ok(EnsureSessionResult::New(self.new_session_locked(
-                p2s, key, peer, bind_addr, event_tx, event_rx, info, None,
+                sessions, key, peer, bind_addr, event_tx, event_rx, info, None,
             )?))
         }
     }
@@ -348,19 +333,16 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         info: SessionInfo,
         unnumbered_manager: Arc<dyn UnnumberedManager>,
     ) -> Result<EnsureSessionResult<Cnx>, Error> {
-        let p2s = lock!(self.peer_to_session);
+        let sessions = lock!(self.sessions);
         let key = PeerId::Interface(interface.clone());
-        if p2s.contains_key(&key) {
-            // Session exists, just update config
-            // Drop the lock before calling update to avoid potential deadlock
-            drop(p2s);
+        if sessions.contains_key(&key) {
+            drop(sessions);
             Ok(EnsureSessionResult::Updated(
                 self.update_unnumbered_session(&interface, peer, info)?,
             ))
         } else {
-            // Create new unnumbered session
             Ok(EnsureSessionResult::New(self.new_session_locked(
-                p2s,
+                sessions,
                 key,
                 peer,
                 bind_addr,
@@ -380,15 +362,13 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         event_rx: Receiver<FsmEvent<Cnx>>,
         info: SessionInfo,
     ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
-        let p2s = lock!(self.peer_to_session);
-        // Use PeerId::Ip for numbered sessions
+        let sessions = lock!(self.sessions);
         let key = PeerId::Ip(peer.host.ip());
-        if p2s.contains_key(&key) {
+        if sessions.contains_key(&key) {
             Err(Error::PeerExists)
         } else {
             self.new_session_locked(
-                p2s, key, peer, bind_addr, event_tx, event_rx, info,
-                None, // No unnumbered_manager for numbered sessions
+                sessions, key, peer, bind_addr, event_tx, event_rx, info, None,
             )
         }
     }
@@ -404,14 +384,13 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         info: SessionInfo,
         unnumbered_manager: Arc<dyn UnnumberedManager>,
     ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
-        let p2s = lock!(self.peer_to_session);
-        // Use PeerId::Interface for unnumbered sessions
+        let sessions = lock!(self.sessions);
         let key = PeerId::Interface(interface);
-        if p2s.contains_key(&key) {
+        if sessions.contains_key(&key) {
             Err(Error::PeerExists)
         } else {
             self.new_session_locked(
-                p2s,
+                sessions,
                 key,
                 peer,
                 bind_addr,
@@ -424,9 +403,9 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new_session_locked(
+    fn new_session_locked(
         self: &Arc<Self>,
-        mut p2s: MutexGuard<BTreeMap<PeerId, SessionEndpoint<Cnx>>>,
+        mut sessions: MutexGuard<SessionMap<Cnx>>,
         peer_id: PeerId,
         peer: PeerConfig,
         bind_addr: Option<SocketAddr>,
@@ -435,7 +414,6 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         info: SessionInfo,
         unnumbered_manager: Option<Arc<dyn UnnumberedManager>>,
     ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
-        // Update the SessionInfo with timer values from peer config
         let mut session_info = info.clone();
         session_info.connect_retry_time =
             Duration::from_secs(peer.connect_retry);
@@ -448,19 +426,10 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
 
         let session = Arc::new(Mutex::new(session_info));
 
-        p2s.insert(
-            peer_id.clone(),
-            SessionEndpoint {
-                event_tx: event_tx.clone(),
-                config: session.clone(),
-            },
-        );
-        drop(p2s);
-
         let neighbor = NeighborInfo {
             name: Arc::new(Mutex::new(peer.name.clone())),
             peer_group: peer.group.clone(),
-            peer: peer_id.clone(),
+            peer: peer_id,
             port: peer.host.port(),
         };
 
@@ -468,13 +437,15 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
             session,
             event_rx,
             event_tx.clone(),
-            neighbor.clone(),
+            neighbor,
             self.clone(),
             unnumbered_manager,
         ));
 
+        sessions.insert(runner.clone());
+        drop(sessions);
+
         self.spawn_session_thread(runner.clone());
-        lock!(self.sessions).insert(runner.clone());
 
         Ok(runner)
     }
@@ -521,7 +492,6 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
 
     pub fn delete_session(&self, peer: impl Into<PeerId>) {
         let peer_id = peer.into();
-        lock!(self.peer_to_session).remove(&peer_id);
         self.remove_fanout(peer_id.clone());
         if let Some(s) = lock!(self.sessions).remove(&peer_id) {
             s.shutdown();

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -1016,26 +1016,6 @@ pub struct NeighborInfo {
     pub port: u16,
 }
 
-/// Session endpoint that combines the event sender with session configuration.
-/// This is used in peer_to_session map to provide both communication channel
-/// and policy information for each peer.
-pub struct SessionEndpoint<Cnx: BgpConnection> {
-    /// Event sender for FSM events to this session
-    pub event_tx: Sender<FsmEvent<Cnx>>,
-
-    /// Session configuration including policy settings
-    pub config: Arc<Mutex<SessionInfo>>,
-}
-
-impl<Cnx: BgpConnection> Clone for SessionEndpoint<Cnx> {
-    fn clone(&self) -> Self {
-        Self {
-            event_tx: self.event_tx.clone(),
-            config: Arc::clone(&self.config),
-        }
-    }
-}
-
 pub const MAX_FSM_HISTORY_ALL: usize = 1024;
 pub const MAX_FSM_HISTORY_MAJOR: usize = 1024;
 

--- a/bgp/src/test.rs
+++ b/bgp/src/test.rs
@@ -8,10 +8,10 @@ use crate::{
     connection_channel::{BgpConnectionChannel, BgpListenerChannel},
     connection_tcp::{BgpConnectionTcp, BgpListenerTcp},
     dispatcher::Dispatcher,
-    router::{EnsureSessionResult, Router},
+    router::{EnsureSessionResult, Router, SessionMap},
     session::{
         AdminEvent, ConnectionKind, FsmEvent, FsmStateKind, PeerId,
-        SessionEndpoint, SessionInfo, SessionRunner,
+        SessionInfo, SessionRunner,
     },
     unnumbered::UnnumberedManager,
     unnumbered_mock::UnnumberedManagerMock,
@@ -27,7 +27,7 @@ use mg_common::test::{IpAllocation, LoopbackIpManager};
 use mg_common::*;
 use rdb::Asn;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
     sync::{
         Arc, Mutex,
@@ -328,16 +328,14 @@ where
         let _ = std::fs::remove_dir_all(&db_path);
         let db = rdb::Db::new(&db_path, log.clone()).expect("create db");
 
-        // Create dispatcher
-        // Phase 4: Use PeerId instead of IpAddr
-        let peer_to_session: Arc<
-            Mutex<BTreeMap<PeerId, SessionEndpoint<Cnx>>>,
-        > = Arc::new(Mutex::new(BTreeMap::new()));
+        // Create shared session map
+        let sessions: Arc<Mutex<SessionMap<Cnx>>> =
+            Arc::new(Mutex::new(SessionMap::new()));
         let dispatcher = Arc::new(Dispatcher::new(
-            peer_to_session.clone(),
+            sessions.clone(),
             logical_router.listen_addr.to_string(),
             log.clone(),
-            None, // No unnumbered manager for tests
+            None,
         ));
 
         // Create router
@@ -348,7 +346,7 @@ where
             },
             log.clone(),
             db.clone(),
-            peer_to_session.clone(),
+            sessions.clone(),
         ));
 
         // Start router and dispatcher
@@ -1810,12 +1808,10 @@ fn unnumbered_peering_helper(
     }
 
     // Create session maps
-    let p2s1: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
-    let p2s2: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
+    let sessions1: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+    let sessions2: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
 
     // Create one Dispatcher per interface for each router.
     // Each Dispatcher binds to a unique link-local address with its interface's scope_id,
@@ -1832,7 +1828,7 @@ fn unnumbered_peering_helper(
             *scope_id,
         ));
         let disp1 = Arc::new(Dispatcher::new(
-            p2s1.clone(),
+            sessions1.clone(),
             r1_addr.to_string(),
             log.clone(),
             Some(mock_ndp1.clone()),
@@ -1857,7 +1853,7 @@ fn unnumbered_peering_helper(
             *scope_id,
         ));
         let disp2 = Arc::new(Dispatcher::new(
-            p2s2.clone(),
+            sessions2.clone(),
             r2_addr.to_string(),
             log.clone(),
             Some(mock_ndp2.clone()),
@@ -1883,7 +1879,7 @@ fn unnumbered_peering_helper(
         },
         log.clone(),
         db1.db().clone(),
-        p2s1.clone(),
+        sessions1.clone(),
     ));
     let router2 = Arc::new(Router::new(
         RouterConfig {
@@ -1892,7 +1888,7 @@ fn unnumbered_peering_helper(
         },
         log.clone(),
         db2.db().clone(),
-        p2s2.clone(),
+        sessions2.clone(),
     ));
 
     router1.run();
@@ -2523,22 +2519,20 @@ fn unnumbered_pair(
         SocketAddr::V6(SocketAddrV6::new(r2_ip, TEST_BGP_PORT, 0, scope_id));
 
     // Create session maps
-    let p2s1: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
-    let p2s2: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
+    let sessions1: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+    let sessions2: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
 
     // Create dispatchers
     let dispatcher1 = Arc::new(Dispatcher::new(
-        p2s1.clone(),
+        sessions1.clone(),
         r1_addr.to_string(),
         log.clone(),
         Some(mock_ndp1.clone()),
     ));
     let dispatcher2 = Arc::new(Dispatcher::new(
-        p2s2.clone(),
+        sessions2.clone(),
         r2_addr.to_string(),
         log.clone(),
         Some(mock_ndp2.clone()),
@@ -2569,7 +2563,7 @@ fn unnumbered_pair(
         },
         log.clone(),
         db1.db().clone(),
-        p2s1.clone(),
+        sessions1.clone(),
     ));
     let router2 = Arc::new(Router::new(
         RouterConfig {
@@ -2578,7 +2572,7 @@ fn unnumbered_pair(
         },
         log.clone(),
         db2.db().clone(),
-        p2s2.clone(),
+        sessions2.clone(),
     ));
 
     router1.run();
@@ -2761,19 +2755,16 @@ fn unnumbered_three_router_chain(
     ));
 
     // Create session maps
-    let p2s1: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
-    let p2s2: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
-    let p2s3: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
+    let sessions1: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+    let sessions2: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+    let sessions3: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
 
     // Create Dispatcher for R1 (single interface)
     let disp1 = Arc::new(Dispatcher::new(
-        p2s1.clone(),
+        sessions1.clone(),
         r1_addr.to_string(),
         log.clone(),
         Some(mock_ndp1.clone()),
@@ -2788,7 +2779,7 @@ fn unnumbered_three_router_chain(
 
     // Create Dispatchers for R2 (two interfaces)
     let disp2_eth0 = Arc::new(Dispatcher::new(
-        p2s2.clone(),
+        sessions2.clone(),
         r2_eth0_addr.to_string(),
         log.clone(),
         Some(mock_ndp2.clone()),
@@ -2802,7 +2793,7 @@ fn unnumbered_three_router_chain(
         .expect("spawn r2 eth0 dispatcher");
 
     let disp2_eth1 = Arc::new(Dispatcher::new(
-        p2s2.clone(),
+        sessions2.clone(),
         r2_eth1_addr.to_string(),
         log.clone(),
         Some(mock_ndp2.clone()),
@@ -2817,7 +2808,7 @@ fn unnumbered_three_router_chain(
 
     // Create Dispatcher for R3 (single interface)
     let disp3 = Arc::new(Dispatcher::new(
-        p2s3.clone(),
+        sessions3.clone(),
         r3_addr.to_string(),
         log.clone(),
         Some(mock_ndp3.clone()),
@@ -2838,7 +2829,7 @@ fn unnumbered_three_router_chain(
         },
         log.clone(),
         db1.db().clone(),
-        p2s1.clone(),
+        sessions1.clone(),
     ));
     let router2 = Arc::new(Router::new(
         RouterConfig {
@@ -2847,7 +2838,7 @@ fn unnumbered_three_router_chain(
         },
         log.clone(),
         db2.db().clone(),
-        p2s2.clone(),
+        sessions2.clone(),
     ));
     let router3 = Arc::new(Router::new(
         RouterConfig {
@@ -2856,7 +2847,7 @@ fn unnumbered_three_router_chain(
         },
         log.clone(),
         db3.db().clone(),
-        p2s3.clone(),
+        sessions3.clone(),
     ));
 
     router1.run();
@@ -3747,12 +3738,10 @@ fn test_unnumbered_interface_lifecycle() {
     mock_ndp2.configure_interface("eth0".to_string(), scope_id);
 
     // Create session maps
-    let p2s1: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
-    let p2s2: Arc<
-        Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionChannel>>>,
-    > = Arc::new(Mutex::new(BTreeMap::new()));
+    let sessions1: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+    let sessions2: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
 
     // Create dispatchers (needed for inbound connections)
     let r1_ip: Ipv6Addr = "fe80::1".parse().unwrap();
@@ -3763,13 +3752,13 @@ fn test_unnumbered_interface_lifecycle() {
         SocketAddr::V6(SocketAddrV6::new(r2_ip, TEST_BGP_PORT, 0, scope_id));
 
     let disp1 = Arc::new(Dispatcher::new(
-        p2s1.clone(),
+        sessions1.clone(),
         r1_addr.to_string(),
         log.clone(),
         Some(mock_ndp1.clone()),
     ));
     let disp2 = Arc::new(Dispatcher::new(
-        p2s2.clone(),
+        sessions2.clone(),
         r2_addr.to_string(),
         log.clone(),
         Some(mock_ndp2.clone()),
@@ -3795,7 +3784,7 @@ fn test_unnumbered_interface_lifecycle() {
         },
         log.clone(),
         db1.db().clone(),
-        p2s1.clone(),
+        sessions1.clone(),
     ));
     let router2 = Arc::new(Router::new(
         RouterConfig {
@@ -3804,7 +3793,7 @@ fn test_unnumbered_interface_lifecycle() {
         },
         log.clone(),
         db2.db().clone(),
-        p2s2.clone(),
+        sessions2.clone(),
     ));
 
     router1.run();

--- a/bgp/src/unnumbered.rs
+++ b/bgp/src/unnumbered.rs
@@ -36,14 +36,22 @@ impl BiHashItem for ScopeEntry {
 #[derive(Debug, Clone)]
 pub struct ScopeMap(BiHashMap<ScopeEntry>);
 
+impl Default for ScopeMap {
+    fn default() -> Self {
+        Self(BiHashMap::new())
+    }
+}
+
 impl ScopeMap {
     pub fn new() -> Self {
-        Self(BiHashMap::new())
+        Self::default()
     }
 
     pub fn insert(&mut self, scope_id: u32, interface: String) {
-        self.0
-            .insert_overwrite(ScopeEntry { scope_id, interface });
+        self.0.insert_overwrite(ScopeEntry {
+            scope_id,
+            interface,
+        });
     }
 
     pub fn remove_by_interface(&mut self, interface: &str) -> Option<u32> {

--- a/bgp/src/unnumbered.rs
+++ b/bgp/src/unnumbered.rs
@@ -2,8 +2,70 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use iddqd::{BiHashItem, BiHashMap, bi_upcast};
 use std::fmt;
 use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+
+/// Bidirectional mapping between scope_id and interface name.
+#[derive(Debug, Clone)]
+struct ScopeEntry {
+    scope_id: u32,
+    interface: String,
+}
+
+impl BiHashItem for ScopeEntry {
+    type K1<'a> = u32;
+    type K2<'a> = &'a str;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.scope_id
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        &self.interface
+    }
+
+    bi_upcast!();
+}
+
+/// Bidirectional scope_id ↔ interface name map.
+///
+/// Wraps a `BiHashMap` to provide domain-specific accessors for the
+/// Dispatcher (lookup by scope_id) and session management (lookup/removal
+/// by interface name) paths.
+#[derive(Debug, Clone)]
+pub struct ScopeMap(BiHashMap<ScopeEntry>);
+
+impl ScopeMap {
+    pub fn new() -> Self {
+        Self(BiHashMap::new())
+    }
+
+    pub fn insert(&mut self, scope_id: u32, interface: String) {
+        self.0
+            .insert_overwrite(ScopeEntry { scope_id, interface });
+    }
+
+    pub fn remove_by_interface(&mut self, interface: &str) -> Option<u32> {
+        self.0.remove2(interface).map(|e| e.scope_id)
+    }
+
+    pub fn get_interface(&self, scope_id: u32) -> Option<&str> {
+        self.0.get1(&scope_id).map(|e| e.interface.as_str())
+    }
+
+    pub fn get_scope_id(&self, interface: &str) -> Option<u32> {
+        self.0.get2(interface).map(|e| e.scope_id)
+    }
+
+    pub fn contains_scope_id(&self, scope_id: u32) -> bool {
+        self.0.contains_key1(&scope_id)
+    }
+
+    pub fn contains_interface(&self, interface: &str) -> bool {
+        self.0.contains_key2(interface)
+    }
+}
 
 /// Error type for UnnumberedManager operations.
 #[derive(Debug, Clone)]

--- a/bgp/src/unnumbered.rs
+++ b/bgp/src/unnumbered.rs
@@ -47,11 +47,22 @@ impl ScopeMap {
         Self::default()
     }
 
-    pub fn insert(&mut self, scope_id: u32, interface: String) {
-        self.0.insert_overwrite(ScopeEntry {
-            scope_id,
-            interface,
-        });
+    /// Inserts a `scope_id ↔ interface` mapping, overwriting any existing
+    /// entries that collide on either key. Returns the displaced entries
+    /// (up to two: one per key dimension) as `(scope_id, interface)` pairs.
+    pub fn insert_overwrite(
+        &mut self,
+        scope_id: u32,
+        interface: String,
+    ) -> Vec<(u32, String)> {
+        self.0
+            .insert_overwrite(ScopeEntry {
+                scope_id,
+                interface,
+            })
+            .into_iter()
+            .map(|e| (e.scope_id, e.interface))
+            .collect()
     }
 
     pub fn remove_by_interface(&mut self, interface: &str) -> Option<u32> {

--- a/bgp/src/unnumbered_mock.rs
+++ b/bgp/src/unnumbered_mock.rs
@@ -42,7 +42,9 @@
 //! - Interface exists at configuration time: `register_interface()` does all three
 //! - Interface removed while session established: `remove_system_interface()`
 
-use crate::unnumbered::{NdpNeighbor, UnnumberedError, UnnumberedManager};
+use crate::unnumbered::{
+    NdpNeighbor, ScopeMap, UnnumberedError, UnnumberedManager,
+};
 use mg_common::lock;
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv6Addr;
@@ -66,13 +68,9 @@ pub struct UnnumberedManagerMock {
     /// NOTE: Peer discovery only works if interface is in `ndp_initialized`.
     discoveries: Arc<Mutex<HashMap<String, Option<Ipv6Addr>>>>,
 
-    /// Map from scope_id to interface name.
+    /// Bidirectional scope_id ↔ interface name mapping.
     /// Used by Dispatcher to route incoming link-local connections.
-    scope_map: Arc<Mutex<HashMap<u32, String>>>,
-
-    /// Reverse map from interface name to scope_id.
-    /// Maintained alongside scope_map for efficient lookup.
-    interface_to_scope: Arc<Mutex<HashMap<String, u32>>>,
+    scope_map: Arc<Mutex<ScopeMap>>,
 
     /// Interfaces that exist on the system (link up).
     /// Presence here means `interface_is_active()` returns true.
@@ -90,8 +88,7 @@ impl UnnumberedManagerMock {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             discoveries: Arc::new(Mutex::new(HashMap::new())),
-            scope_map: Arc::new(Mutex::new(HashMap::new())),
-            interface_to_scope: Arc::new(Mutex::new(HashMap::new())),
+            scope_map: Arc::new(Mutex::new(ScopeMap::new())),
             system_interfaces: Arc::new(Mutex::new(HashSet::new())),
             ndp_initialized: Arc::new(Mutex::new(HashSet::new())),
         })
@@ -109,17 +106,14 @@ impl UnnumberedManagerMock {
     /// Use `add_system_interface()` separately to simulate the interface
     /// appearing on the system.
     pub fn configure_interface(&self, interface: String, scope_id: u32) {
-        lock!(self.scope_map).insert(scope_id, interface.clone());
-        lock!(self.interface_to_scope).insert(interface, scope_id);
+        lock!(self.scope_map).insert(scope_id, interface);
     }
 
     /// Remove interface configuration.
     ///
     /// Removes the scope_id → interface mapping. Does NOT affect system presence.
     pub fn unconfigure_interface(&self, interface: &str) -> Option<u32> {
-        let scope_id = lock!(self.interface_to_scope).remove(interface)?;
-        lock!(self.scope_map).remove(&scope_id);
-        Some(scope_id)
+        lock!(self.scope_map).remove_by_interface(interface)
     }
 
     // =========================================================================
@@ -178,7 +172,7 @@ impl UnnumberedManagerMock {
         }
 
         // Check interface is configured
-        if !lock!(self.interface_to_scope).contains_key(interface) {
+        if !lock!(self.scope_map).contains_interface(interface) {
             return Err("interface not configured");
         }
 
@@ -293,7 +287,7 @@ impl UnnumberedManagerMock {
         let addr = lock!(self.discoveries)
             .get(interface)
             .and_then(|opt| *opt)?;
-        let scope_id = *lock!(self.interface_to_scope).get(interface)?;
+        let scope_id = lock!(self.scope_map).get_scope_id(interface)?;
         Some(NdpNeighbor { addr, scope_id })
     }
 
@@ -302,7 +296,9 @@ impl UnnumberedManagerMock {
     /// This simulates querying `UnnumberedManagerNdp::get_interface_for_scope()`.
     /// Used by Dispatcher to route incoming link-local connections.
     pub fn get_interface_for_scope(&self, scope_id: u32) -> Option<String> {
-        lock!(self.scope_map).get(&scope_id).cloned()
+        lock!(self.scope_map)
+            .get_interface(scope_id)
+            .map(str::to_owned)
     }
 
     /// Get all registered interfaces.
@@ -310,13 +306,13 @@ impl UnnumberedManagerMock {
     /// Returns a list of (interface_name, scope_id, discovered_peer).
     pub fn get_all_interfaces(&self) -> Vec<(String, u32, Option<Ipv6Addr>)> {
         let discoveries = lock!(self.discoveries);
-        let interface_to_scope = lock!(self.interface_to_scope);
+        let scope_map = lock!(self.scope_map);
 
         discoveries
             .iter()
             .filter_map(|(iface, peer)| {
-                let scope_id = interface_to_scope.get(iface)?;
-                Some((iface.clone(), *scope_id, *peer))
+                let scope_id = scope_map.get_scope_id(iface)?;
+                Some((iface.clone(), scope_id, *peer))
             })
             .collect()
     }

--- a/bgp/src/unnumbered_mock.rs
+++ b/bgp/src/unnumbered_mock.rs
@@ -106,7 +106,7 @@ impl UnnumberedManagerMock {
     /// Use `add_system_interface()` separately to simulate the interface
     /// appearing on the system.
     pub fn configure_interface(&self, interface: String, scope_id: u32) {
-        lock!(self.scope_map).insert(scope_id, interface);
+        lock!(self.scope_map).insert_overwrite(scope_id, interface);
     }
 
     /// Remove interface configuration.

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -16,10 +16,9 @@ use bgp::{
     connection::BgpConnection,
     connection_tcp::BgpConnectionTcp,
     policy::{PolicyKind, PolicySource},
-    router::{LoadPolicyError, Router},
+    router::{LoadPolicyError, Router, SessionMap},
     session::{
-        AdminEvent, ConnectionKind, FsmEvent, SessionEndpoint, SessionInfo,
-        SessionRunner,
+        AdminEvent, ConnectionKind, FsmEvent, SessionInfo, SessionRunner,
     },
 };
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -71,23 +70,20 @@ const DEFAULT_BGP_LISTEN: SocketAddr =
 #[derive(Clone)]
 pub struct BgpContext {
     pub(crate) router: Arc<Mutex<BTreeMap<u32, Arc<Router<BgpConnectionTcp>>>>>,
-    peer_to_session:
-        Arc<Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionTcp>>>>,
+    pub(crate) sessions: Arc<Mutex<SessionMap<BgpConnectionTcp>>>,
     pub(crate) unnumbered_manager: Arc<UnnumberedManagerNdp>,
 }
 
 impl BgpContext {
     pub fn new(
-        peer_to_session: Arc<
-            Mutex<BTreeMap<PeerId, SessionEndpoint<BgpConnectionTcp>>>,
-        >,
+        sessions: Arc<Mutex<SessionMap<BgpConnectionTcp>>>,
         log: Logger,
     ) -> Self {
         let router = Arc::new(Mutex::new(BTreeMap::new()));
         let unnumbered_manager = UnnumberedManagerNdp::new(router.clone(), log);
         Self {
             router,
-            peer_to_session,
+            sessions,
             unnumbered_manager,
         }
     }
@@ -2381,7 +2377,7 @@ pub(crate) mod helpers {
             cfg,
             ctx.log.clone(),
             db.clone(),
-            ctx.bgp.peer_to_session.clone(),
+            ctx.bgp.sessions.clone(),
         ));
 
         router.run();
@@ -2618,6 +2614,7 @@ mod tests {
     use crate::{
         admin::HandlerContext, bfd_admin::BfdContext, bgp_admin::BgpContext,
     };
+    use bgp::router::SessionMap;
     use mg_api_types_versions::v1;
     use mg_api_types_versions::v1::bgp::config::{
         ApplyRequest, BgpPeerConfig, BgpPeerParameters,
@@ -2627,7 +2624,7 @@ mod tests {
     #[cfg(all(feature = "mg-lower", target_os = "illumos"))]
     use std::net::Ipv6Addr;
     use std::{
-        collections::{BTreeMap, HashMap},
+        collections::HashMap,
         env::temp_dir,
         fs::{create_dir_all, remove_dir_all},
         net::SocketAddr,
@@ -2654,7 +2651,7 @@ mod tests {
             #[cfg(all(feature = "mg-lower", target_os = "illumos"))]
             tep: Ipv6Addr::UNSPECIFIED,
             bgp: BgpContext::new(
-                Arc::new(Mutex::new(BTreeMap::new())),
+                Arc::new(Mutex::new(SessionMap::new())),
                 log.clone(),
             ),
             bfd: BfdContext::new(log.clone()),

--- a/mgd/src/main.rs
+++ b/mgd/src/main.rs
@@ -270,15 +270,15 @@ fn detect_switch_slot(
 }
 
 fn init_bgp(args: &RunArgs, log: &Logger) -> BgpContext {
-    let peer_to_session = Arc::new(Mutex::new(BTreeMap::new()));
+    let sessions = Arc::new(Mutex::new(bgp::router::SessionMap::new()));
 
     // Create BgpContext first to get access to unnumbered_manager
-    let bgp_context = BgpContext::new(peer_to_session.clone(), log.clone());
+    let bgp_context = BgpContext::new(sessions.clone(), log.clone());
 
     if !args.no_bgp_dispatcher {
         let bgp_dispatcher =
             bgp::dispatcher::Dispatcher::<BgpConnectionTcp>::new(
-                peer_to_session.clone(),
+                sessions.clone(),
                 args.bgp_dispatcher_addr.to_string(),
                 log.clone(),
                 Some(bgp_context.unnumbered_manager.clone()), // Enable link-local connection routing

--- a/mgd/src/oxstats.rs
+++ b/mgd/src/oxstats.rs
@@ -284,7 +284,7 @@ impl Stats {
         for (asn, r) in &*routers {
             let mut session_counters = BTreeMap::new();
             let sessions = lock!(r.sessions);
-            for (key, session) in &*sessions {
+            for (key, session) in sessions.iter() {
                 // Only include IP-based sessions in metrics (unnumbered sessions use interface names)
                 if let PeerId::Ip(addr) = key {
                     session_counters.insert(*addr, session.counters.clone());

--- a/mgd/src/unnumbered_manager.rs
+++ b/mgd/src/unnumbered_manager.rs
@@ -328,8 +328,7 @@ impl UnnumberedManagerNdp {
         }
 
         // Clean up scope mapping
-        lock!(self.interface_scope_map)
-            .remove_by_interface(interface_name);
+        lock!(self.interface_scope_map).remove_by_interface(interface_name);
     }
 
     /// Register an interface for NDP peer discovery.
@@ -424,8 +423,7 @@ impl UnnumberedManagerNdp {
 
         // Clean up scope mapping.
         // This works whether or not the interface still exists in the system.
-        lock!(self.interface_scope_map)
-            .remove_by_interface(interface_str);
+        lock!(self.interface_scope_map).remove_by_interface(interface_str);
 
         slog::info!(
             self.log,

--- a/mgd/src/unnumbered_manager.rs
+++ b/mgd/src/unnumbered_manager.rs
@@ -3,8 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use bgp::{
-    connection_tcp::BgpConnectionTcp, router::Router, session::SessionRunner,
-    unnumbered::NdpNeighbor,
+    connection_tcp::BgpConnectionTcp,
+    router::Router,
+    session::SessionRunner,
+    unnumbered::{NdpNeighbor, ScopeMap},
 };
 use mg_common::lock;
 use mg_common::thread::ManagedThread;
@@ -36,8 +38,8 @@ struct PendingInterfaceConfig {
 pub struct UnnumberedManagerNdp {
     routers: Arc<Mutex<BTreeMap<u32, Arc<Router<BgpConnectionTcp>>>>>,
     ndp_mgr: Arc<NdpManager>,
-    /// Maps scope_id (interface index) to interface name for Dispatcher routing
-    interface_scope_map: Mutex<HashMap<u32, String>>,
+    /// Bidirectional scope_id ↔ interface name mapping for Dispatcher routing
+    interface_scope_map: Mutex<ScopeMap>,
     log: Logger,
 
     // =========================================================================
@@ -99,7 +101,7 @@ impl UnnumberedManagerNdp {
 
         let manager = Arc::new(Self {
             routers,
-            interface_scope_map: Mutex::new(HashMap::default()),
+            interface_scope_map: Mutex::new(ScopeMap::new()),
             ndp_mgr: NdpManager::new(log.clone()),
             log,
             pending_interfaces: Mutex::new(HashMap::new()),
@@ -325,14 +327,9 @@ impl UnnumberedManagerNdp {
             self.ndp_mgr.remove_interface(ifx);
         }
 
-        // Clean up scope mapping by searching for interface name
-        let mut scope_map = lock!(self.interface_scope_map);
-        if let Some((&scope_id, _)) = scope_map
-            .iter()
-            .find(|(_, name)| name.as_str() == interface_name)
-        {
-            scope_map.remove(&scope_id);
-        }
+        // Clean up scope mapping
+        lock!(self.interface_scope_map)
+            .remove_by_interface(interface_name);
     }
 
     /// Register an interface for NDP peer discovery.
@@ -425,15 +422,10 @@ impl UnnumberedManagerNdp {
             self.ndp_mgr.remove_interface(ifx);
         }
 
-        // Clean up scope mapping by searching for interface name.
+        // Clean up scope mapping.
         // This works whether or not the interface still exists in the system.
-        let mut scope_map = lock!(self.interface_scope_map);
-        if let Some((&scope_id, _)) = scope_map
-            .iter()
-            .find(|(_, name)| name.as_str() == interface_str)
-        {
-            scope_map.remove(&scope_id);
-        }
+        lock!(self.interface_scope_map)
+            .remove_by_interface(interface_str);
 
         slog::info!(
             self.log,
@@ -510,7 +502,9 @@ impl UnnumberedManagerNdp {
     /// * `Some(interface_name)` - Interface found for this scope_id
     /// * `None` - No interface registered with this scope_id
     pub fn get_interface_for_scope(&self, scope_id: u32) -> Option<String> {
-        lock!(self.interface_scope_map).get(&scope_id).cloned()
+        lock!(self.interface_scope_map)
+            .get_interface(scope_id)
+            .map(str::to_owned)
     }
 
     /// Validate that a peer address matches the discovered neighbor for an interface.
@@ -679,7 +673,7 @@ impl UnnumberedManagerNdp {
             .into_iter()
             .filter_map(|info| {
                 // Only include interfaces in our scope map
-                if !scope_map.contains_key(&info.interface.index) {
+                if !scope_map.contains_scope_id(info.interface.index) {
                     return None;
                 }
 
@@ -725,7 +719,7 @@ impl UnnumberedManagerNdp {
         let ifx = Self::get_interface(interface_name, &self.log)?;
 
         // Check if we're managing this interface
-        if !lock!(self.interface_scope_map).contains_key(&ifx.index) {
+        if !lock!(self.interface_scope_map).contains_scope_id(ifx.index) {
             return Ok(None);
         }
 

--- a/mgd/src/unnumbered_manager.rs
+++ b/mgd/src/unnumbered_manager.rs
@@ -280,7 +280,7 @@ impl UnnumberedManagerNdp {
 
                 // Store scope_id mapping for Dispatcher routing
                 lock!(self.interface_scope_map)
-                    .insert(ifx.index, ifx.name.clone());
+                    .insert_overwrite(ifx.index, ifx.name.clone());
 
                 // Track as active
                 lock!(self.active_interfaces)
@@ -360,7 +360,7 @@ impl UnnumberedManagerNdp {
 
                 // Store scope_id mapping for Dispatcher routing
                 lock!(self.interface_scope_map)
-                    .insert(ifx.index, ifx.name.clone());
+                    .insert_overwrite(ifx.index, ifx.name.clone());
 
                 // Track as active
                 lock!(self.active_interfaces).insert(interface_str.to_string());


### PR DESCRIPTION
Updates some of the map data structures we use in mgd/bgp.  In particular:
1. Moves `UnnumberedManager` trait impls over to using `iddqd::BiHashMap` for the interface name to scope id mapping. This ensures we only have to maintain a single map (instead of 2 like what was used by UnnumberedManagerMock) and that we get consistent O(1) lookups (instead of the O(n) lookups in the UnnumberedManagerNdp impl).
2. Moves `Router.sessions` over to a new SessionMap type which wraps an `iddqd::IdOrdMap`, which ensures we can't ever insert a SessionRunner into a map behind an invalid PeerId key since it is derived from the SessionRunner being inserted. There was not a known issue with the existing impl, but this provides some more type safety to prevent anything bad from happening in the future.
3. Removes the peer_to_session (previously known as addr_to_session prior to bgp unnumbered) entirely. This was providing a way to get the config (SessionInfo) and handle for sending FSM events (event_tx) for a given peer, primarily in service of the Dispatcher. Since the config and FSM handle are just extensions of the SessionRunner itself, this could all be queried using the global SessionMap (item 2 above). This consolidates us down to just 1 mapping of Peer to SessionRunner instead of 2 where one provides a subset of the others' functionality.