### PR TITLE
Remove redundant package alias that is tripping up renovate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,4 +151,3 @@ rev = "3d1fe6ad2df3752dd189ad462c4fdec74ebe25f8"
 [workspace.dependencies.dpd-client]
 git = "https://github.com/oxidecomputer/dendrite"
 rev = "37992295b5dc708d8f120cee805d67418741b556"
-package = "dpd-client"


### PR DESCRIPTION
I believe this line is a redundant alias.
`package = "dpd-client"` specifies the upstream crate package name (dpd-client)
`[workspace.dependencies.dpd-client]` specifies the package name you would like to use (dpd-client)

Cargo doesn't mind, but I'm pretty sure this is triggering a bug in renovate causing it to crash:
- https://github.com/oxidecomputer/renovate-config/issues/77