### PR TITLE
Reject invalid static-route nexthops

### DIFF
--- a/mgd/src/static_admin.rs
+++ b/mgd/src/static_admin.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::admin::HandlerContext;
-use crate::validation::validate_prefixes;
+use crate::validation::{validate_nexthops, validate_prefixes};
 use dropshot::{
     HttpError, HttpResponseDeleted, HttpResponseOk,
     HttpResponseUpdatedNoContent, RequestContext, TypedBody,
@@ -17,6 +17,7 @@ use mg_api_types::static_routes::{
 };
 use mg_api_types::switch::SwitchIdentifiers;
 use rdb::StaticRouteKey;
+use std::net::IpAddr;
 use std::{collections::BTreeMap, sync::Arc};
 
 // `From<StaticRouteN>` impls cannot live in `mg-api-types-versions` (would
@@ -74,6 +75,9 @@ pub async fn static_add_v4_route(
     // Validate that all prefixes have host bits unset
     let prefixes: Vec<Prefix> = routes.iter().map(|r| r.prefix).collect();
     validate_prefixes(&prefixes)?;
+
+    let nexthops: Vec<IpAddr> = routes.iter().map(|r| r.nexthop).collect();
+    validate_nexthops(&nexthops)?;
 
     ctx.context()
         .db
@@ -134,6 +138,9 @@ pub async fn static_add_v6_route(
     // Validate that all prefixes have host bits unset
     let prefixes: Vec<Prefix> = routes.iter().map(|r| r.prefix).collect();
     validate_prefixes(&prefixes)?;
+
+    let nexthops: Vec<IpAddr> = routes.iter().map(|r| r.nexthop).collect();
+    validate_nexthops(&nexthops)?;
 
     ctx.context()
         .db

--- a/mgd/src/validation.rs
+++ b/mgd/src/validation.rs
@@ -6,6 +6,32 @@
 
 use dropshot::HttpError;
 use mg_api_types::rdb::prefix::{Prefix, Prefix4, Prefix6};
+use rdb::RouterIpAddr;
+use std::net::IpAddr;
+
+/// Validate that a nexthop is a usable forwarding address.
+///
+/// Returns an HTTP 400 Bad Request error if the nexthop is the unspecified,
+/// loopback, multicast, or IPv4 broadcast address, or an IPv4-mapped IPv6
+/// address.
+pub fn validate_nexthop(nexthop: IpAddr) -> Result<(), HttpError> {
+    RouterIpAddr::try_from(nexthop).map(drop).map_err(|err| {
+        HttpError::for_bad_request(
+            Some("InvalidNexthop".to_string()),
+            format!(
+                "Nexthop {nexthop} is not a valid forwarding address ({err})"
+            ),
+        )
+    })
+}
+
+/// Validate a list of nexthops, returning the first failure.
+pub fn validate_nexthops(nexthops: &[IpAddr]) -> Result<(), HttpError> {
+    for nexthop in nexthops {
+        validate_nexthop(*nexthop)?;
+    }
+    Ok(())
+}
 
 /// Validate that all IPv4 prefixes have host bits unset and are valid for RIB.
 ///
@@ -319,6 +345,39 @@ mod tests {
             )),
         ];
         assert!(validate_prefixes(&prefixes).is_ok());
+    }
+
+    #[test]
+    fn test_validate_nexthop_accepts_unicast() {
+        assert!(validate_nexthop(Ipv4Addr::new(10, 0, 0, 1).into()).is_ok());
+        assert!(
+            validate_nexthop(
+                Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1).into()
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_nexthop_rejects_loopback() {
+        let result = validate_nexthop(Ipv4Addr::LOCALHOST.into());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.status_code, http::StatusCode::BAD_REQUEST);
+        assert!(err.external_message.contains("127.0.0.1"));
+        assert!(err.external_message.contains("loopback"));
+    }
+
+    #[test]
+    fn test_validate_nexthop_rejects_unspecified_and_multicast() {
+        assert!(validate_nexthop(Ipv4Addr::UNSPECIFIED.into()).is_err());
+        assert!(validate_nexthop(Ipv4Addr::new(224, 0, 0, 1).into()).is_err());
+    }
+
+    #[test]
+    fn test_validate_nexthop_accepts_v6_link_local() {
+        let ll = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        assert!(validate_nexthop(ll.into()).is_ok());
     }
 
     // Property-based tests to verify equivalence between generic and family-specific validators

--- a/rdb/src/lib.rs
+++ b/rdb/src/lib.rs
@@ -3,10 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 pub mod db;
+pub mod net;
 pub mod rib;
 pub mod types;
 
 pub use db::Db;
+pub use net::{InvalidIpAddr, RouterIpAddr};
 pub use rib::{Rib, Rib4, Rib6, RibExt};
 pub use types::*;
 pub mod bestpath;

--- a/rdb/src/net.rs
+++ b/rdb/src/net.rs
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+use std::net::IpAddr;
+
+/// Reasons an [`IpAddr`] is rejected as a routing address.
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidIpAddr {
+    #[error("unspecified address")]
+    Unspecified,
+    #[error("loopback address")]
+    Loopback,
+    #[error("multicast address")]
+    Multicast,
+    #[error("IPv4 broadcast address")]
+    Broadcast,
+    #[error("IPv4-mapped IPv6 address")]
+    Ipv4Mapped,
+}
+
+/// An [`IpAddr`] validated as usable for routing.
+///
+/// A `RouterIpAddr` is never the unspecified, loopback, multicast, or IPv4
+/// broadcast address, or an IPv4-mapped IPv6 address. IPv6 unicast link-local
+/// addresses are permitted: they are a valid nexthop and the lower half
+/// resolves them to an egress interface.
+///
+/// Modeled on omicron's `RouterPeerIpAddr`; a candidate to lift into `oxnet`
+/// and share across repositories (see oxidecomputer/maghemite#738).
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    JsonSchema,
+)]
+#[serde(into = "IpAddr")]
+#[schemars(transparent)]
+pub struct RouterIpAddr(IpAddr);
+
+impl RouterIpAddr {
+    pub fn addr(&self) -> IpAddr {
+        self.0
+    }
+}
+
+impl TryFrom<IpAddr> for RouterIpAddr {
+    type Error = InvalidIpAddr;
+
+    fn try_from(addr: IpAddr) -> Result<Self, Self::Error> {
+        if addr.is_unspecified() {
+            return Err(InvalidIpAddr::Unspecified);
+        }
+        if addr.is_loopback() {
+            return Err(InvalidIpAddr::Loopback);
+        }
+        if addr.is_multicast() {
+            return Err(InvalidIpAddr::Multicast);
+        }
+        match addr {
+            IpAddr::V4(v4) => {
+                if v4.is_broadcast() {
+                    return Err(InvalidIpAddr::Broadcast);
+                }
+            }
+            IpAddr::V6(v6) => {
+                if v6.to_ipv4_mapped().is_some() {
+                    return Err(InvalidIpAddr::Ipv4Mapped);
+                }
+            }
+        }
+        Ok(Self(addr))
+    }
+}
+
+impl From<RouterIpAddr> for IpAddr {
+    fn from(addr: RouterIpAddr) -> Self {
+        addr.0
+    }
+}
+
+impl fmt::Display for RouterIpAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'de> Deserialize<'de> for RouterIpAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let addr = IpAddr::deserialize(deserializer)?;
+        Self::try_from(addr).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    fn ip(s: &str) -> IpAddr {
+        IpAddr::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn accepts_routable_unicast() {
+        for s in ["10.0.0.1", "192.168.1.1", "203.0.113.7", "2001:db8::1"] {
+            assert!(
+                RouterIpAddr::try_from(ip(s)).is_ok(),
+                "expected {s} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unspecified() {
+        assert_eq!(
+            RouterIpAddr::try_from(IpAddr::from(Ipv4Addr::UNSPECIFIED)),
+            Err(InvalidIpAddr::Unspecified)
+        );
+        assert_eq!(
+            RouterIpAddr::try_from(IpAddr::from(Ipv6Addr::UNSPECIFIED)),
+            Err(InvalidIpAddr::Unspecified)
+        );
+    }
+
+    #[test]
+    fn rejects_loopback() {
+        assert_eq!(
+            RouterIpAddr::try_from(ip("127.0.0.1")),
+            Err(InvalidIpAddr::Loopback)
+        );
+        assert_eq!(
+            RouterIpAddr::try_from(ip("::1")),
+            Err(InvalidIpAddr::Loopback)
+        );
+    }
+
+    #[test]
+    fn rejects_multicast() {
+        assert_eq!(
+            RouterIpAddr::try_from(ip("224.0.0.1")),
+            Err(InvalidIpAddr::Multicast)
+        );
+        assert_eq!(
+            RouterIpAddr::try_from(ip("ff02::1")),
+            Err(InvalidIpAddr::Multicast)
+        );
+    }
+
+    #[test]
+    fn rejects_v4_broadcast() {
+        assert_eq!(
+            RouterIpAddr::try_from(IpAddr::from(Ipv4Addr::BROADCAST)),
+            Err(InvalidIpAddr::Broadcast)
+        );
+    }
+
+    #[test]
+    fn accepts_v6_link_local() {
+        // Link-local nexthops are valid; the lower half resolves them to an
+        // egress interface (e.g. BGP unnumbered, link-local static routes).
+        assert!(RouterIpAddr::try_from(ip("fe80::1")).is_ok());
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_ipv6() {
+        assert_eq!(
+            RouterIpAddr::try_from(ip("::ffff:127.0.0.1")),
+            Err(InvalidIpAddr::Ipv4Mapped)
+        );
+        assert_eq!(
+            RouterIpAddr::try_from(ip("::ffff:10.0.0.1")),
+            Err(InvalidIpAddr::Ipv4Mapped)
+        );
+    }
+
+    #[test]
+    fn deserialize_validates() {
+        let ok: Result<RouterIpAddr, _> = serde_json::from_str("\"10.0.0.1\"");
+        assert!(ok.is_ok());
+
+        let bad: Result<RouterIpAddr, _> =
+            serde_json::from_str("\"127.0.0.1\"");
+        assert!(bad.is_err());
+    }
+
+    #[test]
+    fn serialize_is_transparent() {
+        let addr = RouterIpAddr::try_from(ip("10.0.0.1")).unwrap();
+        assert_eq!(serde_json::to_string(&addr).unwrap(), "\"10.0.0.1\"");
+    }
+}


### PR DESCRIPTION
The `mgd` static routing API accepted any nexthop, including `127.0.0.1` (as a property test found). This adds a `RouterIpAddr` newtype in `rdb` that validates an `IpAddr` as a forwarding address - rejecting the unspecified, loopback, multicast, and IPv4 broadcast addresses and IPv4-mapped IPv6 addresses - and validates nexthops in the static-route add handlers, returning HTTP 400 on a bad one. IPv6 link-local is allowed, since the lower half resolves it to an egress interface.

`RouterIpAddr` is modeled on omicron's `RouterPeerIpAddr`. Since `oxnet` is an external crate it lives in maghemite for now, but it's structured (serde + schemars) to be lifted into `oxnet` and shared, as the issue suggests.

Tested with unit tests for the newtype and the handler validation; ran the rdb and mgd suites. Didn't exercise it against a live switch.

Closes #738