### PR TITLE
justfile: pass all args to cargo build

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,8 +8,8 @@ build_excludes := if os() == "illumos" {
 test_excludes := build_excludes + " --exclude mg-tests"
 
 # Build the workspace.
-build:
-    cargo build --workspace {{ build_excludes }}
+build *ARGS:
+    cargo build --workspace {{ build_excludes }} {{ ARGS }}
 
 # Run cargo test for the workspace.
 test:


### PR DESCRIPTION
Pass all arguments supplied to `just build` to the underlying command `cargo build` so things like `--release` can be passed through just.