### PR TITLE
Expose DEFAULT_RIB_PRIORITY constants through mg-api-types

### DIFF
--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -34,13 +34,14 @@ use mg_api_types::bgp::policy::{ImportExportPolicy4, ImportExportPolicy6};
 pub(crate) use mg_api_types::bgp::session::{
     FsmEventCategory, FsmEventRecord, FsmStateKind, MessageHistory,
 };
+pub use mg_api_types::rdb::DEFAULT_RIB_PRIORITY_BGP;
 use mg_api_types::rdb::path::BgpPathProperties;
 use mg_api_types::rdb::prefix::{Prefix, Prefix4, Prefix6};
 use mg_api_types::rdb::rib::AddressFamily;
 use mg_api_types_versions::v1;
 use mg_common::{lock, read_lock, write_lock};
+pub use rdb::DEFAULT_ROUTE_PRIORITY;
 use rdb::{Asn, Db};
-pub use rdb::{DEFAULT_RIB_PRIORITY_BGP, DEFAULT_ROUTE_PRIORITY};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Logger;

--- a/mg-api-types/versions/src/impls/mod.rs
+++ b/mg-api-types/versions/src/impls/mod.rs
@@ -5,4 +5,4 @@
 //! Functional code for the latest versions of types.
 
 pub(crate) mod bgp;
-mod rdb;
+pub(crate) mod rdb;

--- a/mg-api-types/versions/src/impls/rdb/constants.rs
+++ b/mg-api-types/versions/src/impls/rdb/constants.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-pub(crate) mod constants;
-mod path;
-mod prefix;
+/// The default RIB Priority of BGP routes.
+pub const DEFAULT_RIB_PRIORITY_BGP: u8 = 20;
+
+/// The default RIB Priority of Static routes.
+pub const DEFAULT_RIB_PRIORITY_STATIC: u8 = 1;

--- a/mg-api-types/versions/src/latest.rs
+++ b/mg-api-types/versions/src/latest.rs
@@ -170,6 +170,9 @@ pub mod rdb {
     pub mod router {
         pub use crate::v1::rdb::router::BgpRouterInfo;
     }
+
+    pub use crate::impls::rdb::constants::DEFAULT_RIB_PRIORITY_BGP;
+    pub use crate::impls::rdb::constants::DEFAULT_RIB_PRIORITY_STATIC;
 }
 
 pub mod ndp {

--- a/mgadm/src/static_routing.rs
+++ b/mgadm/src/static_routing.rs
@@ -5,10 +5,10 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use mg_admin_client::Client;
+use mg_api_types::rdb::DEFAULT_RIB_PRIORITY_STATIC;
 use mg_api_types::rdb::prefix::{Prefix4, Prefix6};
 use mg_common::println_nopipe;
 use oxnet::{Ipv4Net, Ipv6Net};
-use rdb::DEFAULT_RIB_PRIORITY_STATIC;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(Subcommand, Debug)]

--- a/rdb/src/bestpath.rs
+++ b/rdb/src/bestpath.rs
@@ -131,11 +131,11 @@ mod test {
     use std::str::FromStr;
 
     use super::bestpaths;
-    use crate::{
-        DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC,
-        types::test_helpers::path_sets_equal,
-    };
+    use crate::types::test_helpers::path_sets_equal;
     use mg_api_types::rdb::path::{BgpPathProperties, Path};
+    use mg_api_types::rdb::{
+        DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC,
+    };
 
     // Bestpaths is purely a function of the path info itself, so we don't
     // need a Rib or Prefix, just a set of candidate paths and a set of

--- a/rdb/src/db.rs
+++ b/rdb/src/db.rs
@@ -1480,9 +1480,10 @@ impl Reaper {
 #[cfg(test)]
 mod test {
     use crate::{
-        DEFAULT_RIB_PRIORITY_STATIC, StaticRouteKey, db::Db, test::TestDb,
-        types::PrefixDbKey, types::test_helpers::path_vecs_equal,
+        StaticRouteKey, db::Db, test::TestDb, types::PrefixDbKey,
+        types::test_helpers::path_vecs_equal,
     };
+    use mg_api_types::rdb::DEFAULT_RIB_PRIORITY_STATIC;
     use mg_api_types::rdb::path::Path;
     use mg_api_types::rdb::prefix::{Prefix, Prefix4, Prefix6};
     use mg_api_types::rdb::rib::AddressFamily;
@@ -1521,12 +1522,13 @@ mod test {
     #[test]
     fn test_rib() {
         use crate::StaticRouteKey;
-        use crate::{
-            DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC, db::Db,
-        };
+        use crate::db::Db;
         use mg_api_types::bgp::peer::PeerId;
         use mg_api_types::rdb::path::{BgpPathProperties, Path};
         use mg_api_types::rdb::prefix::{Prefix, Prefix4};
+        use mg_api_types::rdb::{
+            DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC,
+        };
         // init test vars
         let p0 = Prefix::from("192.168.0.0/24".parse::<Prefix4>().unwrap());
         let p1 = Prefix::from("192.168.1.0/24".parse::<Prefix4>().unwrap());
@@ -2254,13 +2256,13 @@ mod test {
     /// `shutdown` is not part of `Path::Ord` identity.
     #[test]
     fn test_set_nexthop_shutdown_replaces_path() {
-        use crate::{
-            DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC,
-            StaticRouteKey,
-        };
+        use crate::StaticRouteKey;
         use mg_api_types::bgp::peer::PeerId;
         use mg_api_types::rdb::path::{BgpPathProperties, Path};
         use mg_api_types::rdb::prefix::{Prefix, Prefix4, Prefix6};
+        use mg_api_types::rdb::{
+            DEFAULT_RIB_PRIORITY_BGP, DEFAULT_RIB_PRIORITY_STATIC,
+        };
 
         let db = get_test_db();
 

--- a/rdb/src/lib.rs
+++ b/rdb/src/lib.rs
@@ -19,12 +19,6 @@ mod proptest;
 /// The priority routes default to.
 pub const DEFAULT_ROUTE_PRIORITY: u64 = u64::MAX;
 
-/// The default RIB Priority of BGP routes.
-pub const DEFAULT_RIB_PRIORITY_BGP: u8 = 20;
-
-/// The default RIB Priority of Static routes.
-pub const DEFAULT_RIB_PRIORITY_STATIC: u8 = 1;
-
 pub const COMPONENT_RDB: &str = "rdb";
 pub const MOD_DB: &str = "database";
 

--- a/rdb/src/types.rs
+++ b/rdb/src/types.rs
@@ -366,7 +366,7 @@ pub mod test_helpers {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::DEFAULT_RIB_PRIORITY_BGP;
+    use mg_api_types::rdb::DEFAULT_RIB_PRIORITY_BGP;
     use std::{
         cmp::Ordering, collections::BTreeSet, net::IpAddr, str::FromStr,
     };


### PR DESCRIPTION
omicron is currently defining their own constants to mirror maghemite's DEFAULT_RIB_PRIORITY constants.
This exposes them via mg-api-types so omicron can use them too.