### PR TITLE
[mg-admin-api] fix v2/v3 MessageHistory and related types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "drift"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cc7f4e6337c9c0d0402e2dccaeaea63fc38467a3e5ab3f465372dafce2cd89"
+checksum = "d46ae7066bba53a265e8412309dc64739d32c597d688f1938a44c01bd30629e7"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -3882,6 +3882,7 @@ version = "0.1.0"
 dependencies = [
  "bfd",
  "bgp",
+ "chrono",
  "rdb",
  "schemars 0.8.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,4 +152,3 @@ rev = "3d1fe6ad2df3752dd189ad462c4fdec74ebe25f8"
 git = "https://github.com/oxidecomputer/dendrite"
 rev = "37992295b5dc708d8f120cee805d67418741b556"
 package = "dpd-client"
-

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -1033,9 +1033,9 @@ pub const MAX_MESSAGE_HISTORY: usize = 1024;
 /// A message history entry is a BGP message with an associated timestamp and connection ID
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MessageHistoryEntry {
-    timestamp: chrono::DateTime<chrono::Utc>,
-    message: Message,
-    connection_id: ConnectionId,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub message: Message,
+    pub connection_id: ConnectionId,
 }
 
 /// Message history for a BGP session

--- a/mg-api/src/lib.rs
+++ b/mg-api/src/lib.rs
@@ -16,7 +16,7 @@ use dropshot::{
     HttpResponseUpdatedNoContent, Path, Query, RequestContext, TypedBody,
 };
 use dropshot_api_manager_types::api_versions;
-use mg_types_versions::{latest, v1, v2, v5};
+use mg_types_versions::{latest, v1, v2, v4, v5};
 use rdb::{BfdPeerConfig, Prefix};
 
 api_versions!([
@@ -573,7 +573,13 @@ pub trait MgAdminApi {
         request: TypedBody<latest::bgp::MessageHistoryRequest>,
     ) -> Result<HttpResponseOk<latest::bgp::MessageHistoryResponse>, HttpError>;
 
-    #[endpoint { method = GET, path = "/bgp/history/message", versions = VERSION_IPV6_BASIC..VERSION_UNNUMBERED }]
+    #[endpoint { method = GET, path = "/bgp/history/message", versions = VERSION_MP_BGP..VERSION_UNNUMBERED }]
+    async fn message_history_v4(
+        rqctx: RequestContext<Self::Context>,
+        request: TypedBody<v2::bgp::MessageHistoryRequest>,
+    ) -> Result<HttpResponseOk<v4::bgp::MessageHistoryResponse>, HttpError>;
+
+    #[endpoint { method = GET, path = "/bgp/history/message", versions = VERSION_IPV6_BASIC..VERSION_MP_BGP }]
     async fn message_history_v2(
         rqctx: RequestContext<Self::Context>,
         request: TypedBody<v2::bgp::MessageHistoryRequest>,

--- a/mg-types/versions/Cargo.toml
+++ b/mg-types/versions/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 bfd.workspace = true
 bgp.workspace = true
+chrono.workspace = true
 rdb.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/mg-types/versions/src/ipv6_basic/bgp.rs
+++ b/mg-types/versions/src/ipv6_basic/bgp.rs
@@ -2,10 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 
-use bgp::session::{FsmEventRecord, MessageHistory};
+use bgp::connection::ConnectionId;
+use bgp::messages::{
+    NotificationMessage, OpenMessage, PathAttributeV1, RouteRefreshMessage,
+};
+use bgp::session::{
+    FsmEventRecord, MessageHistory as LiveMessageHistory,
+    MessageHistoryEntry as LiveMessageHistoryEntry,
+};
+use rdb::Prefix as RdbPrefix;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -55,4 +63,97 @@ pub struct FsmHistoryResponse {
     /// Events organized by peer address Each peer's value contains only
     /// the events from the requested buffer
     pub by_peer: HashMap<IpAddr, Vec<FsmEventRecord>>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MessageHistory {
+    pub received: VecDeque<MessageHistoryEntry>,
+    pub sent: VecDeque<MessageHistoryEntry>,
+}
+
+impl From<LiveMessageHistory> for MessageHistory {
+    fn from(history: LiveMessageHistory) -> Self {
+        Self {
+            received: history
+                .received
+                .into_iter()
+                .map(MessageHistoryEntry::from)
+                .collect(),
+            sent: history
+                .sent
+                .into_iter()
+                .map(MessageHistoryEntry::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MessageHistoryEntry {
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub message: Message,
+    pub connection_id: ConnectionId,
+}
+
+impl From<LiveMessageHistoryEntry> for MessageHistoryEntry {
+    fn from(entry: LiveMessageHistoryEntry) -> Self {
+        Self {
+            timestamp: entry.timestamp,
+            message: Message::from(entry.message),
+            connection_id: entry.connection_id,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum Message {
+    Open(OpenMessage),
+    Update(UpdateMessage),
+    Notification(NotificationMessage),
+    KeepAlive,
+    RouteRefresh(RouteRefreshMessage),
+}
+
+impl From<bgp::messages::Message> for Message {
+    fn from(msg: bgp::messages::Message) -> Self {
+        match msg {
+            bgp::messages::Message::Open(open) => Self::Open(open),
+            bgp::messages::Message::Update(update) => {
+                Self::Update(UpdateMessage::from(update))
+            }
+            bgp::messages::Message::Notification(notif) => {
+                Self::Notification(notif)
+            }
+            bgp::messages::Message::KeepAlive => Self::KeepAlive,
+            bgp::messages::Message::RouteRefresh(rr) => Self::RouteRefresh(rr),
+        }
+    }
+}
+
+#[derive(
+    Debug, PartialEq, Eq, Clone, Default, Serialize, Deserialize, JsonSchema,
+)]
+pub struct UpdateMessage {
+    pub withdrawn: Vec<RdbPrefix>,
+    pub path_attributes: Vec<PathAttributeV1>,
+    pub nlri: Vec<RdbPrefix>,
+}
+
+impl From<bgp::messages::UpdateMessage> for UpdateMessage {
+    fn from(msg: bgp::messages::UpdateMessage) -> Self {
+        // The latest UpdateMessage carries IPv4-only NLRI in its body; IPv6
+        // NLRI lives in MP_REACH/UNREACH path attributes, which v2 does not
+        // surface. Converting v4 prefixes back into the V4/V6 enum gives the
+        // pre-MP-BGP wire shape.
+        Self {
+            withdrawn: msg.withdrawn.into_iter().map(RdbPrefix::V4).collect(),
+            path_attributes: msg
+                .path_attributes
+                .into_iter()
+                .filter_map(Option::<PathAttributeV1>::from)
+                .collect(),
+            nlri: msg.nlri.into_iter().map(RdbPrefix::V4).collect(),
+        }
+    }
 }

--- a/mg-types/versions/src/mp_bgp/bgp.rs
+++ b/mg-types/versions/src/mp_bgp/bgp.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::collections::HashMap;
 use std::net::IpAddr;
 
 use bgp::params::NeighborResetOp;
+use bgp::session::MessageHistory;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -25,4 +27,9 @@ impl From<v1::bgp::NeighborResetRequest> for NeighborResetRequest {
             op: req.op.into(),
         }
     }
+}
+
+#[derive(Debug, Serialize, JsonSchema, Clone)]
+pub struct MessageHistoryResponse {
+    pub by_peer: HashMap<IpAddr, MessageHistory>,
 }

--- a/mgd/src/admin.rs
+++ b/mgd/src/admin.rs
@@ -29,7 +29,7 @@ use mg_types::static_routes::{
     DeleteStaticRoute6Request,
 };
 use mg_types::switch::SwitchIdentifiers;
-use mg_types_versions::{v1, v2, v5};
+use mg_types_versions::{v1, v2, v4, v5};
 use rdb::{BfdPeerConfig, Db, PeerId, Prefix};
 use slog::{Logger, error, info, o};
 use std::collections::HashMap;
@@ -462,6 +462,14 @@ impl MgAdminApi for MgAdminApiImpl {
         request: TypedBody<MessageHistoryRequest>,
     ) -> Result<HttpResponseOk<MessageHistoryResponse>, HttpError> {
         bgp_admin::message_history(ctx, request).await
+    }
+
+    async fn message_history_v4(
+        ctx: RequestContext<Self::Context>,
+        request: TypedBody<v2::bgp::MessageHistoryRequest>,
+    ) -> Result<HttpResponseOk<v4::bgp::MessageHistoryResponse>, HttpError>
+    {
+        bgp_admin::message_history_v4(ctx, request).await
     }
 
     async fn message_history_v2(

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -40,7 +40,7 @@ use mg_types::ndp::{
     NdpInterface, NdpInterfaceSelector, NdpManagerState, NdpPeer,
     NdpPendingInterface, NdpThreadState,
 };
-use mg_types_versions::{v1, v2, v5};
+use mg_types_versions::{v1, v2, v4, v5};
 use rdb::{
     AddressFamily, Asn, BgpRouterInfo, ImportExportPolicy4,
     ImportExportPolicy6, ImportExportPolicyV1, Prefix, Prefix4, Prefix6,
@@ -1567,6 +1567,32 @@ pub async fn message_history_v1(
     }))
 }
 
+// VERSION_MP_BGP..VERSION_UNNUMBERED endpoint. Uses IpAddr keys for numbered
+// peers; the inner MessageHistory is the currently-latest BGP type (with MP-BGP
+// path attributes).
+pub async fn message_history_v4(
+    ctx: RequestContext<Arc<HandlerContext>>,
+    request: TypedBody<v2::bgp::MessageHistoryRequest>,
+) -> Result<HttpResponseOk<v4::bgp::MessageHistoryResponse>, HttpError> {
+    let rq = request.into_inner();
+    let ctx = ctx.context();
+
+    // Convert IpAddr filter to PeerId and call unified helper
+    let peer_id = rq.peer.map(PeerId::Ip);
+    let by_peer_string =
+        get_message_history_filtered(ctx, rq.asn, peer_id, rq.direction)?;
+
+    // Convert String keys back to IpAddr (filters out unnumbered peers)
+    let by_peer = by_peer_string
+        .into_iter()
+        .filter_map(|(key, history)| {
+            key.parse::<IpAddr>().ok().map(|addr| (addr, history))
+        })
+        .collect();
+
+    Ok(HttpResponseOk(v4::bgp::MessageHistoryResponse { by_peer }))
+}
+
 // Pre-UNNUMBERED API endpoint (VERSION_IPV6_BASIC..VERSION_UNNUMBERED)
 // Uses IpAddr for numbered peers only
 pub async fn message_history_v2(
@@ -1585,7 +1611,9 @@ pub async fn message_history_v2(
     let by_peer = by_peer_string
         .into_iter()
         .filter_map(|(key, history)| {
-            key.parse::<IpAddr>().ok().map(|addr| (addr, history))
+            key.parse::<IpAddr>()
+                .ok()
+                .map(|addr| (addr, v2::bgp::MessageHistory::from(history)))
         })
         .collect();
 


### PR DESCRIPTION
This type was changed in v4, but the change was accidentally also applied to v2 and v3. The nontrivial change was not detected by drift due to https://github.com/oxidecomputer/drift/pull/22, which is now fixed in drift 0.1.4.

Fix this up by introducing types and conversions for v2. This is unfortunately complicated by the fact that a lot of the BGP types are not in mg-admin-types-versions, partly because untangling this is quite difficult. I've opted to just do a relatively minimal fix for now where the v2 types are defined in mg-admin-types-versions, but the newest types continue to live in bgp. I'll try untangling this further in the future.
