### PR TITLE
BFD and falcon-lab cleanup [Spring Cleaning 1/N]

### DIFF
--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -55,3 +55,6 @@ pfexec ./dhcp-server "$first" "$last" "$gw" "$server" &> /work/dhcp-server.log &
 
 RUST_LOG=debug pfexec ./falcon-lab run \
 	trio-unnumbered
+
+RUST_LOG=debug pfexec ./falcon-lab run \
+	trio-bfd-static-routing

--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -53,17 +53,5 @@ gw=$(bmat address ls -f extra -Ho gateway)
 server=$(ipadm show-addr "$EXT_INTERFACE"/dhcp -po ADDR | sed 's#/.*##g')
 pfexec ./dhcp-server "$first" "$last" "$gw" "$server" &> /work/dhcp-server.log &
 
-# workaround for https://www.illumos.org/issues/17853
-# create a dummy0 vnic that persists beyond shutdown of falcon topology to avoid
-# the final vnic removal triggering a panic
-if ! error=$(pfexec dladm create-vnic -l $EXT_INTERFACE dummy0 2>&1); then
-    if [[ "$error" == *"object already exists"* ]]; then
-        echo "VNIC already exists, continuing..."
-    else
-        echo "Unexpected error: $error" >&2
-        exit 1
-    fi
-fi
-
 RUST_LOG=debug pfexec ./falcon-lab run \
 	trio-unnumbered

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-bunyan",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/bfd/Cargo.toml
+++ b/bfd/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 schemars.workspace = true
 serde.workspace = true
 rand.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/bfd/src/lib.rs
+++ b/bfd/src/lib.rs
@@ -2,17 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use mg_common::thread::ManagedThread;
 use num_enum::TryFromPrimitive;
 use rdb::SessionMode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::{Logger, warn};
 use sm::StateMachine;
-use std::collections::HashMap;
-use std::net::IpAddr;
-use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    sync::{Arc, atomic::AtomicU64},
+    time::Duration,
+};
 
 pub mod bidi;
 pub mod log;
@@ -51,15 +53,7 @@ impl Daemon {
 
     /// Add a peer session to the deamon. Peer sessions are started immediately
     /// when added.
-    pub fn add_peer(
-        &mut self,
-        peer: IpAddr,
-        required_rx: Duration,
-        detection_multiplier: u8,
-        mode: SessionMode,
-        endpoint: BfdEndpoint,
-        db: rdb::Db,
-    ) {
+    pub fn add_peer(&mut self, peer: IpAddr, rq: AddPeerRequest) {
         if self.sessions.contains_key(&peer) {
             warn!(self.log, "attempt to add peer that already exists";
                 "component" => COMPONENT_BFD,
@@ -69,18 +63,8 @@ impl Daemon {
             );
             return;
         }
-        self.sessions.insert(
-            peer,
-            Session::new(
-                peer,
-                endpoint,
-                required_rx,
-                detection_multiplier,
-                mode,
-                db,
-                self.log.clone(),
-            ),
-        );
+        self.sessions
+            .insert(peer, Session::new(peer, rq, self.log.clone()));
     }
 
     /// Remove a peer from the daemon. The peer will be immediately shut down.
@@ -112,35 +96,47 @@ pub struct SessionCounters {
     pub unexpected_message: AtomicU64,
 }
 
+/// Parameters for adding a new BFD peer session.
+pub struct AddPeerRequest {
+    pub required_rx: Duration,
+    pub detection_multiplier: u8,
+    pub mode: SessionMode,
+    pub endpoint: BfdEndpoint,
+    pub egress_thread: Option<Arc<ManagedThread>>,
+    pub db: rdb::Db,
+}
+
 /// A session holds a BFD state machine for a particular peer.
 pub struct Session {
     pub sm: StateMachine,
     pub mode: SessionMode,
     pub counters: Arc<SessionCounters>,
+    /// Managed egress thread for UDP packet transmission. Stored here to
+    /// ensure automatic cleanup on drop — the ManagedThread's Drop impl
+    /// will signal shutdown and join the thread. None in test contexts
+    /// where egress is handled differently.
+    _egress_thread: Option<Arc<ManagedThread>>,
 }
 
 impl Session {
     /// Create a new session and start running the underlying BFD state machine
     /// immediately.
-    fn new(
-        addr: IpAddr,
-        ep: BfdEndpoint,
-        required_rx: Duration,
-        detection_multiplier: u8,
-        mode: SessionMode,
-        db: rdb::Db,
-        log: Logger,
-    ) -> Self {
+    fn new(addr: IpAddr, rq: AddPeerRequest, log: Logger) -> Self {
         let counters = Arc::new(SessionCounters::default());
         let mut sm = StateMachine::new(
             addr,
-            required_rx,
-            detection_multiplier,
+            rq.required_rx,
+            rq.detection_multiplier,
             counters.clone(),
             log,
         );
-        sm.run(ep, db);
-        Session { sm, mode, counters }
+        sm.run(rq.endpoint, rq.db);
+        Session {
+            sm,
+            mode: rq.mode,
+            counters,
+            _egress_thread: rq.egress_thread,
+        }
     }
 }
 
@@ -329,26 +325,32 @@ mod test {
         let v4_addr = ip("203.0.113.10");
         daemon.add_peer(
             v4_addr,
-            Duration::from_secs(5),
-            3,
-            SessionMode::MultiHop,
-            a,
-            db.db().clone(),
+            AddPeerRequest {
+                required_rx: Duration::from_secs(5),
+                detection_multiplier: 3,
+                mode: SessionMode::MultiHop,
+                endpoint: a,
+                egress_thread: None,
+                db: db.db().clone(),
+            },
         );
-        assert_eq!(daemon.peer_state(v4_addr), Some(BfdPeerState::Down),);
+        assert_eq!(daemon.peer_state(v4_addr), Some(BfdPeerState::Down));
 
         // Add an IPv6 peer to the same daemon.
         let (a, _b) = bidi::channel();
         let v6_addr = ip("2001:db8::10");
         daemon.add_peer(
             v6_addr,
-            Duration::from_secs(5),
-            3,
-            SessionMode::MultiHop,
-            a,
-            db.db().clone(),
+            AddPeerRequest {
+                required_rx: Duration::from_secs(5),
+                detection_multiplier: 3,
+                mode: SessionMode::MultiHop,
+                endpoint: a,
+                egress_thread: None,
+                db: db.db().clone(),
+            },
         );
-        assert_eq!(daemon.peer_state(v6_addr), Some(BfdPeerState::Down),);
+        assert_eq!(daemon.peer_state(v6_addr), Some(BfdPeerState::Down));
 
         // Both peers coexist.
         assert_eq!(daemon.sessions.len(), 2);
@@ -377,22 +379,28 @@ mod test {
         let (a, b) = bidi::channel();
         d1.add_peer(
             v4_addr1,
-            Duration::from_secs(5),
-            3,
-            SessionMode::MultiHop,
-            a,
-            db.db().clone(),
+            AddPeerRequest {
+                required_rx: Duration::from_secs(5),
+                detection_multiplier: 3,
+                mode: SessionMode::MultiHop,
+                endpoint: a,
+                egress_thread: None,
+                db: db.db().clone(),
+            },
         );
         net.register(v4_addr2, b);
 
         let (a, b) = bidi::channel();
         d1.add_peer(
             v6_addr1,
-            Duration::from_secs(5),
-            3,
-            SessionMode::MultiHop,
-            a,
-            db.db().clone(),
+            AddPeerRequest {
+                required_rx: Duration::from_secs(5),
+                detection_multiplier: 3,
+                mode: SessionMode::MultiHop,
+                endpoint: a,
+                egress_thread: None,
+                db: db.db().clone(),
+            },
         );
         net.register(v6_addr2, b);
 
@@ -401,22 +409,28 @@ mod test {
         let (a, b) = bidi::channel();
         d2.add_peer(
             v4_addr2,
-            Duration::from_secs(5),
-            3,
-            SessionMode::MultiHop,
-            a,
-            db.db().clone(),
+            AddPeerRequest {
+                required_rx: Duration::from_secs(5),
+                detection_multiplier: 3,
+                mode: SessionMode::MultiHop,
+                endpoint: a,
+                egress_thread: None,
+                db: db.db().clone(),
+            },
         );
         net.register(v4_addr1, b);
 
         let (a, b) = bidi::channel();
         d2.add_peer(
             v6_addr2,
-            Duration::from_secs(5),
-            3,
-            SessionMode::MultiHop,
-            a,
-            db.db().clone(),
+            AddPeerRequest {
+                required_rx: Duration::from_secs(5),
+                detection_multiplier: 3,
+                mode: SessionMode::MultiHop,
+                endpoint: a,
+                egress_thread: None,
+                db: db.db().clone(),
+            },
         );
         net.register(v6_addr1, b);
 

--- a/bfd/src/lib.rs
+++ b/bfd/src/lib.rs
@@ -324,17 +324,34 @@ mod test {
         let mut daemon = Daemon::new(log);
         assert_eq!(daemon.sessions.len(), 0);
 
+        // Add an IPv4 peer.
         let (a, _b) = bidi::channel();
-        let p1_addr = ip("203.0.113.10");
+        let v4_addr = ip("203.0.113.10");
         daemon.add_peer(
-            p1_addr,
+            v4_addr,
             Duration::from_secs(5),
             3,
             SessionMode::MultiHop,
             a,
             db.db().clone(),
         );
-        assert_eq!(daemon.peer_state(p1_addr), Some(BfdPeerState::Down));
+        assert_eq!(daemon.peer_state(v4_addr), Some(BfdPeerState::Down),);
+
+        // Add an IPv6 peer to the same daemon.
+        let (a, _b) = bidi::channel();
+        let v6_addr = ip("2001:db8::10");
+        daemon.add_peer(
+            v6_addr,
+            Duration::from_secs(5),
+            3,
+            SessionMode::MultiHop,
+            a,
+            db.db().clone(),
+        );
+        assert_eq!(daemon.peer_state(v6_addr), Some(BfdPeerState::Down),);
+
+        // Both peers coexist.
+        assert_eq!(daemon.sessions.len(), 2);
 
         Ok(())
     }
@@ -347,39 +364,71 @@ mod test {
 
         let mut net = Network::default();
 
-        let addr1 = ip("203.0.113.10");
-        let addr2 = ip("203.0.113.20");
+        // IPv4 peer pair.
+        let v4_addr1 = ip("203.0.113.10");
+        let v4_addr2 = ip("203.0.113.20");
 
+        // IPv6 peer pair.
+        let v6_addr1 = ip("2001:db8::10");
+        let v6_addr2 = ip("2001:db8::20");
+
+        // Daemon 1 peers with both v4 and v6 counterparts.
         let mut d1 = Daemon::new(test_logger());
         let (a, b) = bidi::channel();
         d1.add_peer(
-            addr1,
+            v4_addr1,
             Duration::from_secs(5),
             3,
             SessionMode::MultiHop,
             a,
             db.db().clone(),
         );
-        net.register(addr2, b);
+        net.register(v4_addr2, b);
 
+        let (a, b) = bidi::channel();
+        d1.add_peer(
+            v6_addr1,
+            Duration::from_secs(5),
+            3,
+            SessionMode::MultiHop,
+            a,
+            db.db().clone(),
+        );
+        net.register(v6_addr2, b);
+
+        // Daemon 2 peers with both v4 and v6 counterparts.
         let mut d2 = Daemon::new(test_logger());
         let (a, b) = bidi::channel();
         d2.add_peer(
-            addr2,
+            v4_addr2,
             Duration::from_secs(5),
             3,
             SessionMode::MultiHop,
             a,
             db.db().clone(),
         );
-        net.register(addr1, b);
+        net.register(v4_addr1, b);
+
+        let (a, b) = bidi::channel();
+        d2.add_peer(
+            v6_addr2,
+            Duration::from_secs(5),
+            3,
+            SessionMode::MultiHop,
+            a,
+            db.db().clone(),
+        );
+        net.register(v6_addr1, b);
 
         net.run();
 
         sleep(Duration::from_secs(10));
 
-        assert_eq!(d1.peer_state(addr1), Some(BfdPeerState::Up));
-        assert_eq!(d2.peer_state(addr2), Some(BfdPeerState::Up));
+        // All four sessions should reach Up.
+        assert_eq!(d1.peer_state(v4_addr1), Some(BfdPeerState::Up),);
+        assert_eq!(d1.peer_state(v6_addr1), Some(BfdPeerState::Up),);
+        assert_eq!(d2.peer_state(v4_addr2), Some(BfdPeerState::Up),);
+        assert_eq!(d2.peer_state(v6_addr2), Some(BfdPeerState::Up),);
 
         Ok(())
     }

--- a/bfd/src/lib.rs
+++ b/bfd/src/lib.rs
@@ -52,9 +52,13 @@ impl Daemon {
         }
     }
 
-    /// Add a peer session to the deamon. Peer sessions are started immediately
-    /// when added.
-    pub fn add_peer(&mut self, peer: IpAddr, rq: AddPeerRequest) -> Result<()> {
+    /// Add a peer session to the daemon.
+    /// Peer sessions are started immediately when added.
+    pub fn add_peer(
+        &mut self,
+        peer: IpAddr,
+        rq: AddPeerRequest,
+    ) -> Result<(), AddPeerError> {
         if self.sessions.contains_key(&peer) {
             warn!(self.log, "attempt to add peer that already exists";
                 "component" => COMPONENT_BFD,
@@ -62,7 +66,7 @@ impl Daemon {
                 "unit" => UNIT_PEER,
                 "peer" => format!("{peer}")
             );
-            anyhow::bail!("BFD peer {peer} already exists");
+            return Err(AddPeerError::PeerExists(peer));
         }
         self.sessions
             .insert(peer, Session::new(peer, rq, self.log.clone())?);
@@ -234,6 +238,15 @@ pub enum BfdPeerState {
 }
 
 pub struct Admin {}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AddPeerError {
+    #[error("BFD peer {0} already exists")]
+    PeerExists(IpAddr),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
 
 #[cfg(test)]
 mod test {

--- a/bfd/src/lib.rs
+++ b/bfd/src/lib.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use anyhow::Result;
 use mg_common::thread::ManagedThread;
 use num_enum::TryFromPrimitive;
 use rdb::SessionMode;
@@ -53,7 +54,7 @@ impl Daemon {
 
     /// Add a peer session to the deamon. Peer sessions are started immediately
     /// when added.
-    pub fn add_peer(&mut self, peer: IpAddr, rq: AddPeerRequest) {
+    pub fn add_peer(&mut self, peer: IpAddr, rq: AddPeerRequest) -> Result<()> {
         if self.sessions.contains_key(&peer) {
             warn!(self.log, "attempt to add peer that already exists";
                 "component" => COMPONENT_BFD,
@@ -61,10 +62,11 @@ impl Daemon {
                 "unit" => UNIT_PEER,
                 "peer" => format!("{peer}")
             );
-            return;
+            anyhow::bail!("BFD peer {peer} already exists");
         }
         self.sessions
-            .insert(peer, Session::new(peer, rq, self.log.clone()));
+            .insert(peer, Session::new(peer, rq, self.log.clone())?);
+        Ok(())
     }
 
     /// Remove a peer from the daemon. The peer will be immediately shut down.
@@ -121,7 +123,7 @@ pub struct Session {
 impl Session {
     /// Create a new session and start running the underlying BFD state machine
     /// immediately.
-    fn new(addr: IpAddr, rq: AddPeerRequest, log: Logger) -> Self {
+    fn new(addr: IpAddr, rq: AddPeerRequest, log: Logger) -> Result<Self> {
         let counters = Arc::new(SessionCounters::default());
         let mut sm = StateMachine::new(
             addr,
@@ -130,13 +132,13 @@ impl Session {
             counters.clone(),
             log,
         );
-        sm.run(rq.endpoint, rq.db);
-        Session {
+        sm.run(rq.endpoint, rq.db)?;
+        Ok(Session {
             sm,
             mode: rq.mode,
             counters,
             _egress_thread: rq.egress_thread,
-        }
+        })
     }
 }
 
@@ -333,7 +335,7 @@ mod test {
                 egress_thread: None,
                 db: db.db().clone(),
             },
-        );
+        )?;
         assert_eq!(daemon.peer_state(v4_addr), Some(BfdPeerState::Down));
 
         // Add an IPv6 peer to the same daemon.
@@ -349,7 +351,7 @@ mod test {
                 egress_thread: None,
                 db: db.db().clone(),
             },
-        );
+        )?;
         assert_eq!(daemon.peer_state(v6_addr), Some(BfdPeerState::Down));
 
         // Both peers coexist.
@@ -387,7 +389,7 @@ mod test {
                 egress_thread: None,
                 db: db.db().clone(),
             },
-        );
+        )?;
         net.register(v4_addr2, b);
 
         let (a, b) = bidi::channel();
@@ -401,7 +403,7 @@ mod test {
                 egress_thread: None,
                 db: db.db().clone(),
             },
-        );
+        )?;
         net.register(v6_addr2, b);
 
         // Daemon 2 peers with both v4 and v6 counterparts.
@@ -417,7 +419,7 @@ mod test {
                 egress_thread: None,
                 db: db.db().clone(),
             },
-        );
+        )?;
         net.register(v4_addr1, b);
 
         let (a, b) = bidi::channel();
@@ -431,7 +433,7 @@ mod test {
                 egress_thread: None,
                 db: db.db().clone(),
             },
-        );
+        )?;
         net.register(v6_addr1, b);
 
         net.run();

--- a/bfd/src/sm.rs
+++ b/bfd/src/sm.rs
@@ -88,7 +88,7 @@ impl StateMachine {
     /// incoming control packets. Endpoint is a channel from a connection
     /// dispatcher that sends control packets to this state machine based
     /// on peer address and BFD discriminator.
-    pub fn run(&mut self, endpoint: BfdEndpoint, db: rdb::Db) {
+    pub fn run(&mut self, endpoint: BfdEndpoint, db: rdb::Db) -> Result<()> {
         let local = PeerInfo::with_random_discriminator(
             self.required_rx,
             self.detection_multiplier,
@@ -98,11 +98,13 @@ impl StateMachine {
         // Spawn a thread that runs the send loop for this state machine. This
         // loop is responsible for sending out unsolicited periodic control
         // packets.
-        self.send_loop(endpoint.tx.clone(), local, remote.clone());
+        self.send_loop(endpoint.tx.clone(), local, remote.clone())?;
 
         // Spawn a thread that runs the receive loop. This loop is responsible
         // for handling packets from the connection dispatcher.
-        self.recv_loop(endpoint, db, local, remote.clone());
+        self.recv_loop(endpoint, db, local, remote.clone())?;
+
+        Ok(())
     }
 
     /// Get the current state of this state machine.
@@ -120,7 +122,7 @@ impl StateMachine {
         db: rdb::Db,
         local: PeerInfo,
         remote: Arc<Mutex<PeerInfo>>,
-    ) {
+    ) -> Result<()> {
         let state = self.state.clone();
         let peer = self.peer;
         let kill_switch = self.kill_switch.clone();
@@ -171,8 +173,8 @@ impl StateMachine {
                     sm_log!(log, info, "transition -> {:?}", new; prev, peer);
                 }
             }
-        })
-        .expect("failed to spawn bfd-recv thread");
+        })?;
+        Ok(())
     }
 
     /// This is a send loop for a BFD peer. It takes care of sending out
@@ -184,7 +186,7 @@ impl StateMachine {
         sender: Sender<(IpAddr, packet::Control)>,
         local: PeerInfo,
         remote: Arc<Mutex<PeerInfo>>,
-    ) {
+    ) -> Result<()> {
         let state = self.state.clone();
         let peer = self.peer;
         let stop = self.kill_switch.clone();
@@ -245,8 +247,8 @@ impl StateMachine {
                             .fetch_add(1, Ordering::Relaxed);
                     }
                 }
-            })
-            .expect("failed to spawn bfd-send thread");
+            })?;
+        Ok(())
     }
 
     pub fn required_rx(&self) -> Duration {

--- a/bfd/src/sm.rs
+++ b/bfd/src/sm.rs
@@ -13,8 +13,7 @@ use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, RwLock};
-use std::thread::sleep;
-use std::thread::spawn;
+use std::thread::{Builder, sleep};
 use std::time::Duration;
 
 pub const UNIT_SESSION: &str = "session";
