### PR TITLE
renovate: more package groupings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,53 @@
     {
       "matchPackageNames": ["https://github.com/oxidecomputer/opte"],
       "groupName": "opte"
+    },
+    {
+      "matchPackageNames": ["https://github.com/oxidecomputer/omicron"],
+      "groupName": "omicron"
+    },
+    {
+      "matchPackageNames": ["https://github.com/oxidecomputer/falcon"],
+      "groupName": "falcon"
+    },
+    {
+      "matchPackageNames": [
+        "slog",
+        "slog-term",
+        "slog-envlogger",
+        "slog-async",
+        "slog-bunyan"
+      ],
+      "groupName": "slog"
+    },
+    {
+      "matchPackageNames": [
+        "dropshot",
+        "dropshot-api-manager",
+        "dropshot-api-manager-types"
+      ],
+      "groupName": "dropshot"
+    },
+    {
+      "matchPackageNames": [
+        "progenitor",
+        "progenitor-client"
+      ],
+      "groupName": "progenitor"
+    },
+    {
+      "matchPackageNames": [
+        "hyper",
+        "hyper-util"
+      ],
+      "groupName": "hyper"
+    },
+    {
+      "matchPackageNames": [
+        "http",
+        "http-body-util"
+      ],
+      "groupName": "http"
     }
   ]
 }


### PR DESCRIPTION
New dependency groups:
- omicron
  - oximeter
  - oximeter-producer
  - omicron-common
  - gateway-client
- falcon
  - ztest
  - libfalcon
- slog
  - slog
  - slog-term
  - slog-envlogger
  - slog-async
  - slog-bunyan
- dropshot
  - dropshot
  - dropshot-api-manager
  - dropshot-api-manager-types
- progenitor
  - progenitor
  - progenitor-client
- hyper
  - hyper
  - hyper-util
- http
  - http
  - http-body-util