### PR TITLE
NDP: bind RA sockets to interface, add RA validation

### DIFF
--- a/falcon-lab/src/eos.rs
+++ b/falcon-lab/src/eos.rs
@@ -64,29 +64,50 @@ impl EosNode {
         LinuxNode(self.0)
     }
 
-    /// Capture BGP / BFD / routing state via the Arista CLI.
+    /// Capture BGP / BFD / routing state via the Arista CLI, plus container
+    /// and host state.
     pub async fn collect_diagnostics(&self, d: &Runner, topo: &str) {
         let name = self.name(d);
-        // `Cli -c` takes a single newline-separated script.
-        const SCRIPT: &str = "enable
-            show running-config
-            show ip interface brief
-            show ip bgp summary
-            show ip bgp
-            show ipv6 bgp
-            show ip route
-            show ipv6 route
-            show bfd peers
-        ";
-        match self.shell(d, SCRIPT).await {
-            Ok(out) => crate::diagnostics::write_artifact(
+        for (suffix, cmd) in [
+            ("running-config", "show running-config"),
+            ("ip-interface-brief", "show ip interface brief"),
+            ("ip-bgp-summary", "show ip bgp summary"),
+            ("ip-bgp", "show ip bgp"),
+            ("ipv6-bgp", "show ipv6 bgp"),
+            ("ip-route", "show ip route"),
+            ("ipv6-route", "show ipv6 route"),
+            ("bfd-peers", "show bfd peers"),
+        ] {
+            let script = format!("enable\n{cmd}");
+            match self.shell(d, &script).await {
+                Ok(out) => crate::diagnostics::write_artifact(
+                    d,
+                    topo,
+                    &format!("{name}-{suffix}"),
+                    Some(cmd),
+                    &out,
+                ),
+                Err(e) => {
+                    slog::warn!(d.log, "diagnostics {name}-{suffix}: {e}")
+                }
+            }
+        }
+        // Container log plus host-side interface state, so there is something
+        // to look at even if the CLI is unresponsive.
+        for (suffix, cmd) in [
+            ("ceos-logs", "docker logs --tail 200 ceos"),
+            ("host-ip-link", "ip -d -s link show"),
+            ("host-ip-addr", "ip -d -s addr show"),
+            ("host-ip-neigh", "ip -d -s neigh show"),
+        ] {
+            crate::diagnostics::capture(
                 d,
+                self.0,
                 topo,
-                &format!("{name}-cli"),
-                None,
-                &out,
-            ),
-            Err(e) => slog::warn!(d.log, "diagnostics {name}-cli: {e}"),
+                &format!("{name}-{suffix}"),
+                cmd,
+            )
+            .await;
         }
     }
 

--- a/falcon-lab/src/frr.rs
+++ b/falcon-lab/src/frr.rs
@@ -134,7 +134,7 @@ impl FrrNode {
             .collect::<Vec<_>>()
             .join(" ");
         let output = d
-            .exec(self.0, &format!("vtysh {args}"))
+            .exec(self.0, &format!("/usr/bin/vtysh {args}"))
             .await
             .context("vtysh shell failed")?;
         Ok(output)

--- a/falcon-lab/src/illumos.rs
+++ b/falcon-lab/src/illumos.rs
@@ -144,6 +144,8 @@ impl IllumosNode {
             ("ipadm", "ipadm show-addr"),
             ("dladm", "dladm show-link"),
             ("netstat", "netstat -nr"),
+            ("ndp", "ndp -a -n"),
+            ("arp", "arp -a -n"),
         ] {
             crate::diagnostics::capture(
                 d,

--- a/falcon-lab/src/mgd.rs
+++ b/falcon-lab/src/mgd.rs
@@ -62,6 +62,49 @@ impl MgdNode {
             Err(e) => slog::warn!(d.log, "diagnostics {label}: {e}"),
         }
     }
+
+    pub async fn collect_ndp_diagnostics(
+        &self,
+        d: &Runner,
+        client: &Client,
+        topo: &str,
+    ) {
+        let name = d.get_node(self.0).name.clone();
+        let routers = match client.read_routers().await {
+            Ok(r) => r.into_inner(),
+            Err(e) => {
+                slog::warn!(d.log, "diagnostics {name}-ndp: read routers: {e}");
+                return;
+            }
+        };
+        for router in routers {
+            let asn = router.asn;
+            for (suffix, result) in [
+                (
+                    "ndp-manager",
+                    client
+                        .get_ndp_manager_state(asn)
+                        .await
+                        .map(|r| format!("{:#?}", r.into_inner())),
+                ),
+                (
+                    "ndp-interfaces",
+                    client
+                        .get_ndp_interfaces(asn)
+                        .await
+                        .map(|r| format!("{:#?}", r.into_inner())),
+                ),
+            ] {
+                let label = format!("{name}-{suffix}-asn{asn}");
+                match result {
+                    Ok(contents) => crate::diagnostics::write_artifact(
+                        d, topo, &label, None, &contents,
+                    ),
+                    Err(e) => slog::warn!(d.log, "diagnostics {label}: {e}"),
+                }
+            }
+        }
+    }
 }
 
 pub async fn wait_for_mgd(

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -96,11 +96,13 @@ where
     let ox = bt.ox;
     let cr1 = bt.cr1;
     let cr2 = bt.cr2;
+    let mgd = bt.mgd.clone();
     let topo_name = bt.topo_name.clone();
     let result = body(bt).await;
     if let Err(e) = &result {
         warn!(ad.log, "{topo_name} failed: {e:#}");
         collect_diagnostics(&ad, ox, cr1, cr2, &topo_name).await;
+        ox.collect_ndp_diagnostics(&ad, &mgd, &topo_name).await;
     }
     result
 }

--- a/ndp/src/manager.rs
+++ b/ndp/src/manager.rs
@@ -11,7 +11,7 @@ use crate::util::{
 };
 use mg_common::thread::ManagedThread;
 use mg_common::{lock, read_lock, write_lock};
-use slog::{Logger, error};
+use slog::{Logger, debug, error};
 use socket2::Socket;
 use std::mem::MaybeUninit;
 use std::net::Ipv6Addr;
@@ -340,6 +340,16 @@ impl InterfaceNdpManagerInner {
     /// is updated as well as the time of reception and the stored advertisement
     /// containing the reachable time.
     fn handle_ra(&self, ra: Icmp6RouterAdvertisement, src: Ipv6Addr) {
+        // Per RFC 4861 Section 6.1.2: a valid RA's source is always link-local
+        if !src.is_unicast_link_local() {
+            debug!(
+                self.log,
+                "ignoring RA from non-link-local source {src} on {}",
+                self.ifx.name,
+            );
+            return;
+        }
+
         let mut guard = lock!(self.neighbor_router);
         let now = Instant::now();
 

--- a/ndp/src/packet.rs
+++ b/ndp/src/packet.rs
@@ -39,8 +39,13 @@ impl Icmp6RouterAdvertisement {
     const TYPE: u8 = 134;
     const CODE: u8 = 0;
     const DEFAULT_HOPLIMIT: u8 = 255;
+    const MIN_PAYLOAD_LEN: usize = 16;
 
     pub fn from_wire(buf: &[u8]) -> Result<Self, Icmp6RaFromWireError> {
+        // Per RFC 4861 Section 6.1.2: a valid RA has an ICMP payload of >= 16b
+        if buf.len() < Self::MIN_PAYLOAD_LEN {
+            return Err(Icmp6RaFromWireError::TooShort(buf.len()));
+        }
         let s: Self = ispf::from_bytes_be(buf)?;
         if s.typ != Self::TYPE {
             return Err(Icmp6RaFromWireError::WrongType(s.typ));
@@ -85,6 +90,9 @@ impl Default for Icmp6RouterAdvertisement {
 pub enum Icmp6RaFromWireError {
     #[error("deserialization error: {0}")]
     Ispf(#[from] ispf::Error),
+
+    #[error("too short: {0} octets, expected at least 16")]
+    TooShort(usize),
 
     #[error("wrong type: expected {expected}, got {0}", expected = Icmp6RouterAdvertisement::TYPE)]
     WrongType(u8),

--- a/ndp/src/util.rs
+++ b/ndp/src/util.rs
@@ -11,6 +11,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use std::{
     ffi::c_void,
     net::{Ipv6Addr, SocketAddrV6},
+    num::NonZeroU32,
     os::fd::AsRawFd,
     thread::sleep,
     time::{Duration, Instant},
@@ -72,6 +73,12 @@ pub enum ListeningSocketError {
 
     #[error("failed to set ipv6 min hop count: {0}")]
     SetIpv6MinHopCount(std::io::Error),
+
+    #[error("failed to bind socket to interface: {0}")]
+    SetBoundIf(std::io::Error),
+
+    #[error("interface index must be non-zero")]
+    InvalidInterfaceIndex,
 }
 
 pub fn send_ra(
@@ -204,6 +211,10 @@ pub fn create_socket(index: u32) -> Result<Socket, ListeningSocketError> {
 
     s.join_multicast_v6(&ALL_ROUTERS_MCAST, index)
         .map_err(E::JoinAllRoutersMulticast)?;
+
+    let ifindex = NonZeroU32::new(index).ok_or(E::InvalidInterfaceIndex)?;
+    s.bind_device_by_index_v6(Some(ifindex))
+        .map_err(E::SetBoundIf)?;
 
     s.bind(&sa).map_err(ListeningSocketError::Bind)?;
 

--- a/ndp/src/util.rs
+++ b/ndp/src/util.rs
@@ -5,14 +5,11 @@
 // Copyright 2026 Oxide Computer Company
 
 use crate::packet::{Icmp6RouterAdvertisement, Icmp6RouterSolicitation};
-use libc::{c_int, socklen_t};
 use slog::{Logger, error};
 use socket2::{Domain, Protocol, Socket, Type};
 use std::{
-    ffi::c_void,
     net::{Ipv6Addr, SocketAddrV6},
     num::NonZeroU32,
-    os::fd::AsRawFd,
     thread::sleep,
     time::{Duration, Instant},
 };
@@ -71,6 +68,7 @@ pub enum ListeningSocketError {
     #[error("set read timeout error: {0}")]
     SetReadTimeoutError(std::io::Error),
 
+    #[cfg(any(target_os = "linux", target_os = "illumos"))]
     #[error("failed to set ipv6 min hop count: {0}")]
     SetIpv6MinHopCount(std::io::Error),
 
@@ -221,23 +219,43 @@ pub fn create_socket(index: u32) -> Result<Socket, ListeningSocketError> {
     s.set_read_timeout(Some(READ_TIMEOUT))
         .map_err(E::SetReadTimeoutError)?;
 
-    unsafe {
-        // from <netinet/in.h>
-        const IPV6_MINHOPCOUNT: c_int = 0x2f;
-        let min_hops: c_int = 255;
-        let rc = libc::setsockopt(
+    // Per RFC 4861 Section 6.1.2: a valid RA must have a hop limit of 255
+    set_min_hopcount(&s)?;
+
+    Ok(s)
+}
+
+#[cfg(any(target_os = "linux", target_os = "illumos"))]
+fn set_min_hopcount(s: &Socket) -> Result<(), ListeningSocketError> {
+    use std::os::fd::AsRawFd;
+
+    // illumos does not export IPV6_MINHOPCOUNT via libc; value from
+    // <netinet/in.h>. Linux provides it.
+    #[cfg(target_os = "illumos")]
+    const IPV6_MINHOPCOUNT: libc::c_int = 0x2f;
+    #[cfg(target_os = "linux")]
+    use libc::IPV6_MINHOPCOUNT;
+
+    let min_hops: libc::c_int = 255;
+    // SAFETY: setsockopt with a correctly-sized pointer to an integer option.
+    let rc = unsafe {
+        libc::setsockopt(
             s.as_raw_fd(),
             libc::IPPROTO_IPV6,
             IPV6_MINHOPCOUNT,
-            &min_hops as *const _ as *const c_void,
-            std::mem::size_of::<libc::c_int>() as socklen_t,
-        );
-        if rc < 0 {
-            return Err(ListeningSocketError::SetIpv6MinHopCount(
-                std::io::Error::last_os_error(),
-            ));
-        }
+            &min_hops as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(ListeningSocketError::SetIpv6MinHopCount(
+            std::io::Error::last_os_error(),
+        ));
     }
+    Ok(())
+}
 
-    Ok(s)
+#[cfg(not(any(target_os = "linux", target_os = "illumos")))]
+fn set_min_hopcount(_s: &Socket) -> Result<(), ListeningSocketError> {
+    Ok(())
 }


### PR DESCRIPTION
The primary motivation for this PR is to fix a bug where the per-interface RA listener socket was not properly scoped/bound to that interface.  This resulted in behavior where RAs received on one interface could sometimes "leak" and be delivered to the listening socket of a different interface.

This is reliably reproducible in falcon-lab without any config changes, and can be observed as easily as running `mgadm ndp status interfaces <ASN>` on a 1 second interval. When doing this, you will observe that the peer address on one interface will "flap" between the expected peer IP (matching the kernel's NDP entry and the IP assigned to the peer's interface) and the peer IP of the other interface with BGP unnumbered enabled. Using `snoop`, it can be observed that RA packets sourced from the erroneous peer IP never arrive on the victim interface.

For example, in the output below you'll see that the NDP entry on `tfportqsfp0_0` flaps between `fe80::aa40:25ff:fe00:1` (expected) and `fe80::42:acff:fe12:2` (erroneous), and that `snoop` shows RAs from `fe80::42:acff:fe12:2` only arrive on `tfportqsfp1_0`:
```
root@ox:~# while true; do mgadm ndp status interfaces; sleep 1; done
Interface      Local Address              Scope  Discovered Peer                     TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::42:acff:fe12:2%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0  Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                       TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::aa40:25ff:fe00:1%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0    Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                       TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::aa40:25ff:fe00:1%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0    Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                     TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::42:acff:fe12:2%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0  Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                     TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::42:acff:fe12:2%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0  Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                       TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::aa40:25ff:fe00:1%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0    Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                       TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::aa40:25ff:fe00:1%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0    Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                     TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::42:acff:fe12:2%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0  Run  Run  Yes
Interface      Local Address              Scope  Discovered Peer                     TX   RX   Reachable
tfportqsfp0_0  fe80::aa40:25ff:fe0b:4ebc  3      fe80::42:acff:fe12:2%tfportqsfp0_0  Run  Run  Yes
tfportqsfp1_0  fe80::aa40:25ff:fe0b:4ec0  4      fe80::42:acff:fe12:2%tfportqsfp1_0  Run  Run  Yes
^C
root@ox:~#

root@ox:~# ndp -an

Net to Media Table: IPv6
 If   Physical Address    Type      State      Destination/Mask
----- -----------------  ------- ------------ ---------------------------
tfportqsfp1_0 33:33:00:00:00:01  other   REACHABLE    ff02::1
tfportqsfp0_0 33:33:00:00:00:01  other   REACHABLE    ff02::1
tfportqsfp0_0 33:33:00:00:00:02  other   REACHABLE    ff02::2
tfportqsfp1_0 33:33:00:00:00:02  other   REACHABLE    ff02::2
tfportqsfp1_0 33:33:00:00:00:16  other   REACHABLE    ff02::16
tfportqsfp0_0 33:33:00:00:00:16  other   REACHABLE    ff02::16
tfportqsfp0_0 a8:40:25:0b:4e:bc  local   REACHABLE    fe80::aa40:25ff:fe0b:4ebc
tfportqsfp1_0 a8:40:25:0b:4e:c0  local   REACHABLE    fe80::aa40:25ff:fe0b:4ec0
tfportqsfp1_0 33:33:ff:0b:4e:c0  other   REACHABLE    ff02::1:ff0b:4ec0
tfportqsfp0_0 a8:40:25:00:00:01  dynamic REACHABLE    fe80::aa40:25ff:fe00:1
tfportqsfp0_0 33:33:ff:0b:4e:bc  other   REACHABLE    ff02::1:ff0b:4ebc
tfportqsfp1_0 02:42:ac:12:00:02  dynamic REACHABLE    fe80::42:acff:fe12:2

root@ox:~# snoop -d tfportqsfp0_0 -t a 'icmp6'
Using device tfportqsfp0_0 (promiscuous mode)
05:34:22.89111 fe80::aa40:25ff:fe0b:4ebc -> ff02::1      ICMPv6 Router advertisement
05:34:22.89125 fe80::aa40:25ff:fe0b:4ebc -> ff02::2      ICMPv6 Router solicitation
05:34:22.89180 fe80::aa40:25ff:fe00:1 -> ff02::1      ICMPv6 Router advertisement
05:34:22.89184 fe80::aa40:25ff:fe00:1 -> ff02::1      ICMPv6 Router advertisement
05:34:27.89159 fe80::aa40:25ff:fe0b:4ebc -> ff02::1      ICMPv6 Router advertisement
05:34:27.89169 fe80::aa40:25ff:fe0b:4ebc -> ff02::2      ICMPv6 Router solicitation
05:34:27.89222 fe80::aa40:25ff:fe00:1 -> ff02::1      ICMPv6 Router advertisement
05:34:27.89227 fe80::aa40:25ff:fe00:1 -> ff02::1      ICMPv6 Router advertisement
05:34:32.89180 fe80::aa40:25ff:fe0b:4ebc -> ff02::1      ICMPv6 Router advertisement
05:34:32.89188 fe80::aa40:25ff:fe0b:4ebc -> ff02::2      ICMPv6 Router solicitation
05:34:32.89238 fe80::aa40:25ff:fe00:1 -> ff02::1      ICMPv6 Router advertisement
05:34:32.89240 fe80::aa40:25ff:fe00:1 -> ff02::1      ICMPv6 Router advertisement
^Croot@ox:~#

root@ox:~# snoop -d tfportqsfp1_0 -t a 'icmp6'
Using device tfportqsfp1_0 (promiscuous mode)
05:39:57.95035 fe80::aa40:25ff:fe51:1482 -> ff02::1      ICMPv6 Router advertisement
05:39:57.95048 fe80::aa40:25ff:fe51:1482 -> ff02::2      ICMPv6 Router solicitation
05:39:58.32815 fe80::42:acff:fe12:2 -> fe80::aa40:25ff:fe51:1482 ICMPv6 Router advertisement
05:39:58.32818 fe80::42:acff:fe12:2 -> fe80::aa40:25ff:fe51:1482 ICMPv6 Router advertisement
05:40:02.95061 fe80::aa40:25ff:fe51:1482 -> ff02::1      ICMPv6 Router advertisement
05:40:02.95071 fe80::aa40:25ff:fe51:1482 -> ff02::2      ICMPv6 Router solicitation
05:40:03.27626 fe80::42:acff:fe12:2 -> fe80::aa40:25ff:fe51:1482 ICMPv6 Router advertisement
05:40:03.27630 fe80::42:acff:fe12:2 -> fe80::aa40:25ff:fe51:1482 ICMPv6 Router advertisement
05:40:07.95082 fe80::aa40:25ff:fe51:1482 -> ff02::1      ICMPv6 Router advertisement
05:40:07.95092 fe80::aa40:25ff:fe51:1482 -> ff02::2      ICMPv6 Router solicitation
05:40:08.20339 fe80::42:acff:fe12:2 -> fe80::aa40:25ff:fe51:1482 ICMPv6 Router advertisement
05:40:08.20343 fe80::42:acff:fe12:2 -> fe80::aa40:25ff:fe51:1482 ICMPv6 Router advertisement
^Croot@ox:~#
```

This is resolved by binding the tx/rx sockets to the ifindex it's associated with. There is a socket2 wrapper for both Illumos and Linux, which we now make use of.

Above and beyond this small bug fix, this PR adds some validation of received RAs (aligning with RFC 4861 Section 6.1.2):
1. confirm source IP is a unicast link-local address
2. confirm ICMP payload length >= 16 bytes
3. set `IPV6_MINHOPCOUNT` on Linux in addition to Illumos

This PR also removes the BGP ASN from the NDP queries. There is only a single global NdpManager per daemon, not one per BGP router. Therefore there is no inherent association between an NdpManager and a router, and there's no reason to force the client to supply one.

Finally, this PR moves the NDP API handlers out of `bgp_admin.rs` into `ndp_admin.rs`.

For reviewers: this is broken down commit by commit with different logical changes. I'd recommend going one commit at a time.