### PR TITLE
unbreak omicron ci

### DIFF
--- a/.github/buildomat/jobs/linux.sh
+++ b/.github/buildomat/jobs/linux.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "linux"
 #: variety = "basic"
-#: target = "ubuntu-24.04"
+#: target = "ubuntu-22.04"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/debug/*",


### PR DESCRIPTION
Changing the linux build environment torpedoes omicron CI with

```
mgd: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by mgd)
```