### PR TITLE
clean up accumulated detritus

### DIFF
--- a/mg-api-types/versions/src/initial/bgp/config.rs
+++ b/mg-api-types/versions/src/initial/bgp/config.rs
@@ -27,7 +27,6 @@ pub struct NeighborSelector {
 
 /// V1 API neighbor reset operations (backwards compatibility)
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[schemars(rename = "NeighborResetOp")]
 pub enum NeighborResetOp {
     Hard,
     SoftInbound,
@@ -54,7 +53,6 @@ pub struct MessageHistoryResponse {
 
 /// Legacy neighbor configuration (v1/v2 API compatibility)
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "Neighbor")]
 pub struct Neighbor {
     pub asn: u32,
     pub name: String,
@@ -66,7 +64,6 @@ pub struct Neighbor {
 
 /// Apply changes to an ASN (v1/v2 API - legacy format).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[schemars(rename = "ApplyRequest")]
 pub struct ApplyRequest {
     /// ASN to apply changes to.
     pub asn: u32,
@@ -95,7 +92,6 @@ pub struct ApplyRequest {
 
 /// BGP peer configuration for v1/v2 API (legacy format with combined import/export).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[schemars(rename = "BgpPeerConfig")]
 pub struct BgpPeerConfig {
     pub host: SocketAddr,
     pub name: String,
@@ -104,7 +100,6 @@ pub struct BgpPeerConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "BgpPeerParameters")]
 pub struct BgpPeerParameters {
     pub hold_time: u64,
     pub idle_hold_time: u64,
@@ -158,7 +153,6 @@ pub struct ShaperSource {
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, JsonSchema,
 )]
-#[schemars(rename = "FsmStateKind")]
 pub enum FsmStateKind {
     /// Initial state. Refuse all incomming BGP connections. No resources
     /// allocated to peer.
@@ -184,21 +178,18 @@ pub enum FsmStateKind {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[schemars(rename = "DynamicTimerInfo")]
 pub struct DynamicTimerInfo {
     pub configured: Duration,
     pub negotiated: Duration,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[schemars(rename = "PeerTimers")]
 pub struct PeerTimers {
     pub hold: DynamicTimerInfo,
     pub keepalive: DynamicTimerInfo,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[schemars(rename = "PeerInfo")]
 pub struct PeerInfo {
     pub state: FsmStateKind,
     pub asn: Option<u32>,

--- a/mg-api-types/versions/src/initial/bgp/messages.rs
+++ b/mg-api-types/versions/src/initial/bgp/messages.rs
@@ -229,10 +229,6 @@ pub enum Safi {
 
 /// An enumeration describing available path attribute type codes (initial
 /// API version, prior to MP-BGP).
-///
-/// The schema-published name is `PathAttributeTypeCode` (preserved via
-/// `#[schemars(rename = ...)]`); the in-source name disambiguates from the
-/// 12-variant MP-BGP form at [`crate::v4::bgp::messages::PathAttributeTypeCode`].
 #[derive(
     Clone,
     Copy,

--- a/mg-api-types/versions/src/initial/bgp/session.rs
+++ b/mg-api-types/versions/src/initial/bgp/session.rs
@@ -17,7 +17,6 @@ use super::messages::Message;
 
 // V1 API compatibility type for message history entry (IPv4-only with v1 Message)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename = "MessageHistoryEntry")]
 pub(crate) struct MessageHistoryEntry {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub message: Message,
@@ -25,7 +24,6 @@ pub(crate) struct MessageHistoryEntry {
 
 // V1 API compatibility type for message history collection
 #[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename = "MessageHistory")]
 pub struct MessageHistory {
     pub(crate) received: VecDeque<MessageHistoryEntry>,
     pub(crate) sent: VecDeque<MessageHistoryEntry>,

--- a/mg-api-types/versions/src/ipv6_basic/bgp/history.rs
+++ b/mg-api-types/versions/src/ipv6_basic/bgp/history.rs
@@ -70,7 +70,6 @@ pub struct FsmHistoryResponse {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
-#[schemars(rename = "PeerInfo")]
 pub struct PeerInfo {
     pub state: FsmStateKind,
     pub asn: Option<u32>,

--- a/mg-api-types/versions/src/mp_bgp/bgp/config.rs
+++ b/mg-api-types/versions/src/mp_bgp/bgp/config.rs
@@ -123,7 +123,6 @@ pub struct Ipv6UnicastConfig {
 
 /// BGP peer parameters for v4-v6 API (lacks src_addr/src_port).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "BgpPeerParameters")]
 pub struct BgpPeerParameters {
     pub hold_time: u64,
     pub idle_hold_time: u64,
@@ -149,7 +148,6 @@ pub struct BgpPeerParameters {
 
 /// BGP peer config for v4-v6 API (lacks src_addr/src_port).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "BgpPeerConfig")]
 pub struct BgpPeerConfig {
     pub host: SocketAddr,
     pub name: String,
@@ -159,7 +157,6 @@ pub struct BgpPeerConfig {
 
 /// Neighbor configuration for v4-v6 API (lacks src_addr/src_port).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "Neighbor")]
 pub struct Neighbor {
     pub asn: u32,
     pub name: String,
@@ -171,7 +168,6 @@ pub struct Neighbor {
 
 /// Unnumbered BGP peer config for v4-v6 API (lacks src_addr/src_port).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "UnnumberedBgpPeerConfig")]
 pub struct UnnumberedBgpPeerConfig {
     pub interface: String,
     pub name: String,
@@ -182,7 +178,6 @@ pub struct UnnumberedBgpPeerConfig {
 
 /// Apply request for v4-v6 API (lacks src_addr/src_port in peer configs).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[schemars(rename = "ApplyRequest")]
 pub struct ApplyRequest {
     pub asn: u32,
     pub originate: Vec<Prefix>,

--- a/mg-api-types/versions/src/unnumbered/bgp/config.rs
+++ b/mg-api-types/versions/src/unnumbered/bgp/config.rs
@@ -38,7 +38,6 @@ pub struct UnnumberedNeighborResetRequest {
 
 /// Unnumbered neighbor configuration for v4-v6 API (lacks src_addr/src_port).
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq)]
-#[schemars(rename = "UnnumberedNeighbor")]
 pub struct UnnumberedNeighbor {
     pub asn: u32,
     pub name: String,

--- a/mg-api/src/lib.rs
+++ b/mg-api/src/lib.rs
@@ -247,19 +247,6 @@ pub trait MgAdminApi {
     // numbered and unnumbered neighbors but lacks src_addr/src_port.
 
     #[endpoint {
-        method = PUT,
-        path = "/bgp/config/neighbor",
-        operation_id = "create_neighbor",
-        versions = VERSION_UNNUMBERED..VERSION_BGP_SRC_ADDR,
-    }]
-    async fn create_neighbor_v5(
-        rqctx: RequestContext<Self::Context>,
-        request: TypedBody<v4::bgp::config::Neighbor>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        Self::create_neighbor_v8(rqctx, request.map(Into::into)).await
-    }
-
-    #[endpoint {
         method = GET,
         path = "/bgp/config/neighbor/{asn}/{peer}",
         operation_id = "read_neighbor",
@@ -289,34 +276,20 @@ pub trait MgAdminApi {
             .map(|r| r.map(|v| v.into_iter().map(Into::into).collect()))
     }
 
-    #[endpoint {
-        method = POST,
-        path = "/bgp/config/neighbor",
-        operation_id = "update_neighbor",
-        versions = VERSION_UNNUMBERED..VERSION_BGP_SRC_ADDR,
-    }]
-    async fn update_neighbor_v5(
-        rqctx: RequestContext<Self::Context>,
-        request: TypedBody<v4::bgp::config::Neighbor>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        Self::update_neighbor_v8(rqctx, request.map(Into::into)).await
-    }
-
     // V4 API - new Neighbor type with explicit per-AF configuration (numbered
-    // peers only). create and update take v4::bgp::config::Neighbor (same schema as V5);
-    // read and delete use a different selector type.
+    // peers only).
 
     #[endpoint {
         method = PUT,
         path = "/bgp/config/neighbor",
         operation_id = "create_neighbor",
-        versions = VERSION_MP_BGP..VERSION_UNNUMBERED,
+        versions = VERSION_MP_BGP..VERSION_BGP_SRC_ADDR,
     }]
     async fn create_neighbor_v4(
         rqctx: RequestContext<Self::Context>,
         request: TypedBody<v4::bgp::config::Neighbor>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        Self::create_neighbor_v5(rqctx, request).await
+        Self::create_neighbor_v8(rqctx, request.map(Into::into)).await
     }
 
     #[endpoint {
@@ -358,13 +331,13 @@ pub trait MgAdminApi {
         method = POST,
         path = "/bgp/config/neighbor",
         operation_id = "update_neighbor",
-        versions = VERSION_MP_BGP..VERSION_UNNUMBERED,
+        versions = VERSION_MP_BGP..VERSION_BGP_SRC_ADDR,
     }]
     async fn update_neighbor_v4(
         rqctx: RequestContext<Self::Context>,
         request: TypedBody<v4::bgp::config::Neighbor>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        Self::update_neighbor_v5(rqctx, request).await
+        Self::update_neighbor_v8(rqctx, request.map(Into::into)).await
     }
 
     // V1/V2 API - legacy Neighbor type with combined import/export policies.
@@ -525,7 +498,7 @@ pub trait MgAdminApi {
     #[endpoint {
         method = DELETE,
         path = "/bgp/config/unnumbered-neighbor",
-        versions = VERSION_PREFIX_TO_OXNET..,
+        versions = VERSION_UNNUMBERED..,
     }]
     async fn delete_unnumbered_neighbor(
         rqctx: RequestContext<Self::Context>,
@@ -592,19 +565,6 @@ pub trait MgAdminApi {
         request: TypedBody<v8::bgp::config::UnnumberedNeighbor>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         Self::update_unnumbered_neighbor(rqctx, request.map(Into::into)).await
-    }
-
-    #[endpoint {
-        method = DELETE,
-        path = "/bgp/config/unnumbered-neighbor",
-        operation_id = "delete_unnumbered_neighbor",
-        versions = VERSION_BGP_SRC_ADDR..VERSION_PREFIX_TO_OXNET,
-    }]
-    async fn delete_unnumbered_neighbor_v8(
-        rqctx: RequestContext<Self::Context>,
-        request: Query<latest::bgp::config::UnnumberedNeighborSelector>,
-    ) -> Result<HttpResponseDeleted, HttpError> {
-        Self::delete_unnumbered_neighbor(rqctx, request).await
     }
 
     // V5 API (VERSION_UNNUMBERED..VERSION_BGP_SRC_ADDR) - unnumbered neighbors
@@ -674,19 +634,6 @@ pub trait MgAdminApi {
     }
 
     #[endpoint {
-        method = DELETE,
-        path = "/bgp/config/unnumbered-neighbor",
-        operation_id = "delete_unnumbered_neighbor",
-        versions = VERSION_UNNUMBERED..VERSION_BGP_SRC_ADDR,
-    }]
-    async fn delete_unnumbered_neighbor_v5(
-        rqctx: RequestContext<Self::Context>,
-        request: Query<v5::bgp::config::UnnumberedNeighborSelector>,
-    ) -> Result<HttpResponseDeleted, HttpError> {
-        Self::delete_unnumbered_neighbor_v8(rqctx, request).await
-    }
-
-    #[endpoint {
         method = POST,
         path = "/bgp/clear/unnumbered-neighbor",
         versions = VERSION_UNNUMBERED..,
@@ -731,7 +678,7 @@ pub trait MgAdminApi {
     #[endpoint {
         method = DELETE,
         path = "/bgp/config/origin4",
-        versions = VERSION_PREFIX_TO_OXNET..,
+        versions = ..,
     }]
     async fn delete_origin4(
         rqctx: RequestContext<Self::Context>,
@@ -780,19 +727,6 @@ pub trait MgAdminApi {
     }
 
     #[endpoint {
-        method = DELETE,
-        path = "/bgp/config/origin4",
-        operation_id = "delete_origin4",
-        versions = ..VERSION_PREFIX_TO_OXNET,
-    }]
-    async fn delete_origin4_v1(
-        rqctx: RequestContext<Self::Context>,
-        request: Query<latest::bgp::config::AsnSelector>,
-    ) -> Result<HttpResponseDeleted, HttpError> {
-        Self::delete_origin4(rqctx, request).await
-    }
-
-    #[endpoint {
         method = PUT,
         path = "/bgp/config/origin6",
         versions = VERSION_PREFIX_TO_OXNET..,
@@ -825,7 +759,7 @@ pub trait MgAdminApi {
     #[endpoint {
         method = DELETE,
         path = "/bgp/config/origin6",
-        versions = VERSION_PREFIX_TO_OXNET..,
+        versions = VERSION_IPV6_BASIC..,
     }]
     async fn delete_origin6(
         rqctx: RequestContext<Self::Context>,
@@ -871,19 +805,6 @@ pub trait MgAdminApi {
         request: TypedBody<v2::bgp::history::Origin6>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         Self::update_origin6(rqctx, request.map(Into::into)).await
-    }
-
-    #[endpoint {
-        method = DELETE,
-        path = "/bgp/config/origin6",
-        operation_id = "delete_origin6",
-        versions = VERSION_IPV6_BASIC..VERSION_PREFIX_TO_OXNET,
-    }]
-    async fn delete_origin6_v2(
-        rqctx: RequestContext<Self::Context>,
-        request: Query<latest::bgp::config::AsnSelector>,
-    ) -> Result<HttpResponseDeleted, HttpError> {
-        Self::delete_origin6(rqctx, request).await
     }
 
     #[endpoint {


### PR DESCRIPTION
This fixes two misconceptions I stumbled across in #771:
- there are a bunch of no-op renames with `schemars`
- there are bunch of interstitial versioned endpoints that didn't need to be created