@@ -127,7 +126,9 @@ impl StateMachine {
         let kill_switch = self.kill_switch.clone();
         let log = self.log.clone();
         let counters = self.counters.clone();
-        spawn(move || {
+        Builder::new()
+            .name(format!("bfd-recv-{peer}"))
+            .spawn(move || {
             loop {
                 let prev = state.read().unwrap().state();
                 let (st, ep) = match state.read().unwrap().run(
@@ -170,7 +171,8 @@ impl StateMachine {
                     sm_log!(log, info, "transition -> {:?}", new; prev, peer);
                 }
             }
-        });
+        })
+        .expect("failed to spawn bfd-recv thread");
     }
 
     /// This is a send loop for a BFD peer. It takes care of sending out
@@ -192,54 +194,59 @@ impl StateMachine {
         // just copy it out of self for sending into the spawned thread. The
         // reason this is a dynamic method at all is to get runtime polymorphic
         // behavior over `State` trait implementors.
-        spawn(move || {
-            loop {
-                if stop.load(Ordering::Relaxed) {
-                    break;
-                };
+        Builder::new()
+            .name(format!("bfd-send-{peer}"))
+            .spawn(move || {
+                loop {
+                    if stop.load(Ordering::Relaxed) {
+                        break;
+                    };
 
-                // Get what we need from peer info, holding the lock a briefly as
-                // possible.
-                let (_delay, demand_mode, your_discriminator) = {
-                    let r = lock!(remote);
-                    (
-                        DeferredDelay(r.required_min_rx),
-                        r.demand_mode,
-                        r.discriminator,
-                    )
-                };
+                    // Get what we need from peer info, holding the lock a
+                    // briefly as possible.
+                    let (_delay, demand_mode, your_discriminator) = {
+                        let r = lock!(remote);
+                        (
+                            DeferredDelay(r.required_min_rx),
+                            r.demand_mode,
+                            r.discriminator,
+                        )
+                    };
 
-                // Unsolicited packets are not sent in demand mode.
-                //
-                // TODO we could probably just park this thread on a signal waiting
-                // to leave demand mode instead of continuing to iterate.
-                if demand_mode {
-                    continue;
+                    // Unsolicited packets are not sent in demand mode.
+                    //
+                    // TODO we could probably just park this thread on a signal
+                    // waiting to leave demand mode instead of continuing to
+                    // iterate.
+                    if demand_mode {
+                        continue;
+                    }
+
+                    let mut pkt = packet::Control {
+                        desired_min_tx: local.desired_min_tx.as_micros() as u32,
+                        required_min_rx: local.required_min_rx.as_micros()
+                            as u32,
+                        my_discriminator: local.discriminator,
+                        your_discriminator,
+                        ..Default::default()
+                    };
+
+                    let st = state.read().unwrap().state();
+                    pkt.set_state(st);
+
+                    if let Err(e) = sender.send((peer, pkt)) {
+                        sm_log!(log, warn, "send error: {e}"; st, peer);
+                        counters
+                            .control_packet_send_failures
+                            .fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        counters
+                            .control_packets_sent
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-
-                let mut pkt = packet::Control {
-                    desired_min_tx: local.desired_min_tx.as_micros() as u32,
-                    required_min_rx: local.required_min_rx.as_micros() as u32,
-                    my_discriminator: local.discriminator,
-                    your_discriminator,
-                    ..Default::default()
-                };
-
-                let st = state.read().unwrap().state();
-                pkt.set_state(st);
-
-                if let Err(e) = sender.send((peer, pkt)) {
-                    sm_log!(log, warn, "send error: {e}"; st, peer);
-                    counters
-                        .control_packet_send_failures
-                        .fetch_add(1, Ordering::Relaxed);
-                } else {
-                    counters
-                        .control_packets_sent
-                        .fetch_add(1, Ordering::Relaxed);
-                }
-            }
-        });
+            })
+            .expect("failed to spawn bfd-send thread");
     }
 
     pub fn required_rx(&self) -> Duration {

--- a/falcon-lab/cargo-bay/.gitignore
+++ b/falcon-lab/cargo-bay/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/falcon-lab/falcon-lab
+++ b/falcon-lab/falcon-lab
@@ -1,0 +1,1 @@
+../target/debug/falcon-lab

--- a/falcon-lab/src/eos.rs
+++ b/falcon-lab/src/eos.rs
@@ -79,7 +79,9 @@ impl EosNode {
     }
 
     /// Query ceos for the local status of a BFD session to `peer`. Returns
-    /// `true` iff EOS reports the session as `up`.
+    /// `true` iff EOS reports any per-interface peerStats entry under this
+    /// peer with status `up`. The nested shape is:
+    ///   vrfs.<vrf>.ipv4Neighbors.<peer>.peers.<iface>.types.normal.peerStats.<local>.status
     pub async fn bfd_peer_up(&self, d: &Runner, peer: IpAddr) -> Result<bool> {
         let output = self.shell(d, "show bfd peers | json").await?;
         let resp: EosBfdResponse = serde_json::from_str(&output)
@@ -90,8 +92,18 @@ impl EosNode {
                 IpAddr::V4(_) => &vrf.ipv4_neighbors,
                 IpAddr::V6(_) => &vrf.ipv6_neighbors,
             };
-            if let Some(n) = neighbors.get(&key) {
-                return Ok(n.status.eq_ignore_ascii_case("up"));
+            let Some(neighbor) = neighbors.get(&key) else {
+                continue;
+            };
+            for if_peer in neighbor.peers.values() {
+                let Some(normal) = if_peer.types.normal.as_ref() else {
+                    continue;
+                };
+                for stats in normal.peer_stats.values() {
+                    if stats.status.eq_ignore_ascii_case("up") {
+                        return Ok(true);
+                    }
+                }
             }
         }
         Ok(false)
@@ -201,7 +213,9 @@ impl BgpIpv6Response {
 }
 
 /// Subset of `show bfd peers | json` output. Neighbor keys are raw IP
-/// strings; we compare after normalizing via `IpAddr::to_string()`.
+/// strings; we compare after normalizing via `IpAddr::to_string()`. The
+/// schema is deeply nested:
+/// `vrfs.<vrf>.ipv[46]Neighbors.<peer>.peers.<iface>.types.normal.peerStats.<local>.status`.
 #[derive(Debug, Deserialize)]
 pub struct EosBfdResponse {
     pub vrfs: HashMap<String, EosBfdVrf>,
@@ -218,5 +232,28 @@ pub struct EosBfdVrf {
 
 #[derive(Debug, Deserialize)]
 pub struct EosBfdNeighbor {
+    #[serde(default)]
+    pub peers: HashMap<String, EosBfdIfPeer>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EosBfdIfPeer {
+    pub types: EosBfdTypes,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EosBfdTypes {
+    #[serde(default)]
+    pub normal: Option<EosBfdNormal>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EosBfdNormal {
+    pub peer_stats: HashMap<String, EosBfdStats>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EosBfdStats {
     pub status: String,
 }

--- a/falcon-lab/src/eos.rs
+++ b/falcon-lab/src/eos.rs
@@ -3,13 +3,14 @@
 #![allow(dead_code)]
 
 use crate::linux::LinuxNode;
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use colored::Colorize;
 use libfalcon::{NodeRef, Runner};
 use oxnet::{Ipv4Net, Ipv6Net};
 use serde::Deserialize;
 use slog::info;
 use std::collections::HashMap;
+use std::net::IpAddr;
 
 #[derive(Copy, Clone)]
 pub struct EosNode(pub NodeRef);
@@ -61,6 +62,39 @@ impl EosNode {
 
     pub fn linux(&self) -> LinuxNode {
         LinuxNode(self.0)
+    }
+
+    /// Freeze the ceos container. BFD packets stop being processed without
+    /// tearing down running-config, so `unpause` restores the session.
+    pub async fn pause(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: pausing ceos", self.name(d));
+        d.exec(self.0, "docker pause ceos").await?;
+        Ok(())
+    }
+
+    pub async fn unpause(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: unpausing ceos", self.name(d));
+        d.exec(self.0, "docker unpause ceos").await?;
+        Ok(())
+    }
+
+    /// Query ceos for the local status of a BFD session to `peer`. Returns
+    /// `true` iff EOS reports the session as `up`.
+    pub async fn bfd_peer_up(&self, d: &Runner, peer: IpAddr) -> Result<bool> {
+        let output = self.shell(d, "show bfd peers | json").await?;
+        let resp: EosBfdResponse = serde_json::from_str(&output)
+            .context("parse eos bfd peers json")?;
+        let key = peer.to_string();
+        for vrf in resp.vrfs.values() {
+            let neighbors = match peer {
+                IpAddr::V4(_) => &vrf.ipv4_neighbors,
+                IpAddr::V6(_) => &vrf.ipv6_neighbors,
+            };
+            if let Some(n) = neighbors.get(&key) {
+                return Ok(n.status.eq_ignore_ascii_case("up"));
+            }
+        }
+        Ok(false)
     }
 
     /// Get BGP IPv4 imported prefixes from EOS.
@@ -164,4 +198,25 @@ impl BgpIpv6Response {
             })
         })
     }
+}
+
+/// Subset of `show bfd peers | json` output. Neighbor keys are raw IP
+/// strings; we compare after normalizing via `IpAddr::to_string()`.
+#[derive(Debug, Deserialize)]
+pub struct EosBfdResponse {
+    pub vrfs: HashMap<String, EosBfdVrf>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EosBfdVrf {
+    #[serde(default)]
+    pub ipv4_neighbors: HashMap<String, EosBfdNeighbor>,
+    #[serde(default)]
+    pub ipv6_neighbors: HashMap<String, EosBfdNeighbor>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EosBfdNeighbor {
+    pub status: String,
 }

--- a/falcon-lab/src/frr.rs
+++ b/falcon-lab/src/frr.rs
@@ -53,6 +53,32 @@ impl FrrNode {
         LinuxNode(self.0)
     }
 
+    /// Freeze the BFD daemon. Control packets stop flowing without disturbing
+    /// the peer's configuration or interfaces, so `resume_bfdd` restores the
+    /// session without reapplying config.
+    pub async fn pause_bfdd(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: pausing frr bfdd", self.name(d));
+        d.exec(self.0, "pkill -STOP bfdd").await?;
+        Ok(())
+    }
+
+    pub async fn resume_bfdd(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: resuming frr bfdd", self.name(d));
+        d.exec(self.0, "pkill -CONT bfdd").await?;
+        Ok(())
+    }
+
+    /// Query FRR for the local status of a BFD session to `peer`. Returns
+    /// `true` iff bfdd reports the session as `up`.
+    pub async fn bfd_peer_up(&self, d: &Runner, peer: IpAddr) -> Result<bool> {
+        let output = self.shell(d, "show bfd peers json").await?;
+        let peers: Vec<FrrBfdPeer> = serde_json::from_str(&output)
+            .context("parse frr bfd peers json")?;
+        Ok(peers
+            .iter()
+            .any(|p| p.peer == peer && p.status.eq_ignore_ascii_case("up")))
+    }
+
     /// Execute a vtysh command and return the output.
     pub async fn shell(&self, d: &Runner, script: &str) -> Result<String> {
         info!(
@@ -145,4 +171,11 @@ pub struct FrrBgpRoutePath {
 #[derive(Debug, Deserialize)]
 pub struct FrrBgpNexthop {
     pub ip: IpAddr,
+}
+
+/// Subset of an element in FRR's `show bfd peers json` response.
+#[derive(Debug, Deserialize)]
+pub struct FrrBfdPeer {
+    pub peer: IpAddr,
+    pub status: String,
 }

--- a/falcon-lab/src/illumos.rs
+++ b/falcon-lab/src/illumos.rs
@@ -47,6 +47,20 @@ impl IllumosNode {
         Err(anyhow!("dhcp timed out"))
     }
 
+    pub async fn staticaddr(
+        &self,
+        d: &Runner,
+        addrobj: &str,
+        cidr: &str,
+    ) -> Result<IpAddr> {
+        d.exec(
+            self.0,
+            &format!("ipadm create-addr -T static -a {cidr} {addrobj}"),
+        )
+        .await?;
+        self.ip(d, addrobj).await
+    }
+
     pub async fn addrconf(&self, d: &Runner, addrobj: &str) -> Result<IpAddr> {
         d.exec(self.0, &format!("ipadm create-addr -T addrconf {addrobj}"))
             .await?;

--- a/falcon-lab/src/illumos.rs
+++ b/falcon-lab/src/illumos.rs
@@ -53,17 +53,16 @@ impl IllumosNode {
         addrobj: &str,
         cidr: &str,
     ) -> Result<IpAddr> {
-        d.exec(
-            self.0,
-            &format!("ipadm create-addr -T static -a {cidr} {addrobj}"),
-        )
-        .await?;
+        let cmd = format!("ipadm create-addr -T static -a {cidr} {addrobj}");
+        let out = d.exec(self.0, &cmd).await?;
+        ensure_ipadm_ok(&out, &cmd)?;
         self.ip(d, addrobj).await
     }
 
     pub async fn addrconf(&self, d: &Runner, addrobj: &str) -> Result<IpAddr> {
-        d.exec(self.0, &format!("ipadm create-addr -T addrconf {addrobj}"))
-            .await?;
+        let cmd = format!("ipadm create-addr -T addrconf {addrobj}");
+        let out = d.exec(self.0, &cmd).await?;
+        ensure_ipadm_ok(&out, &cmd)?;
         let mut retries = 10usize;
         loop {
             match self.ip(d, addrobj).await {
@@ -111,4 +110,16 @@ impl IllumosNode {
         }
         Err(anyhow!("timeout waiting for link {name}"))
     }
+}
+
+/// Treat `ipadm` output as success unless it contains an error line and the
+/// error is not an "already assigned / already exists" idempotency case.
+/// ipadm prefixes error messages with `ipadm:` and is otherwise silent on
+/// success.
+fn ensure_ipadm_ok(output: &str, cmd: &str) -> Result<()> {
+    let lower = output.to_lowercase();
+    if lower.contains("ipadm:") && !lower.contains("already") {
+        return Err(anyhow!("'{cmd}' failed: {}", output.trim()));
+    }
+    Ok(())
 }

--- a/falcon-lab/src/main.rs
+++ b/falcon-lab/src/main.rs
@@ -1,6 +1,9 @@
 //! Falcon test lab
 
-use crate::test::{cleanup_unnumbered_test, run_trio_unnumbered_test};
+use crate::test::{
+    cleanup_bfd_static_test, cleanup_unnumbered_test, run_trio_bfd_static_test,
+    run_trio_unnumbered_test,
+};
 use clap::{Parser, Subcommand};
 
 mod bgp;
@@ -60,6 +63,7 @@ struct Serial {
 #[derive(Debug, Subcommand)]
 enum TestCommand {
     TrioUnnumbered,
+    TrioBfdStaticRouting,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -79,9 +83,21 @@ async fn run() -> anyhow::Result<()> {
                 )
                 .await?
             }
+            TestCommand::TrioBfdStaticRouting => {
+                run_trio_bfd_static_test(
+                    cmd.no_cleanup,
+                    cmd.npuvm_commit.clone(),
+                    cmd.dendrite_commit,
+                    cmd.sidecar_lite_commit,
+                )
+                .await?
+            }
         },
         Command::Cleanup(cmd) => match cmd.command {
             TestCommand::TrioUnnumbered => cleanup_unnumbered_test().await?,
+            TestCommand::TrioBfdStaticRouting => {
+                cleanup_bfd_static_test().await?
+            }
         },
         Command::Serial(cmd) => {
             libfalcon::cli::console(&cmd.node, ".falcon".into()).await?

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -759,15 +759,15 @@ async fn expect_route(
 ) -> Result<()> {
     // Push cr1 before cr2 so the list is already in the sorted order that
     // dpd_v*_targets returns.
-    let mut want_v4 = Vec::new();
-    let mut want_v6 = Vec::new();
+    let mut want_v4: Vec<IpAddr> = Vec::new();
+    let mut want_v6: Vec<IpAddr> = Vec::new();
     if cr1_in {
-        want_v4.push(CR1_V4);
-        want_v6.push(CR1_V6);
+        want_v4.push(IpAddr::V4(CR1_V4));
+        want_v6.push(IpAddr::V6(CR1_V6));
     }
     if cr2_in {
-        want_v4.push(CR2_V4);
-        want_v6.push(CR2_V6);
+        want_v4.push(IpAddr::V4(CR2_V4));
+        want_v6.push(IpAddr::V6(CR2_V6));
     }
 
     let desc_v4 = format!("{phase} v4");
@@ -841,19 +841,22 @@ async fn mgd_selected_paths(
         .map(|paths| paths.len())
 }
 
-async fn dpd_v4_targets(dpd: &DpdClient, prefix: &Prefix4) -> Vec<Ipv4Addr> {
+/// All dpd target addresses for the given v4 prefix. Targets may be v4
+/// (static routes) or v6 (BGP-unnumbered uses v6 link-local next-hops for
+/// v4 prefixes), so the return type is `IpAddr`.
+async fn dpd_v4_targets(dpd: &DpdClient, prefix: &Prefix4) -> Vec<IpAddr> {
     let items = match dpd.route_ipv4_list(None, None).await {
         Ok(r) => r.into_inner().items,
         Err(_) => return Vec::new(),
     };
     let want_cidr = prefix.to_string();
-    let mut out: Vec<Ipv4Addr> = items
+    let mut out: Vec<IpAddr> = items
         .into_iter()
         .filter(|r| r.cidr.to_string() == want_cidr)
         .flat_map(|r| {
-            r.targets.into_iter().filter_map(|t| match t {
-                dpd_client::types::Route::V4(rt) => Some(rt.tgt_ip),
-                _ => None,
+            r.targets.into_iter().map(|t| match t {
+                dpd_client::types::Route::V4(rt) => IpAddr::V4(rt.tgt_ip),
+                dpd_client::types::Route::V6(rt) => IpAddr::V6(rt.tgt_ip),
             })
         })
         .collect();
@@ -861,16 +864,16 @@ async fn dpd_v4_targets(dpd: &DpdClient, prefix: &Prefix4) -> Vec<Ipv4Addr> {
     out
 }
 
-async fn dpd_v6_targets(dpd: &DpdClient, prefix: &Prefix6) -> Vec<Ipv6Addr> {
+async fn dpd_v6_targets(dpd: &DpdClient, prefix: &Prefix6) -> Vec<IpAddr> {
     let items = match dpd.route_ipv6_list(None, None).await {
         Ok(r) => r.into_inner().items,
         Err(_) => return Vec::new(),
     };
     let want_cidr = prefix.to_string();
-    let mut out: Vec<Ipv6Addr> = items
+    let mut out: Vec<IpAddr> = items
         .into_iter()
         .filter(|r| r.cidr.to_string() == want_cidr)
-        .flat_map(|r| r.targets.into_iter().map(|t| t.tgt_ip))
+        .flat_map(|r| r.targets.into_iter().map(|t| IpAddr::V6(t.tgt_ip)))
         .collect();
     out.sort();
     out

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -458,11 +458,18 @@ pub async fn run_trio_bfd_static_test(
     .await?;
 
     // Configure numbered v4 + v6 addresses on the ox side of each softnpu
-    // link so static-route nexthops resolve.
+    // link so static-route nexthops resolve. illumos requires a v6 link-local
+    // (via addrconf) on an interface before a static global v6 address can
+    // be added, so do addrconf first.
     for (link, v4_cidr, v6_cidr) in [
         ("tfportqsfp0_0", OX_CR1_V4_CIDR, OX_CR1_V6_CIDR),
         ("tfportqsfp1_0", OX_CR2_V4_CIDR, OX_CR2_V6_CIDR),
     ] {
+        let ll = format!("{link}/ll");
+        ox.illumos()
+            .addrconf(&ad, &ll)
+            .await
+            .context(format!("addrconf {ll}"))?;
         for (suffix, cidr) in [("v4", v4_cidr), ("v6", v6_cidr)] {
             let addrobj = format!("{link}/{suffix}");
             ox.illumos()

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -585,7 +585,7 @@ async fn frr_bfd_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
           no shutdown
         exit
         bfd
-          peer {ox_v4}
+          peer {ox_v4} local-address {cr_v4}
             detect-multiplier {mult}
             receive-interval {rx_ms}
             transmit-interval {rx_ms}
@@ -603,6 +603,7 @@ async fn frr_bfd_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
         cr_v6_cidr = CR1_V6_CIDR,
         ox_v4 = OX_CR1_V4,
         ox_v6 = OX_CR1_V6,
+        cr_v4 = CR1_V4,
         cr_v6 = CR1_V6,
         mult = BFD_DETECTION_MULT,
     );

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -464,7 +464,8 @@ pub async fn run_trio_bfd_static_test(
     // Register each ox-side address with dpd so softnpu punts packets for
     // those destinations to the CPU port. Link-local v6 is handled
     // implicitly by the P4 pipeline, but globally-scoped addresses need an
-    // explicit per-link mapping.
+    // explicit per-link mapping. IPv6 is also disabled by default per-link
+    // in the P4 pipeline, so enable it before registering v6 addresses.
     for (qsfp, v4, v6) in [
         ("qsfp0", OX_CR1_V4, OX_CR1_V6),
         ("qsfp1", OX_CR2_V4, OX_CR2_V6),
@@ -481,6 +482,9 @@ pub async fn run_trio_bfd_static_test(
         )
         .await
         .context(format!("dpd: program {v4} on {qsfp}/0"))?;
+        dpd.link_ipv6_enabled_set(&port, &link, true)
+            .await
+            .context(format!("dpd: enable ipv6 on {qsfp}/0"))?;
         dpd.link_ipv6_create(
             &port,
             &link,

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -7,19 +7,142 @@ use crate::{
     dendrite::{softnpu_link_create, wait_for_dpd},
     eos::EosNode,
     frr::FrrNode,
-    mgd::wait_for_mgd,
+    mgd::{MgdNode, wait_for_mgd},
     topo::{Trio, trio},
     wait_for_eq,
 };
 use anyhow::{Context, Result};
+use dpd_client::Client as DpdClient;
 use libfalcon::Runner;
-use mg_admin_client::types::{FsmStateKind, Origin4, Origin6, Router};
-use rdb_types::AddressFamily;
+use mg_admin_client::{
+    Client as MgdClient,
+    types::{
+        AddStaticRoute4Request, AddStaticRoute6Request, BfdPeerConfig,
+        BfdPeerState, FsmStateKind, Origin4, Origin6, Router, SessionMode,
+        StaticRoute4, StaticRoute4List, StaticRoute6, StaticRoute6List,
+    },
+};
+use rdb_types::{AddressFamily, Prefix4, Prefix6};
 use slog::info;
-use std::{sync::Arc, time::Duration};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::Arc,
+    time::Duration,
+};
 
 const TRIO_UNNUMBERED_TOPO_NAME: &str = "mgtriou";
+const TRIO_BFD_STATIC_TOPO_NAME: &str = "mgtriobfd";
 const OP_TIMEOUT: Duration = Duration::from_secs(10);
+
+// BFD-static test addressing. `OX_*` addresses are configured on the helios
+// side of each softnpu link; `CR*` addresses are configured on the peer.
+const OX_CR1_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+const CR1_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
+const OX_CR2_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 1);
+const CR2_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 2);
+const OX_CR1_V4_CIDR: &str = "10.0.0.1/24";
+const OX_CR2_V4_CIDR: &str = "10.0.1.1/24";
+const CR1_V4_CIDR: &str = "10.0.0.2/24";
+const CR2_V4_CIDR: &str = "10.0.1.2/24";
+
+const OX_CR1_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 1, 0, 0, 0, 0, 0, 1); // fd00:1::1
+const CR1_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 1, 0, 0, 0, 0, 0, 2); // fd00:1::2
+const OX_CR2_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 2, 0, 0, 0, 0, 0, 1); // fd00:2::1
+const CR2_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 2, 0, 0, 0, 0, 0, 2); // fd00:2::2
+const OX_CR1_V6_CIDR: &str = "fd00:1::1/64";
+const OX_CR2_V6_CIDR: &str = "fd00:2::1/64";
+const CR1_V6_CIDR: &str = "fd00:1::2/64";
+const CR2_V6_CIDR: &str = "fd00:2::2/64";
+
+/// Destination prefixes with nexthops via both cr1 and cr2.
+const TEST_PREFIX_V4: &str = "192.168.100.0/24";
+const TEST_PREFIX_V6: &str = "fd01::/64";
+
+/// BFD detection time: 300ms * 3 = 900ms.
+const BFD_REQUIRED_RX_US: u64 = 300_000;
+const BFD_DETECTION_MULT: u8 = 3;
+
+/// Output of `boot_trio`: the running topology plus clients ready for
+/// test-specific configuration.
+struct BootedTrio {
+    ad: Arc<Runner>,
+    ox: MgdNode,
+    cr1: FrrNode,
+    cr2: EosNode,
+    mgd: MgdClient,
+    dpd: DpdClient,
+    #[allow(dead_code)]
+    mgmt_addr: IpAddr,
+}
+
+/// Launch the trio topology and complete the work shared by every trio-based
+/// test: dhcp mgmt, concurrent peer install + npuvm setup, dpd startup,
+/// softnpu link creation, and tfport readiness. The caller supplies a closure
+/// that populates a `JoinSet` with per-peer setup futures so that they run
+/// concurrently with the npuvm install.
+async fn boot_trio<F>(
+    topo_name: &str,
+    persistent: bool,
+    npuvm_commit: String,
+    dendrite_commit: Option<String>,
+    sidecar_lite_commit: Option<String>,
+    spawn_peer_setups: F,
+) -> Result<BootedTrio>
+where
+    F: FnOnce(
+        FrrNode,
+        EosNode,
+        Arc<Runner>,
+    ) -> tokio::task::JoinSet<Result<()>>,
+{
+    let Trio {
+        mut d,
+        ox,
+        cr1,
+        cr2,
+    } = trio(topo_name)?;
+    d.persistent = persistent;
+    d.launch().await.context("launch failed")?;
+    let ad = Arc::new(d);
+
+    let mgmt_addr = ox.illumos().dhcp(&ad, "vioif1/dhcp").await?;
+
+    let mut js = spawn_peer_setups(cr1, cr2, ad.clone());
+    js.spawn(ox.dendrite().npuvm(
+        ad.clone(),
+        2,
+        0,
+        npuvm_commit,
+        dendrite_commit,
+        sidecar_lite_commit,
+    ));
+    for result in js.join_all().await.into_iter() {
+        result?;
+    }
+
+    let mgd = ox.client(&ad, mgmt_addr).await?;
+    let dpd = ox.dendrite().client(&ad, mgmt_addr).await?;
+    wait_for_dpd(&dpd, OP_TIMEOUT, &ad.log).await?;
+
+    for link in ["qsfp0", "qsfp1"] {
+        softnpu_link_create(&dpd, link)
+            .await
+            .context(format!("create {link}"))?;
+    }
+    for link in ["tfportqsfp0_0", "tfportqsfp1_0"] {
+        ox.illumos().wait_for_link(&ad, link, OP_TIMEOUT).await?;
+    }
+
+    Ok(BootedTrio {
+        ad,
+        ox,
+        cr1,
+        cr2,
+        mgd,
+        dpd,
+        mgmt_addr,
+    })
+}
 
 pub async fn cleanup_unnumbered_test() -> Result<()> {
     // dropping this with out persistent set will destroy
@@ -34,50 +157,30 @@ pub async fn run_trio_unnumbered_test(
     dendrite_commit: Option<String>,
     sidecar_lite_commit: Option<String>,
 ) -> Result<()> {
-    let Trio {
-        mut d,
+    let BootedTrio {
+        ad,
         ox,
         cr1,
         cr2,
-    } = trio(TRIO_UNNUMBERED_TOPO_NAME)?;
-    d.persistent = persistent;
-
-    d.launch().await.context("launch failed")?;
-
-    let ad = std::sync::Arc::new(d);
-
-    let addr = ox.illumos().dhcp(&ad, "vioif1/dhcp").await?;
-
-    // These take a minute, knock them out concurrently
-    let mut js = tokio::task::JoinSet::new();
-    js.spawn(frr_setup(cr1, ad.clone()));
-    js.spawn(eos_setup(cr2, ad.clone()));
-    js.spawn(ox.dendrite().npuvm(
-        ad.clone(),
-        2,
-        0,
+        mgd,
+        dpd,
+        ..
+    } = boot_trio(
+        TRIO_UNNUMBERED_TOPO_NAME,
+        persistent,
         npuvm_commit,
         dendrite_commit,
         sidecar_lite_commit,
-    ));
-    for result in js.join_all().await.into_iter() {
-        result?;
-    }
-
-    let mgd = ox.client(&ad, addr).await?;
-    let dpd = ox.dendrite().client(&ad, addr).await?;
-
-    // Wait for dpd to start
-    wait_for_dpd(&dpd, OP_TIMEOUT, &ad.log).await?;
-
-    for link in ["qsfp0", "qsfp1"] {
-        softnpu_link_create(&dpd, link)
-            .await
-            .context(format!("create {link}"))?;
-    }
+        |cr1, cr2, ad| {
+            let mut js = tokio::task::JoinSet::new();
+            js.spawn(frr_setup(cr1, ad.clone()));
+            js.spawn(eos_setup(cr2, ad.clone()));
+            js
+        },
+    )
+    .await?;
 
     for link in ["tfportqsfp0_0", "tfportqsfp1_0"] {
-        ox.illumos().wait_for_link(&ad, link, OP_TIMEOUT).await?;
         let addr = format!("{link}/ll");
         ox.illumos()
             .addrconf(&ad, &addr)
@@ -87,8 +190,6 @@ pub async fn run_trio_unnumbered_test(
 
     ox.run_mgd(&ad).await?;
     ox.ddm().run_ddm(&ad).await?;
-
-    // Wait for mgd to start
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
     let local_asn: u32 = 33;
@@ -319,4 +420,350 @@ async fn eos_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
     r.wait_for_init(&d).await?;
     r.shell(&d, BASE_CONFIG).await?;
     Ok(())
+}
+
+pub async fn cleanup_bfd_static_test() -> Result<()> {
+    // dropping this without persistent set will destroy the topo
+    let _topo = trio(TRIO_BFD_STATIC_TOPO_NAME)?;
+    Ok(())
+}
+
+pub async fn run_trio_bfd_static_test(
+    persistent: bool,
+    npuvm_commit: String,
+    dendrite_commit: Option<String>,
+    sidecar_lite_commit: Option<String>,
+) -> Result<()> {
+    let BootedTrio {
+        ad,
+        ox,
+        cr1,
+        cr2,
+        mgd,
+        dpd,
+        ..
+    } = boot_trio(
+        TRIO_BFD_STATIC_TOPO_NAME,
+        persistent,
+        npuvm_commit,
+        dendrite_commit,
+        sidecar_lite_commit,
+        |cr1, cr2, ad| {
+            let mut js = tokio::task::JoinSet::new();
+            js.spawn(frr_bfd_setup(cr1, ad.clone()));
+            js.spawn(eos_bfd_setup(cr2, ad.clone()));
+            js
+        },
+    )
+    .await?;
+
+    // Configure numbered v4 + v6 addresses on the ox side of each softnpu
+    // link so static-route nexthops resolve.
+    for (link, v4_cidr, v6_cidr) in [
+        ("tfportqsfp0_0", OX_CR1_V4_CIDR, OX_CR1_V6_CIDR),
+        ("tfportqsfp1_0", OX_CR2_V4_CIDR, OX_CR2_V6_CIDR),
+    ] {
+        for (suffix, cidr) in [("v4", v4_cidr), ("v6", v6_cidr)] {
+            let addrobj = format!("{link}/{suffix}");
+            ox.illumos()
+                .staticaddr(&ad, &addrobj, cidr)
+                .await
+                .context(format!("assign {cidr} to {link}"))?;
+        }
+    }
+
+    ox.run_mgd(&ad).await?;
+    wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
+
+    let prefix_v4: Prefix4 =
+        TEST_PREFIX_V4.parse().expect("parse v4 test prefix");
+    let prefix_v6: Prefix6 =
+        TEST_PREFIX_V6.parse().expect("parse v6 test prefix");
+
+    info!(ad.log, "installing static v4 route {TEST_PREFIX_V4}");
+    mgd.static_add_v4_route(&AddStaticRoute4Request {
+        routes: StaticRoute4List {
+            list: [CR1_V4, CR2_V4]
+                .into_iter()
+                .map(|nh| StaticRoute4 {
+                    prefix: prefix_v4,
+                    nexthop: nh,
+                    vlan_id: None,
+                    rib_priority: 0,
+                })
+                .collect(),
+        },
+    })
+    .await
+    .context("mgd: add v4 static route")?;
+
+    info!(ad.log, "installing static v6 route {TEST_PREFIX_V6}");
+    mgd.static_add_v6_route(&AddStaticRoute6Request {
+        routes: StaticRoute6List {
+            list: [CR1_V6, CR2_V6]
+                .into_iter()
+                .map(|nh| StaticRoute6 {
+                    prefix: prefix_v6,
+                    nexthop: nh,
+                    vlan_id: None,
+                    rib_priority: 0,
+                })
+                .collect(),
+        },
+    })
+    .await
+    .context("mgd: add v6 static route")?;
+
+    info!(ad.log, "adding BFD peers for cr1 and cr2 (dual-stack)");
+    for (peer, listen) in [
+        (IpAddr::V4(CR1_V4), IpAddr::V4(OX_CR1_V4)),
+        (IpAddr::V4(CR2_V4), IpAddr::V4(OX_CR2_V4)),
+        (IpAddr::V6(CR1_V6), IpAddr::V6(OX_CR1_V6)),
+        (IpAddr::V6(CR2_V6), IpAddr::V6(OX_CR2_V6)),
+    ] {
+        mgd.add_bfd_peer(&BfdPeerConfig {
+            peer,
+            listen,
+            required_rx: BFD_REQUIRED_RX_US,
+            detection_threshold: BFD_DETECTION_MULT,
+            mode: SessionMode::SingleHop,
+        })
+        .await
+        .context(format!("mgd: add bfd peer {peer}"))?;
+    }
+
+    use BfdPeerState::{Down, Up};
+
+    info!(ad.log, "phase 1: both peers up");
+    expect_bfd(&mgd, cr1, cr2, &ad, Up, Up).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, "phase 1").await?;
+
+    info!(ad.log, "phase 2: pause bfdd on cr1");
+    cr1.pause_bfdd(&ad).await?;
+    expect_bfd(&mgd, cr1, cr2, &ad, Down, Up).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, false, true, "phase 2").await?;
+
+    info!(ad.log, "phase 3: pause ceos on cr2");
+    cr2.pause(&ad).await?;
+    expect_bfd(&mgd, cr1, cr2, &ad, Down, Down).await?;
+    // With every nexthop shutdown, all shutdown nexthops are reinstated.
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, "phase 3").await?;
+
+    info!(ad.log, "phase 4: resume bfdd on cr1");
+    cr1.resume_bfdd(&ad).await?;
+    expect_bfd(&mgd, cr1, cr2, &ad, Up, Down).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, false, "phase 4").await?;
+
+    info!(ad.log, "phase 5: unpause ceos on cr2");
+    cr2.unpause(&ad).await?;
+    expect_bfd(&mgd, cr1, cr2, &ad, Up, Up).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, "phase 5").await?;
+
+    info!(ad.log, "trio bfd static routing test passed 🎉");
+
+    Ok(())
+}
+
+async fn frr_bfd_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
+    // Address the softnpu-facing link (v4 + v6) and bring up passive BFD peers
+    // for each family. Once mgd initiates BFD to these addresses the sessions
+    // establish bidirectionally.
+    let rx_ms = BFD_REQUIRED_RX_US / 1000;
+    let config = format!(
+        "
+        configure
+        interface enp0s8
+          ip address {cr_v4_cidr}
+          ipv6 address {cr_v6_cidr}
+          no shutdown
+        exit
+        bfd
+          peer {ox_v4}
+            detect-multiplier {mult}
+            receive-interval {rx_ms}
+            transmit-interval {rx_ms}
+            no shutdown
+          exit
+          peer {ox_v6} local-address {cr_v6}
+            detect-multiplier {mult}
+            receive-interval {rx_ms}
+            transmit-interval {rx_ms}
+            no shutdown
+          exit
+        exit
+        ",
+        cr_v4_cidr = CR1_V4_CIDR,
+        cr_v6_cidr = CR1_V6_CIDR,
+        ox_v4 = OX_CR1_V4,
+        ox_v6 = OX_CR1_V6,
+        cr_v6 = CR1_V6,
+        mult = BFD_DETECTION_MULT,
+    );
+
+    r.install(&d).await?;
+    r.enable_daemons(&d, &["bfdd"]).await?;
+    r.shell(&d, &config).await?;
+    Ok(())
+}
+
+async fn eos_bfd_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
+    // Address the softnpu-facing link (v4 + v6) and install dummy BFD-tracked
+    // static routes whose nexthops are the ox side of the link. This is EOS's
+    // idiomatic way to bring up BFD sessions without a BGP/OSPF client.
+    let rx_ms = BFD_REQUIRED_RX_US / 1000;
+    let config = format!(
+        "
+        enable
+        configure
+        ip routing
+        ipv6 unicast-routing
+        interface Ethernet1
+          no switchport
+          ip address {cr_v4_cidr}
+          ipv6 enable
+          ipv6 address {cr_v6_cidr}
+          bfd interval {rx_ms} min-rx {rx_ms} multiplier {mult}
+        exit
+        ip route 172.30.0.0/24 {ox_v4} bfd
+        ipv6 route fd99::/64 {ox_v6} bfd
+        exit
+        ",
+        cr_v4_cidr = CR2_V4_CIDR,
+        cr_v6_cidr = CR2_V6_CIDR,
+        ox_v4 = OX_CR2_V4,
+        ox_v6 = OX_CR2_V6,
+        mult = BFD_DETECTION_MULT,
+    );
+    r.wait_for_init(&d).await?;
+    r.shell(&d, &config).await?;
+    Ok(())
+}
+
+/// Expect a scalar BFD state per peer. Since failure injection targets the
+/// peer daemon as a whole, the v4 and v6 sessions to a given peer always
+/// share the same state.
+///
+/// mgd-side state is always checked. Peer-side state is checked only when
+/// the peer is expected `Up`: a paused daemon cannot answer queries, so
+/// `Down` phases have no observable peer-side truth.
+async fn expect_bfd(
+    mgd: &MgdClient,
+    cr1: FrrNode,
+    cr2: EosNode,
+    d: &Runner,
+    cr1_state: BfdPeerState,
+    cr2_state: BfdPeerState,
+) -> Result<()> {
+    for (peer, want) in [
+        (IpAddr::V4(CR1_V4), cr1_state),
+        (IpAddr::V6(CR1_V6), cr1_state),
+        (IpAddr::V4(CR2_V4), cr2_state),
+        (IpAddr::V6(CR2_V6), cr2_state),
+    ] {
+        let desc = format!("mgd bfd {peer} -> {want:?}");
+        wait_for_eq!(bfd_state(mgd, peer).await, Some(want), &desc);
+    }
+
+    if matches!(cr1_state, BfdPeerState::Up) {
+        for peer in [IpAddr::V4(OX_CR1_V4), IpAddr::V6(OX_CR1_V6)] {
+            let desc = format!("cr1 bfd {peer} -> Up");
+            wait_for_eq!(
+                cr1.bfd_peer_up(d, peer).await.unwrap_or(false),
+                true,
+                &desc
+            );
+        }
+    }
+    if matches!(cr2_state, BfdPeerState::Up) {
+        for peer in [IpAddr::V4(OX_CR2_V4), IpAddr::V6(OX_CR2_V6)] {
+            let desc = format!("cr2 bfd {peer} -> Up");
+            wait_for_eq!(
+                cr2.bfd_peer_up(d, peer).await.unwrap_or(false),
+                true,
+                &desc
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Expect the test's v4 + v6 prefixes to resolve to the given subset of cr1 /
+/// cr2 as dpd targets.
+async fn expect_route(
+    dpd: &DpdClient,
+    prefix_v4: &Prefix4,
+    prefix_v6: &Prefix6,
+    cr1_in: bool,
+    cr2_in: bool,
+    phase: &str,
+) -> Result<()> {
+    // Push cr1 before cr2 so the list is already in the sorted order that
+    // dpd_v*_targets returns.
+    let mut want_v4 = Vec::new();
+    let mut want_v6 = Vec::new();
+    if cr1_in {
+        want_v4.push(CR1_V4);
+        want_v6.push(CR1_V6);
+    }
+    if cr2_in {
+        want_v4.push(CR2_V4);
+        want_v6.push(CR2_V6);
+    }
+
+    let desc_v4 = format!("{phase} v4");
+    let desc_v6 = format!("{phase} v6");
+    wait_for_eq!(
+        dpd_v4_targets(dpd, prefix_v4).await,
+        want_v4.clone(),
+        &desc_v4
+    );
+    wait_for_eq!(
+        dpd_v6_targets(dpd, prefix_v6).await,
+        want_v6.clone(),
+        &desc_v6
+    );
+    Ok(())
+}
+
+async fn bfd_state(mgd: &MgdClient, peer: IpAddr) -> Option<BfdPeerState> {
+    let peers = mgd.get_bfd_peers().await.ok()?.into_inner();
+    peers
+        .into_iter()
+        .find(|p| p.config.peer == peer)
+        .map(|p| p.state)
+}
+
+async fn dpd_v4_targets(dpd: &DpdClient, prefix: &Prefix4) -> Vec<Ipv4Addr> {
+    let items = match dpd.route_ipv4_list(None, None).await {
+        Ok(r) => r.into_inner().items,
+        Err(_) => return Vec::new(),
+    };
+    let want_cidr = prefix.to_string();
+    let mut out: Vec<Ipv4Addr> = items
+        .into_iter()
+        .filter(|r| r.cidr.to_string() == want_cidr)
+        .flat_map(|r| {
+            r.targets.into_iter().filter_map(|t| match t {
+                dpd_client::types::Route::V4(rt) => Some(rt.tgt_ip),
+                _ => None,
+            })
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+async fn dpd_v6_targets(dpd: &DpdClient, prefix: &Prefix6) -> Vec<Ipv6Addr> {
+    let items = match dpd.route_ipv6_list(None, None).await {
+        Ok(r) => r.into_inner().items,
+        Err(_) => return Vec::new(),
+    };
+    let want_cidr = prefix.to_string();
+    let mut out: Vec<Ipv6Addr> = items
+        .into_iter()
+        .filter(|r| r.cidr.to_string() == want_cidr)
+        .flat_map(|r| r.targets.into_iter().map(|t| t.tgt_ip))
+        .collect();
+    out.sort();
+    out
 }

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -12,7 +12,10 @@ use crate::{
     wait_for_eq,
 };
 use anyhow::{Context, Result};
-use dpd_client::Client as DpdClient;
+use dpd_client::{
+    Client as DpdClient,
+    types::{Ipv4Entry, Ipv6Entry, LinkId, PortId},
+};
 use libfalcon::Runner;
 use mg_admin_client::{
     Client as MgdClient,
@@ -456,6 +459,38 @@ pub async fn run_trio_bfd_static_test(
         },
     )
     .await?;
+
+    // Register each ox-side address with dpd so softnpu punts packets for
+    // those destinations to the CPU port. Link-local v6 is handled
+    // implicitly by the P4 pipeline, but globally-scoped addresses need an
+    // explicit per-link mapping.
+    for (qsfp, v4, v6) in [
+        ("qsfp0", OX_CR1_V4, OX_CR1_V6),
+        ("qsfp1", OX_CR2_V4, OX_CR2_V6),
+    ] {
+        let port = PortId::Qsfp(qsfp.parse().expect("parse qsfp port"));
+        let link = LinkId(0);
+        dpd.link_ipv4_create(
+            &port,
+            &link,
+            &Ipv4Entry {
+                addr: v4,
+                tag: "falcon-lab".into(),
+            },
+        )
+        .await
+        .context(format!("dpd: program {v4} on {qsfp}/0"))?;
+        dpd.link_ipv6_create(
+            &port,
+            &link,
+            &Ipv6Entry {
+                addr: v6,
+                tag: "falcon-lab".into(),
+            },
+        )
+        .await
+        .context(format!("dpd: program {v6} on {qsfp}/0"))?;
+    }
 
     // Configure numbered v4 + v6 addresses on the ox side of each softnpu
     // link so static-route nexthops resolve. illumos requires a v6 link-local

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -362,22 +362,18 @@ async fn frr_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
         ipv6 forwarding
         ip route 1.2.3.0/24 null0
         ipv6 route fd99::/64 null0
-        route-map PERMIT-ALL permit 10
         router bgp 44
+          no bgp ebgp-requires-policy
           timers bgp 2 6
           neighbor enp0s8 interface remote-as external
           neighbor enp0s8 timers connect 1     
           address-family ipv4 unicast
             network 1.2.3.0/24
             neighbor enp0s8 activate
-            neighbor enp0s8 route-map PERMIT-ALL out
-            neighbor enp0s8 route-map PERMIT-ALL in
           exit-address-family
           address-family ipv6 unicast
             network fd99::/64
             neighbor enp0s8 activate
-            neighbor enp0s8 route-map PERMIT-ALL out
-            neighbor enp0s8 route-map PERMIT-ALL in
           exit-address-family
         exit
     ";

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -20,9 +20,10 @@ use libfalcon::Runner;
 use mg_admin_client::{
     Client as MgdClient,
     types::{
-        AddStaticRoute4Request, AddStaticRoute6Request, BfdPeerConfig,
-        BfdPeerState, FsmStateKind, Origin4, Origin6, Router, SessionMode,
-        StaticRoute4, StaticRoute4List, StaticRoute6, StaticRoute6List,
+        AddStaticRoute4Request, AddStaticRoute6Request, BestpathFanoutRequest,
+        BfdPeerConfig, BfdPeerState, FsmStateKind, Origin4, Origin6, Router,
+        SessionMode, StaticRoute4, StaticRoute4List, StaticRoute6,
+        StaticRoute6List,
     },
 };
 use rdb_types::{AddressFamily, Prefix4, Prefix6};
@@ -515,7 +516,20 @@ pub async fn run_trio_bfd_static_test(
     }
 
     ox.run_mgd(&ad).await?;
+    // mg-lower's sync loop queries ddm on every prefix change and bails the
+    // whole sync when ddm is unreachable. We don't exercise DDM here, but
+    // ddmd has to be up for static routes to lower into dpd.
+    ox.ddm().run_ddm(&ad).await?;
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
+
+    // Default fanout is 1, which collapses the two static paths into a single
+    // selected nexthop. Bump to 2 so both paths propagate through best-path
+    // selection and land in dpd as ECMP.
+    mgd.update_bestpath_fanout(&BestpathFanoutRequest {
+        fanout: std::num::NonZeroU8::new(2).expect("fanout > 0"),
+    })
+    .await
+    .context("mgd: set bestpath fanout")?;
 
     let prefix_v4: Prefix4 =
         TEST_PREFIX_V4.parse().expect("parse v4 test prefix");

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -26,6 +26,7 @@ use mg_admin_client::{
         StaticRoute6List,
     },
 };
+use oxnet::{Ipv4Net, Ipv6Net};
 use rdb_types::{AddressFamily, Prefix4, Prefix6};
 use slog::info;
 use std::{
@@ -196,6 +197,14 @@ pub async fn run_trio_unnumbered_test(
     ox.ddm().run_ddm(&ad).await?;
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
+    // Fanout of 2 so both peer paths survive best-path selection and we can
+    // validate ECMP in loc_rib and dpd.
+    mgd.update_bestpath_fanout(&BestpathFanoutRequest {
+        fanout: std::num::NonZeroU8::new(2).expect("fanout > 0"),
+    })
+    .await
+    .context("mgd: set bestpath fanout")?;
+
     let local_asn: u32 = 33;
 
     info!(ad.log, "adding BGP router to mgd");
@@ -243,112 +252,102 @@ pub async fn run_trio_unnumbered_test(
     .await
     .context("announce v6 prefix")?;
 
+    // Prefixes announced by the two peers back to ox, and by ox back to them.
+    const CR_V4_PREFIX: &str = "1.2.3.0/24";
+    const CR_V6_PREFIX: &str = "fd99::/64";
+    const OX_V4_ORIGIN: &str = "4.5.6.0/24";
+    const OX_V6_ORIGIN: &str = "fdee::/64";
+
     wait_for_eq!(
         mgd.get_neighbors(local_asn)
             .await
             .map(|x| x.into_inner().len())
             .unwrap_or(0),
         2,
-        "neighbors"
+        "mgd neighbor count"
     );
 
-    wait_for_eq!(
-        mgd.get_neighbors(local_asn)
-            .await
-            .map(|x| x.into_inner().values().nth(0).map(|y| y.fsm_state))
-            .unwrap_or(None),
-        Some(FsmStateKind::Established),
-        "first neighbor established"
-    );
+    for name in ["cr1", "cr2"] {
+        let desc = format!("mgd bgp {name} established");
+        wait_for_eq!(
+            neighbor_fsm_state(&mgd, local_asn, name).await,
+            Some(FsmStateKind::Established),
+            &desc
+        );
+    }
 
+    // Both peers advertise the same prefix, so mgd should see a single
+    // imported entry per family with two paths, and — with fanout=2 — the
+    // same two paths should survive into the selected (loc) RIB.
     wait_for_eq!(
-        mgd.get_rib_imported(Some(&AddressFamily::Ipv4), None)
-            .await
-            .map(|x| x.len())
-            .unwrap_or(0),
-        1,
-        "imported ipv4 route"
-    );
-
-    wait_for_eq!(
-        mgd.get_rib_imported(Some(&AddressFamily::Ipv4), None)
-            .await
-            .map(|x| x.values().nth(0).map(|x| x.len()))
-            .unwrap_or(None),
+        mgd_imported_paths(&mgd, AddressFamily::Ipv4, CR_V4_PREFIX).await,
         Some(2),
-        "ipv4 paths"
+        "mgd imported paths for 1.2.3.0/24"
     );
-
     wait_for_eq!(
-        dpd.route_ipv4_list(None, None)
-            .await
-            .map(|x| x.items.len())
-            .unwrap_or(0),
-        1,
-        "dpd ipv4 routes"
-    );
-
-    wait_for_eq!(
-        mgd.get_rib_imported(Some(&AddressFamily::Ipv6), None)
-            .await
-            .map(|x| x.len())
-            .unwrap_or(0),
-        1,
-        "imported ipv6 route"
-    );
-
-    wait_for_eq!(
-        mgd.get_rib_imported(Some(&AddressFamily::Ipv6), None)
-            .await
-            .map(|x| x.values().nth(0).map(|x| x.len()))
-            .unwrap_or(None),
+        mgd_imported_paths(&mgd, AddressFamily::Ipv6, CR_V6_PREFIX).await,
         Some(2),
-        "ipv6 paths"
+        "mgd imported paths for fd99::/64"
     );
-
     wait_for_eq!(
-        dpd.route_ipv6_list(None, None)
-            .await
-            .map(|x| x.items.len())
-            .unwrap_or(0),
-        1,
-        "dpd ipv6 routes"
+        mgd_selected_paths(&mgd, AddressFamily::Ipv4, CR_V4_PREFIX).await,
+        Some(2),
+        "mgd selected paths for 1.2.3.0/24"
+    );
+    wait_for_eq!(
+        mgd_selected_paths(&mgd, AddressFamily::Ipv6, CR_V6_PREFIX).await,
+        Some(2),
+        "mgd selected paths for fd99::/64"
     );
 
+    // dpd should have the specific prefixes, each with two ECMP targets.
+    let cr_v4: Prefix4 = CR_V4_PREFIX.parse().expect("parse cr v4 prefix");
+    let cr_v6: Prefix6 = CR_V6_PREFIX.parse().expect("parse cr v6 prefix");
+    wait_for_eq!(
+        dpd_v4_targets(&dpd, &cr_v4).await.len(),
+        2,
+        "dpd ipv4 targets for 1.2.3.0/24"
+    );
+    wait_for_eq!(
+        dpd_v6_targets(&dpd, &cr_v6).await.len(),
+        2,
+        "dpd ipv6 targets for fd99::/64"
+    );
+
+    // Each peer should have imported ox's originated prefixes.
+    let ox_v4: Ipv4Net = OX_V4_ORIGIN.parse().expect("parse ox v4 origin");
+    let ox_v6: Ipv6Net = OX_V6_ORIGIN.parse().expect("parse ox v6 origin");
     wait_for_eq!(
         cr1.bgp_ipv4_imported(&ad)
             .await
-            .map(|x| x.all().count())
-            .unwrap_or(0),
-        1,
-        "cr1 imported ipv4 routes"
+            .map(|r| r.all().any(|(p, _)| *p == ox_v4))
+            .unwrap_or(false),
+        true,
+        "cr1 imported 4.5.6.0/24"
     );
-
     wait_for_eq!(
         cr1.bgp_ipv6_imported(&ad)
             .await
-            .map(|x| x.all().count())
-            .unwrap_or(0),
-        1,
-        "cr1 imported ipv6 routes"
+            .map(|r| r.all().any(|(p, _)| *p == ox_v6))
+            .unwrap_or(false),
+        true,
+        "cr1 imported fdee::/64"
     );
-
     wait_for_eq!(
         cr2.bgp_ipv4_imported(&ad)
             .await
-            .map(|x| x.all().count())
-            .unwrap_or(0),
-        1,
-        "cr2 imported ipv4 routes"
+            .map(|r| r.all().any(|(p, _)| *p == ox_v4))
+            .unwrap_or(false),
+        true,
+        "cr2 imported 4.5.6.0/24"
     );
-
     wait_for_eq!(
         cr2.bgp_ipv6_imported(&ad)
             .await
-            .map(|x| x.all().count())
-            .unwrap_or(0),
-        1,
-        "cr2 imported ipv6 routes"
+            .map(|r| r.all().any(|(p, _)| *p == ox_v6))
+            .unwrap_or(false),
+        true,
+        "cr2 imported fdee::/64"
     );
 
     info!(ad.log, "trio bgp unnumbered test passed 🎉");
@@ -792,6 +791,54 @@ async fn bfd_state(mgd: &MgdClient, peer: IpAddr) -> Option<BfdPeerState> {
         .into_iter()
         .find(|p| p.config.peer == peer)
         .map(|p| p.state)
+}
+
+/// Look up the FSM state of the neighbor with the given `name`. The
+/// `get_neighbors` map is keyed by interface/peer-id which we don't care
+/// about here; we iterate values and match on `PeerInfo::name`.
+async fn neighbor_fsm_state(
+    mgd: &MgdClient,
+    local_asn: u32,
+    name: &str,
+) -> Option<FsmStateKind> {
+    mgd.get_neighbors(local_asn)
+        .await
+        .ok()?
+        .into_inner()
+        .into_values()
+        .find(|p| p.name == name)
+        .map(|p| p.fsm_state)
+}
+
+/// Number of imported paths in the mgd RIB for a given prefix, or `None`
+/// if the prefix is absent. Reflects every path mgd has seen regardless of
+/// best-path selection.
+async fn mgd_imported_paths(
+    mgd: &MgdClient,
+    af: AddressFamily,
+    prefix: &str,
+) -> Option<usize> {
+    mgd.get_rib_imported(Some(&af), None)
+        .await
+        .ok()?
+        .into_inner()
+        .get(prefix)
+        .map(|paths| paths.len())
+}
+
+/// Number of selected (loc_rib) paths in the mgd RIB for a given prefix,
+/// or `None` if the prefix is absent. Reflects bestpath fanout.
+async fn mgd_selected_paths(
+    mgd: &MgdClient,
+    af: AddressFamily,
+    prefix: &str,
+) -> Option<usize> {
+    mgd.get_rib_selected(Some(&af), None)
+        .await
+        .ok()?
+        .into_inner()
+        .get(prefix)
+        .map(|paths| paths.len())
 }
 
 async fn dpd_v4_targets(dpd: &DpdClient, prefix: &Prefix4) -> Vec<Ipv4Addr> {

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -667,8 +667,8 @@ async fn eos_bfd_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
           ipv6 address {cr_v6_cidr}
           bfd interval {rx_ms} min-rx {rx_ms} multiplier {mult}
         exit
-        ip route 172.30.0.0/24 {ox_v4} bfd
-        ipv6 route fd99::/64 {ox_v6} bfd
+        ip route 100.64.0.0/24 {ox_v4} track bfd
+        ipv6 route 3fff::/64 {ox_v6} track bfd
         exit
         ",
         cr_v4_cidr = CR2_V4_CIDR,

--- a/mgd/src/bfd_admin.rs
+++ b/mgd/src/bfd_admin.rs
@@ -23,7 +23,7 @@ use std::{
         atomic::AtomicBool,
         mpsc::{Receiver, Sender},
     },
-    thread::{JoinHandle, sleep, spawn},
+    thread::{Builder, JoinHandle, sleep},
     time::Duration,
 };
 
@@ -212,7 +212,7 @@ pub(crate) fn channel(
     // Spawn an egress thread to take packets from the session and send them
     // out a UDP socket.
     let egress_thread =
-        egress(remote.rx, listen, src_port, dst_port, log.clone());
+        egress(remote.rx, listen, peer, src_port, dst_port, log.clone());
 
     Ok((local, egress_thread))
 }
@@ -234,12 +234,15 @@ fn egress_socket(local: IpAddr, src_port: u16) -> std::io::Result<UdpSocket> {
 fn egress(
     rx: Receiver<(IpAddr, packet::Control)>,
     local: IpAddr,
+    peer: IpAddr,
     src_port: u16,
     dst_port: u16,
     log: Logger,
 ) -> Arc<ManagedThread> {
     let thread = Arc::new(ManagedThread::new());
-    let handle = spawn(move || {
+    let handle = Builder::new()
+        .name(format!("bfd-egress-{peer}"))
+        .spawn(move || {
         let log = log.new(slog::o!(
             "local" => format!("{local}"),
             "src_port" => src_port,
@@ -281,7 +284,8 @@ fn egress(
                 }
             }
         }
-    });
+    })
+    .expect("failed to spawn bfd-egress thread");
     thread.start(handle);
     thread
 }
@@ -354,7 +358,10 @@ impl Dispatcher {
                 local,
                 Listener {
                     sk: sk.try_clone()?,
-                    handle: spawn(move || Self::listen(skl, sessions, ks, log)),
+                    handle: Builder::new()
+                        .name(format!("bfd-listen-{local}"))
+                        .spawn(move || Self::listen(skl, sessions, ks, log))
+                        .expect("failed to spawn bfd-listen thread"),
                     peers,
                     kill_switch,
                 },

--- a/mgd/src/bfd_admin.rs
+++ b/mgd/src/bfd_admin.rs
@@ -20,8 +20,8 @@ use std::{
     net::{IpAddr, SocketAddr, UdpSocket},
     sync::{
         Arc, Mutex, RwLock,
-        atomic::AtomicBool,
-        mpsc::{Receiver, Sender},
+        atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, RecvTimeoutError, Sender},
     },
     thread::{Builder, JoinHandle, sleep},
     time::Duration,
@@ -133,7 +133,7 @@ pub(crate) fn add_peer(
     .map_err(|e| {
         bfd_log!(log, error, "udp channel error: {e}";
             "params" => format!("{rq:?}"),
-            "peer" => format!("rq.peer"),
+            "peer" => format!("{}", rq.peer),
             "src_port" => src_port,
             "dst_port" => dst_port,
             "error" => format!("{e}")
@@ -153,7 +153,17 @@ pub(crate) fn add_peer(
                 db,
             },
         )
-        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+        .map_err(|e| match e {
+            bfd::AddPeerError::PeerExists(_) => {
+                HttpError::for_client_error_with_status(
+                    Some(e.to_string()),
+                    ClientErrorStatusCode::CONFLICT,
+                )
+            }
+            bfd::AddPeerError::Other(e) => {
+                HttpError::for_internal_error(e.to_string())
+            }
+        })?;
 
     Ok(())
 }
@@ -245,52 +255,61 @@ fn egress(
     log: Logger,
 ) -> Result<Arc<ManagedThread>> {
     let thread = Arc::new(ManagedThread::new());
-    let handle = Builder::new()
-        .name(format!("bfd-egress-{peer}"))
-        .spawn(move || {
-        let log = log.new(slog::o!(
-            "local" => format!("{local}"),
-            "src_port" => src_port,
-            "dst_port" => dst_port,
-        ));
-        'egress: loop {
-            let sk = match egress_socket(local, src_port) {
-                Err(e) => {
-                    bfd_log!(log, error, "failed to bind egress socket: {e}";
-                        "error" => format!("{e}")
-                    );
-                    // Explicit sleep call here to prevent spin-lock in case
-                    // socket creation/bind failures are persistent.
-                    sleep(Duration::from_secs(5));
-                    continue;
+    let dropped = thread.dropped_flag();
+    let handle = Builder::new().name(format!("bfd-egress-{peer}")).spawn(
+        move || {
+            let log = log.new(slog::o!(
+                "local" => format!("{local}"),
+                "src_port" => src_port,
+                "dst_port" => dst_port,
+            ));
+            'egress: loop {
+                if dropped.load(Ordering::Relaxed) {
+                    break;
                 }
-                Ok(sk) => sk,
-            };
 
-            'socket: loop {
-                let (addr, pkt) = match rx.recv() {
-                    Ok(result) => result,
+                let sk = match egress_socket(local, src_port) {
                     Err(e) => {
-                        bfd_log!(log, warn, "udp egress channel closed: {e}";
+                        bfd_log!(log, error, "failed to bind egress socket: {e}";
                             "error" => format!("{e}")
                         );
-                        break 'egress;
+                        // Explicit sleep call here to prevent spin-lock in case
+                        // socket creation/bind failures are persistent.
+                        sleep(Duration::from_secs(5));
+                        continue;
                     }
+                    Ok(sk) => sk,
                 };
 
-                let sa = SocketAddr::new(addr, dst_port);
-                if let Err(e) = sk.send_to(&pkt.to_bytes(), sa) {
-                    bfd_log!(log, error, "udp send error: {e}";
-                        "message" => "control",
-                        "message_contents" => format!("{pkt}"),
-                        "error" => format!("{e}")
-                    );
-                    break 'socket;
+                'socket: loop {
+                    let (addr, pkt) =
+                        match rx.recv_timeout(Duration::from_secs(1)) {
+                            Ok(result) => result,
+                            Err(RecvTimeoutError::Timeout) => {
+                                if dropped.load(Ordering::Relaxed) {
+                                    break 'egress;
+                                }
+                                continue;
+                            }
+                            Err(RecvTimeoutError::Disconnected) => {
+                                bfd_log!(log, warn, "udp egress channel closed");
+                                break 'egress;
+                            }
+                        };
+
+                    let sa = SocketAddr::new(addr, dst_port);
+                    if let Err(e) = sk.send_to(&pkt.to_bytes(), sa) {
+                        bfd_log!(log, error, "udp send error: {e}";
+                            "message" => "control",
+                            "message_contents" => format!("{pkt}"),
+                            "error" => format!("{e}")
+                        );
+                        break 'socket;
+                    }
                 }
             }
-        }
-    })
-    ?;
+        },
+    )?;
     thread.start(handle);
     Ok(thread)
 }
@@ -299,7 +318,6 @@ type Sessions = HashMap<IpAddr, Sender<(IpAddr, packet::Control)>>;
 
 #[derive(Debug)]
 struct Listener {
-    sk: UdpSocket,
     #[allow(dead_code)]
     handle: JoinHandle<()>,
     peers: HashSet<IpAddr>,
@@ -342,11 +360,11 @@ impl Dispatcher {
         sender: Sender<(IpAddr, packet::Control)>,
         port: u16,
         log: Logger,
-    ) -> Result<UdpSocket> {
+    ) -> Result<()> {
         self.sessions.write().unwrap().insert(remote, sender);
         if let Some(ref mut listener) = self.listeners.get_mut(&local) {
             listener.peers.insert(remote);
-            Ok(listener.sk.try_clone()?)
+            Ok(())
         } else {
             let sessions = self.sessions.clone();
             let sa = SocketAddr::new(local, port);
@@ -362,7 +380,6 @@ impl Dispatcher {
             self.listeners.insert(
                 local,
                 Listener {
-                    sk: sk.try_clone()?,
                     handle: Builder::new()
                         .name(format!("bfd-listen-{local}"))
                         .spawn(move || Self::listen(skl, sessions, ks, log))?,
@@ -370,7 +387,7 @@ impl Dispatcher {
                     kill_switch,
                 },
             );
-            Ok(sk)
+            Ok(())
         }
     }
 
@@ -380,9 +397,7 @@ impl Dispatcher {
             if listener.peers.contains(&peer) {
                 listener.peers.remove(&peer);
                 if listener.peers.is_empty() {
-                    listener
-                        .kill_switch
-                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                    listener.kill_switch.store(true, Ordering::Relaxed);
                     to_remove.push(*local);
                 }
             }
@@ -401,7 +416,7 @@ impl Dispatcher {
         log: Logger,
     ) {
         loop {
-            if kill_switch.load(std::sync::atomic::Ordering::Relaxed) {
+            if kill_switch.load(Ordering::Relaxed) {
                 bfd_log!(
                     log,
                     warn,

--- a/mgd/src/bfd_admin.rs
+++ b/mgd/src/bfd_admin.rs
@@ -4,12 +4,13 @@
 
 use crate::{admin::HandlerContext, log::bfd_log};
 use anyhow::Result;
-use bfd::{BfdEndpoint, DEFAULT_BFD_TTL, Daemon, bidi, packet};
+use bfd::{AddPeerRequest, BfdEndpoint, DEFAULT_BFD_TTL, Daemon, bidi, packet};
 use dropshot::{
     HttpError, HttpResponseOk, HttpResponseUpdatedNoContent, Path,
     RequestContext, TypedBody,
 };
 use mg_common::lock;
+use mg_common::thread::ManagedThread;
 use mg_types::bfd::{BfdPeerInfo, DeleteBfdPeerPathParams};
 use rdb::{BfdPeerConfig, SessionMode};
 use slog::Logger;
@@ -118,7 +119,7 @@ pub(crate) fn add_peer(
 
     let log = ctx.log.clone();
 
-    let ch = channel(
+    let (ch, egress_thread) = channel(
         dispatcher,
         rq.listen,
         rq.peer,
@@ -137,8 +138,17 @@ pub(crate) fn add_peer(
         HttpError::for_internal_error(e.to_string())
     })?;
 
-    let timeout = Duration::from_micros(rq.required_rx);
-    daemon.add_peer(rq.peer, timeout, rq.detection_threshold, rq.mode, ch, db);
+    daemon.add_peer(
+        rq.peer,
+        AddPeerRequest {
+            required_rx: Duration::from_micros(rq.required_rx),
+            detection_multiplier: rq.detection_threshold,
+            mode: rq.mode,
+            endpoint: ch,
+            egress_thread: Some(egress_thread),
+            db,
+        },
+    );
 
     Ok(())
 }
@@ -191,7 +201,7 @@ pub(crate) fn channel(
     src_port: u16,
     dst_port: u16,
     log: Logger,
-) -> Result<BfdEndpoint> {
+) -> Result<(BfdEndpoint, Arc<ManagedThread>)> {
     let (local, remote) = bidi::channel();
 
     // Ensure there is a dispatcher thread for this listening address and a
@@ -201,9 +211,10 @@ pub(crate) fn channel(
 
     // Spawn an egress thread to take packets from the session and send them
     // out a UDP socket.
-    egress(remote.rx, listen, src_port, dst_port, log.clone());
+    let egress_thread =
+        egress(remote.rx, listen, src_port, dst_port, log.clone());
 
-    Ok(local)
+    Ok((local, egress_thread))
 }
 
 /// Bind a UDP socket for BFD egress and configure the TTL/Hop Limit to 255
@@ -226,14 +237,14 @@ fn egress(
     src_port: u16,
     dst_port: u16,
     log: Logger,
-) {
-    spawn(move || {
+) -> Arc<ManagedThread> {
+    let thread = Arc::new(ManagedThread::new());
+    let handle = spawn(move || {
         let log = log.new(slog::o!(
             "local" => format!("{local}"),
             "src_port" => src_port,
             "dst_port" => dst_port,
         ));
-
         'egress: loop {
             let sk = match egress_socket(local, src_port) {
                 Err(e) => {
@@ -271,6 +282,8 @@ fn egress(
             }
         }
     });
+    thread.start(handle);
+    thread
 }
 
 type Sessions = HashMap<IpAddr, Sender<(IpAddr, packet::Control)>>;

--- a/mgd/src/bfd_admin.rs
+++ b/mgd/src/bfd_admin.rs
@@ -6,8 +6,8 @@ use crate::{admin::HandlerContext, log::bfd_log};
 use anyhow::Result;
 use bfd::{AddPeerRequest, BfdEndpoint, DEFAULT_BFD_TTL, Daemon, bidi, packet};
 use dropshot::{
-    HttpError, HttpResponseOk, HttpResponseUpdatedNoContent, Path,
-    RequestContext, TypedBody,
+    ClientErrorStatusCode, HttpError, HttpResponseOk,
+    HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
 };
 use mg_common::lock;
 use mg_common::thread::ManagedThread;
@@ -105,7 +105,10 @@ pub(crate) fn add_peer(
     let db = ctx.db.clone();
 
     if daemon.sessions.contains_key(&rq.peer) {
-        return Ok(());
+        return Err(HttpError::for_client_error_with_status(
+            Some(format!("BFD peer {} already exists", rq.peer)),
+            ClientErrorStatusCode::CONFLICT,
+        ));
     }
 
     let (src_port, dst_port) = match rq.mode {
@@ -138,17 +141,19 @@ pub(crate) fn add_peer(
         HttpError::for_internal_error(e.to_string())
     })?;
 
-    daemon.add_peer(
-        rq.peer,
-        AddPeerRequest {
-            required_rx: Duration::from_micros(rq.required_rx),
-            detection_multiplier: rq.detection_threshold,
-            mode: rq.mode,
-            endpoint: ch,
-            egress_thread: Some(egress_thread),
-            db,
-        },
-    );
+    daemon
+        .add_peer(
+            rq.peer,
+            AddPeerRequest {
+                required_rx: Duration::from_micros(rq.required_rx),
+                detection_multiplier: rq.detection_threshold,
+                mode: rq.mode,
+                endpoint: ch,
+                egress_thread: Some(egress_thread),
+                db,
+            },
+        )
+        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 
     Ok(())
 }
@@ -212,7 +217,7 @@ pub(crate) fn channel(
     // Spawn an egress thread to take packets from the session and send them
     // out a UDP socket.
     let egress_thread =
-        egress(remote.rx, listen, peer, src_port, dst_port, log.clone());
+        egress(remote.rx, listen, peer, src_port, dst_port, log.clone())?;
 
     Ok((local, egress_thread))
 }
@@ -238,7 +243,7 @@ fn egress(
     src_port: u16,
     dst_port: u16,
     log: Logger,
-) -> Arc<ManagedThread> {
+) -> Result<Arc<ManagedThread>> {
     let thread = Arc::new(ManagedThread::new());
     let handle = Builder::new()
         .name(format!("bfd-egress-{peer}"))
@@ -285,9 +290,9 @@ fn egress(
             }
         }
     })
-    .expect("failed to spawn bfd-egress thread");
+    ?;
     thread.start(handle);
-    thread
+    Ok(thread)
 }
 
 type Sessions = HashMap<IpAddr, Sender<(IpAddr, packet::Control)>>;
@@ -360,8 +365,7 @@ impl Dispatcher {
                     sk: sk.try_clone()?,
                     handle: Builder::new()
                         .name(format!("bfd-listen-{local}"))
-                        .spawn(move || Self::listen(skl, sessions, ks, log))
-                        .expect("failed to spawn bfd-listen thread"),
+                        .spawn(move || Self::listen(skl, sessions, ks, log))?,
                     peers,
                     kill_switch,
                 },


### PR DESCRIPTION
First round of splits from #648 

## BFD daemon cleanup

- Switch BFD threads to `ManagedThread` + named `Builder::spawn`; propagate spawn `Result`s up to admin callers.
- Group peer config into `AddPeerRequest`; add `AddPeerError::PeerExists` so mgd returns 409 instead of 500 on duplicates.
- Convert `egress()` from blocking `rx.recv()` to `recv_timeout(1s)` with a kill-switch poll, avoiding the silent-channel deadlock.
- Extend bfd unit tests with IPv6 peers.

## New falcon-lab test: `trio-bfd-static-routing`

- Dual-stack BFD + static routing over the existing trio topology (FRR + cEOS peers), with shared bootstrap extracted into `boot_trio()` / `BootedTrio`.
- Five-phase assertion matrix exercises BFD-gated next-hop shutdown and the "all shutdown → all reinstated" fallback. Each phase validates mgd BFD state, peer-side BFD state on live peers, and the dpd target sets for both v4 and v6 prefixes.
- Failure injection via `pkill -STOP bfdd` on FRR and `docker pause ceos` on EOS — reversible, daemon-state-preserving.
- Plumbing needed for numbered peers to work: per-link `link_ipv{4,6}_create` + `link_ipv6_enabled_set`, run ddmd (mg-lower depends on it), bump `bestpath_fanout` to 2, pre-seed each tfport with an `addrconf` link-local before static v6, and tolerate "already"-style `ipadm` errors for `--no-cleanup` re-runs.

## Trio-unnumbered assertion tightening

- Per-neighbor FSM check.
- Assert specific prefixes and path counts in imported RIB, selected RIB, dpd targets, and each peer's imported BGP routes, replacing count-only assertions.
- Bump `bestpath_fanout` to 2 so ECMP is actually exercised.