### PR TITLE
update dropshot-api-manager to 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ serde = { version = "1.0.228", features = ["derive"] }
 hostname = "0.4"
 thiserror = "2.0"
 dropshot = { version = "0.17.0", features = [ "usdt-probes" ] }
-dropshot-api-manager = "0.7.1"
-dropshot-api-manager-types = "0.7.1"
+dropshot-api-manager = "0.7.2"
+dropshot-api-manager-types = "0.7.2"
 schemars = { version = "0.8", features = [ "uuid1", "chrono" ] }
 tokio = { version = "1.49", features = ["full"] }
 serde_repr = "0.1"


### PR DESCRIPTION
Has a neat new UI for reporting incompatibilities (see https://github.com/oxidecomputer/dropshot-api-manager/pull/105).
