### PR TITLE
buildomat: add test-ddm job

### DIFF
--- a/.github/buildomat/jobs/test-ddm.sh
+++ b/.github/buildomat/jobs/test-ddm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#:
+#: name = "test-ddm"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "/work/*.log",
+#:   "/tmp/*.db",
+#: ]
+#:
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+
+source .github/buildomat/test-common.sh
+banner ddm
+cargo nextest run -p ddm --nocapture


### PR DESCRIPTION
DDM unit tests were not covered by CI. Granted... there's currently only one such test... but it's still worth having in CI.