### PR TITLE
Start unifying un/numbered bgp peer internals

### DIFF
--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -63,6 +63,9 @@ server=$(ipadm show-addr "${EXT_INTERFACE}"/dhcp -po ADDR | sed 's#/.*##g')
 pfexec ./dhcp-server "${first}" "${last}" "${gw}" "${server}" &> /work/dhcp-server.log &
 
 RUST_LOG=debug pfexec ./falcon-lab run \
+	mgd-unnumbered
+
+RUST_LOG=debug pfexec ./falcon-lab run \
 	trio-unnumbered
 
 RUST_LOG=debug pfexec ./falcon-lab run \

--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -54,6 +54,14 @@ mkdir -p cargo-bay
 mv mgd cargo-bay/
 mv ddmd cargo-bay/
 
+# Juniper/cRPD images require a runtime license. Fetch it on the CI runner,
+# which has catacomb access, and pass it to the guest by file via cargo-bay.
+# The license contents must never be printed or committed.
+curl -sSfL --retry 10 --retry-all-errors \
+	-o cargo-bay/falcon-juniper-license.key \
+	http://catacomb.eng.oxide.computer:12346/falcon/jl
+chmod 0600 cargo-bay/falcon-juniper-license.key
+
 export EXT_INTERFACE=${EXT_INTERFACE:-igb0}
 
 first=$(bmat address ls -f extra -Ho first)
@@ -66,7 +74,7 @@ RUST_LOG=debug pfexec ./falcon-lab run \
 	mgd-unnumbered
 
 RUST_LOG=debug pfexec ./falcon-lab run \
-	trio-unnumbered
+	quartet-unnumbered
 
 RUST_LOG=debug pfexec ./falcon-lab run \
-	trio-bfd-static-routing
+	quartet-bfd-static-routing

--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -70,11 +70,15 @@ gw=$(bmat address ls -f extra -Ho gateway)
 server=$(ipadm show-addr "${EXT_INTERFACE}"/dhcp -po ADDR | sed 's#/.*##g')
 pfexec ./dhcp-server "${first}" "${last}" "${gw}" "${server}" &> /work/dhcp-server.log &
 
-RUST_LOG=debug pfexec ./falcon-lab run \
-	mgd-unnumbered
+run_test() {
+	local test=$1
+	local status=0
 
-RUST_LOG=debug pfexec ./falcon-lab run \
-	quartet-unnumbered
+	RUST_LOG=debug pfexec ./falcon-lab run "${test}" || status=$?
+	pfexec ./falcon-lab cleanup "${test}" || true
+	return "${status}"
+}
 
-RUST_LOG=debug pfexec ./falcon-lab run \
-	quartet-bfd-static-routing
+run_test mgd-unnumbered
+run_test quartet-unnumbered
+run_test quartet-bfd-static-routing

--- a/bgp/src/config.rs
+++ b/bgp/src/config.rs
@@ -2,20 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::BGP_PORT;
 use mg_api_types::bgp::config::{
     BgpPeerParameters, Neighbor, UnnumberedNeighbor,
 };
+use mg_api_types::bgp::peer::PeerId;
 use mg_api_types_versions::v1;
 use rdb::Asn;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::net::{SocketAddr, SocketAddrV6};
+use std::num::NonZeroU16;
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct PeerConfig {
     pub name: String,
     pub group: String,
-    pub host: SocketAddr,
+    pub id: PeerId,
+    pub port: NonZeroU16,
     pub hold_time: u64,
     pub idle_hold_time: u64,
     pub delay_open: u64,
@@ -77,7 +80,8 @@ impl From<Neighbor> for PeerConfig {
         Self {
             name,
             group,
-            host: *host,
+            id: PeerId::Ip(host.ip()),
+            port: NonZeroU16::new(host.port()).unwrap_or(BGP_PORT),
             hold_time,
             idle_hold_time,
             delay_open,
@@ -119,7 +123,8 @@ impl From<v1::bgp::config::Neighbor> for PeerConfig {
         Self {
             name,
             group,
-            host,
+            id: PeerId::Ip(host.ip()),
+            port: NonZeroU16::new(host.port()).unwrap_or(BGP_PORT),
             hold_time,
             idle_hold_time,
             delay_open,
@@ -131,17 +136,15 @@ impl From<v1::bgp::config::Neighbor> for PeerConfig {
 }
 
 impl PeerConfig {
-    /// Construct a `PeerConfig` from an `UnnumberedNeighbor` (uses the supplied
-    /// IPv6 link-local socket address as the connection target).
-    pub fn from_unnumbered_neighbor(
-        n: &UnnumberedNeighbor,
-        addr: SocketAddrV6,
-    ) -> Self {
+    /// Construct a `PeerConfig` from an `UnnumberedNeighbor`. The peer is
+    /// identified by its interface; the connection target is resolved via NDP
+    /// at connect time, and the port is always the well-known BGP port.
+    pub fn from_unnumbered_neighbor(n: &UnnumberedNeighbor) -> Self {
         let UnnumberedNeighbor {
             asn: _,
             name,
             group,
-            interface: _,
+            interface,
             act_as_a_default_ipv6_router: _,
             parameters,
         } = n.clone();
@@ -171,8 +174,9 @@ impl PeerConfig {
         } = parameters;
         Self {
             name,
-            host: addr.into(),
             group,
+            id: PeerId::Interface(interface),
+            port: BGP_PORT,
             hold_time,
             idle_hold_time,
             delay_open,

--- a/bgp/src/connection_channel.rs
+++ b/bgp/src/connection_channel.rs
@@ -256,7 +256,7 @@ impl BgpListener<BgpConnectionChannel> for BgpListenerChannel {
         let runner = lock!(sessions)
             .get(&key)
             .cloned()
-            .ok_or(Error::UnknownPeer(peer.ip()))?;
+            .ok_or_else(|| Error::UnknownPeer(key.clone()))?;
 
         let config = lock!(runner.session);
         Ok(BgpConnectionChannel::with_conn(

--- a/bgp/src/connection_tcp.rs
+++ b/bgp/src/connection_tcp.rs
@@ -1382,7 +1382,7 @@ fn get_md5_source_addrs(peer_ip: IpAddr) -> Result<Vec<SocketAddr>, Error> {
 
     Ok(sources
         .iter()
-        .map(|x| SocketAddr::new(*x, crate::BGP_PORT))
+        .map(|x| SocketAddr::new(*x, crate::BGP_PORT.get()))
         .collect())
 }
 
@@ -1520,7 +1520,7 @@ fn setup_outbound_md5(
 
     let local: Vec<SocketAddr> = sources
         .iter()
-        .map(|x| SocketAddr::new(*x, crate::BGP_PORT))
+        .map(|x| SocketAddr::new(*x, crate::BGP_PORT.get()))
         .collect();
 
     init_md5_associations(fd, key, local.clone(), peer)?;

--- a/bgp/src/connection_tcp.rs
+++ b/bgp/src/connection_tcp.rs
@@ -172,7 +172,7 @@ impl BgpListener<BgpConnectionTcp> for BgpListenerTcp {
                     let runner = lock!(sessions)
                         .get(&key)
                         .cloned()
-                        .ok_or(Error::UnknownPeer(ip))?;
+                        .ok_or_else(|| Error::UnknownPeer(key.clone()))?;
 
                     let config = lock!(runner.session);
                     return BgpConnectionTcp::with_conn(

--- a/bgp/src/connection_tcp.rs
+++ b/bgp/src/connection_tcp.rs
@@ -30,6 +30,7 @@ use std::{
     io::Read,
     io::Write,
     net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs},
+    num::NonZeroU32,
     sync::atomic::AtomicBool,
     sync::{Arc, Mutex, atomic::Ordering, mpsc::Sender},
     thread::{JoinHandle, sleep},
@@ -315,6 +316,22 @@ impl BgpConnector<BgpConnectionTcp> for BgpConnectorTcp {
                     "peer" => format!("{peer}"),
                     "timeout" => timeout.as_millis()
                 );
+
+                // Bind the socket to the destination's interface for scoped
+                // (link-local / unnumbered) peers.
+                if let SocketAddr::V6(v6) = peer
+                    && let Some(idx) = NonZeroU32::new(v6.scope_id())
+                    && let Err(e) = s.bind_device_by_index_v6(Some(idx))
+                {
+                    connection_log_lite!(log,
+                        warn,
+                        "failed to bind device index {idx} for {peer}: {e}";
+                        "direction" => ConnectionDirection::Outbound,
+                        "peer" => format!("{peer}"),
+                        "error" => format!("{e}")
+                    );
+                    return;
+                }
 
                 // Bind to source address/port if specified
                 if let Some(src) = config.bind_addr {

--- a/bgp/src/error.rs
+++ b/bgp/src/error.rs
@@ -7,6 +7,7 @@ use std::{
     net::{IpAddr, Ipv4Addr},
 };
 
+use mg_api_types::bgp::peer::PeerId;
 use num_enum::TryFromPrimitiveError;
 
 #[derive(thiserror::Error, Debug)]
@@ -122,7 +123,7 @@ pub enum Error {
     NotConnected,
 
     #[error("Connection attempt from unknown peer: {0}")]
-    UnknownPeer(IpAddr),
+    UnknownPeer(PeerId),
 
     #[error("Session for peer already exists")]
     PeerExists,

--- a/bgp/src/lib.rs
+++ b/bgp/src/lib.rs
@@ -16,6 +16,8 @@ pub mod router;
 pub mod session;
 pub mod unnumbered;
 
+use std::num::NonZeroU16;
+
 mod rhai_integration;
 
 #[cfg(test)]
@@ -34,7 +36,7 @@ pub mod connection_channel;
 #[cfg(test)]
 pub mod unnumbered_mock;
 
-pub const BGP_PORT: u16 = 179;
+pub const BGP_PORT: NonZeroU16 = NonZeroU16::new(179).unwrap();
 pub const BGP_VERSION: u8 = 4;
 pub const COMPONENT_BGP: &str = "bgp";
 pub const MOD_ROUTER: &str = "router";

--- a/bgp/src/router.rs
+++ b/bgp/src/router.rs
@@ -305,6 +305,7 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn ensure_session(
         self: &Arc<Self>,
         peer: PeerConfig,
@@ -312,53 +313,28 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         event_tx: Sender<FsmEvent<Cnx>>,
         event_rx: Receiver<FsmEvent<Cnx>>,
         info: SessionInfo,
+        unnumbered_manager: Option<Arc<dyn UnnumberedManager>>,
     ) -> Result<EnsureSessionResult<Cnx>, Error> {
         let sessions = lock!(self.sessions);
-        let key = PeerId::Ip(peer.host.ip());
-        if sessions.contains_key(&key) {
+        if sessions.contains_key(&peer.id) {
             drop(sessions);
             Ok(EnsureSessionResult::Updated(
                 self.update_session(peer, info)?,
             ))
         } else {
             Ok(EnsureSessionResult::New(self.new_session_locked(
-                sessions, key, peer, bind_addr, event_tx, event_rx, info, None,
-            )?))
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn ensure_unnumbered_session(
-        self: &Arc<Self>,
-        interface: String,
-        peer: PeerConfig,
-        bind_addr: Option<SocketAddr>,
-        event_tx: Sender<FsmEvent<Cnx>>,
-        event_rx: Receiver<FsmEvent<Cnx>>,
-        info: SessionInfo,
-        unnumbered_manager: Arc<dyn UnnumberedManager>,
-    ) -> Result<EnsureSessionResult<Cnx>, Error> {
-        let sessions = lock!(self.sessions);
-        let key = PeerId::Interface(interface.clone());
-        if sessions.contains_key(&key) {
-            drop(sessions);
-            Ok(EnsureSessionResult::Updated(
-                self.update_unnumbered_session(&interface, peer, info)?,
-            ))
-        } else {
-            Ok(EnsureSessionResult::New(self.new_session_locked(
                 sessions,
-                key,
                 peer,
                 bind_addr,
                 event_tx,
                 event_rx,
                 info,
-                Some(unnumbered_manager),
+                unnumbered_manager,
             )?))
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_session(
         self: &Arc<Self>,
         peer: PeerConfig,
@@ -366,43 +342,20 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         event_tx: Sender<FsmEvent<Cnx>>,
         event_rx: Receiver<FsmEvent<Cnx>>,
         info: SessionInfo,
+        unnumbered_manager: Option<Arc<dyn UnnumberedManager>>,
     ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
         let sessions = lock!(self.sessions);
-        let key = PeerId::Ip(peer.host.ip());
-        if sessions.contains_key(&key) {
-            Err(Error::PeerExists)
-        } else {
-            self.new_session_locked(
-                sessions, key, peer, bind_addr, event_tx, event_rx, info, None,
-            )
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_unnumbered_session(
-        self: &Arc<Self>,
-        interface: String,
-        peer: PeerConfig,
-        bind_addr: Option<SocketAddr>,
-        event_tx: Sender<FsmEvent<Cnx>>,
-        event_rx: Receiver<FsmEvent<Cnx>>,
-        info: SessionInfo,
-        unnumbered_manager: Arc<dyn UnnumberedManager>,
-    ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
-        let sessions = lock!(self.sessions);
-        let key = PeerId::Interface(interface);
-        if sessions.contains_key(&key) {
+        if sessions.contains_key(&peer.id) {
             Err(Error::PeerExists)
         } else {
             self.new_session_locked(
                 sessions,
-                key,
                 peer,
                 bind_addr,
                 event_tx,
                 event_rx,
                 info,
-                Some(unnumbered_manager),
+                unnumbered_manager,
             )
         }
     }
@@ -411,7 +364,6 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
     fn new_session_locked(
         self: &Arc<Self>,
         mut sessions: MutexGuard<SessionMap<Cnx>>,
-        peer_id: PeerId,
         peer: PeerConfig,
         bind_addr: Option<SocketAddr>,
         event_tx: Sender<FsmEvent<Cnx>>,
@@ -434,8 +386,8 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         let neighbor = NeighborInfo {
             name: Arc::new(Mutex::new(peer.name.clone())),
             peer_group: peer.group.clone(),
-            peer: peer_id,
-            port: peer.host.port(),
+            peer: peer.id.clone(),
+            port: peer.port,
         };
 
         let runner = Arc::new(SessionRunner::new(
@@ -460,33 +412,9 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         peer: PeerConfig,
         info: SessionInfo,
     ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
-        // Use PeerId::Ip for numbered sessions
-        let key = PeerId::Ip(peer.host.ip());
+        let key = peer.id.clone();
         let session = match lock!(self.sessions).get(&key) {
-            None => return Err(Error::UnknownPeer(peer.host.ip())),
-            Some(s) => s.clone(),
-        };
-
-        session.update_session_parameters(peer, info)?;
-
-        Ok(session)
-    }
-
-    pub fn update_unnumbered_session(
-        self: &Arc<Self>,
-        interface: &str,
-        peer: PeerConfig,
-        info: SessionInfo,
-    ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
-        // Use PeerId::Interface for unnumbered sessions
-        let key = PeerId::Interface(interface.to_string());
-        let session = match lock!(self.sessions).get(&key) {
-            None => {
-                return Err(Error::InternalCommunication(format!(
-                    "unnumbered session not found for interface: {}",
-                    interface
-                )));
-            }
+            None => return Err(Error::UnknownPeer(key)),
             Some(s) => s.clone(),
         };
 

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -1781,7 +1781,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         }
     }
 
-    /// Resolve the outbound connection target for this attempt.
+    /// Resolve the target for an outbound connection attempt.
     ///
     /// For numbered peers this is the configured address. For unnumbered peers
     /// it queries NDP for the neighbor on the peer's interface.

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -49,6 +49,7 @@ use std::{
     collections::{BTreeSet, VecDeque},
     fmt::{self, Display, Formatter},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    num::NonZeroU16,
     sync::{
         Arc, Mutex, RwLock,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -1018,7 +1019,7 @@ pub struct NeighborInfo {
     pub name: Arc<Mutex<String>>,
     pub peer_group: String,
     pub peer: PeerId,
-    pub port: u16,
+    pub port: NonZeroU16,
 }
 
 pub const MAX_FSM_HISTORY_ALL: usize = 1024;
@@ -1746,7 +1747,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                 let mgr = self.unnumbered_manager.as_ref()?;
                 match mgr.get_neighbor_by_interface(iface) {
                     Ok(Some(neighbor)) => {
-                        Some(neighbor.to_socket_addr(self.neighbor.port))
+                        Some(neighbor.to_socket_addr(self.neighbor.port.get()))
                     }
                     Ok(None) => None, // No neighbor discovered yet - expected
                     Err(e) => {
@@ -1763,7 +1764,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             }
             PeerId::Ip(ip) => {
                 // Numbered: construct from NeighborInfo
-                Some(SocketAddr::new(*ip, self.neighbor.port))
+                Some(SocketAddr::new(*ip, self.neighbor.port.get()))
             }
         }
     }
@@ -1791,7 +1792,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                 }
                 match mgr.get_neighbor_by_interface(iface) {
                     Ok(Some(neighbor)) => {
-                        Some(neighbor.to_socket_addr(self.neighbor.port))
+                        Some(neighbor.to_socket_addr(self.neighbor.port.get()))
                     }
                     Ok(None) => {
                         session_log_lite!(
@@ -1814,7 +1815,9 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                     }
                 }
             }
-            PeerId::Ip(ip) => Some(SocketAddr::new(*ip, self.neighbor.port)),
+            PeerId::Ip(ip) => {
+                Some(SocketAddr::new(*ip, self.neighbor.port.get()))
+            }
         }
     }
 
@@ -8836,12 +8839,9 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         *lock!(self.neighbor.name) = cfg.name;
         let mut reset_needed = false;
 
-        // Note: We don't validate that cfg.host matches self.neighbor.peer here.
+        // We don't validate that cfg.peer matches self.neighbor.peer here.
         // Session identity is enforced by the lookup mechanism - you can only
-        // update a session you found via its PeerId (IP for numbered, interface
-        // for unnumbered). The cfg.host field is a placeholder for unnumbered
-        // sessions anyway.
-        // XXX: consider re-adding this when PeerConfig uses PeerId
+        // update a session you found via its PeerId.
 
         if cfg.keepalive >= cfg.hold_time {
             return Err(Error::KeepaliveLargerThanHoldTime);
@@ -9217,7 +9217,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
                     local_ip,
                     remote_ip,
                     local_tcp_port: 0u16,
-                    remote_tcp_port: self.neighbor.port,
+                    remote_tcp_port: self.neighbor.port.get(),
                     received_capabilities: vec![],
                     timers,
                     counters,

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -23,7 +23,7 @@ use crate::{
     policy::{CheckerResult, ShaperResult, shape_outgoing_update},
     recv_event_loop, recv_event_return,
     router::Router,
-    unnumbered::UnnumberedManager,
+    unnumbered::{UnnumberedError, UnnumberedManager},
 };
 use mg_api_types::bgp::config::{
     BgpPeerParameters, DynamicTimerInfo, Ipv4UnicastConfig, Ipv6UnicastConfig,
@@ -272,6 +272,18 @@ fn derive_nexthop_interface(
         }
         _ => None,
     }
+}
+
+/// Why an outbound connection target could not be resolved for an attempt.
+/// These are all retryable, per-attempt conditions.
+#[derive(Debug, thiserror::Error)]
+enum ResolveTargetError {
+    #[error("no unnumbered manager configured")]
+    NoUnnumberedManager,
+    #[error("no NDP neighbor discovered yet")]
+    NoNeighbor,
+    #[error(transparent)]
+    Unnumbered(#[from] UnnumberedError),
 }
 
 pub fn v4_over_v6_nexthop(
@@ -1769,54 +1781,26 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
         }
     }
 
-    /// Resolve peer address for outbound connection attempts.
+    /// Resolve the outbound connection target for this attempt.
     ///
-    /// For numbered peers, returns the configured address.
-    /// For unnumbered peers, verifies interface is active and queries NDP neighbor.
-    /// Returns None if:
-    /// - Unnumbered peer has no UnnumberedManager configured
-    /// - Interface is not active on the system
-    /// - No NDP neighbor has been discovered
-    fn try_resolve_connect_addr(&self) -> Option<SocketAddr> {
+    /// For numbered peers this is the configured address. For unnumbered peers
+    /// it queries NDP for the neighbor on the peer's interface.
+    fn try_resolve_connect_addr(
+        &self,
+    ) -> Result<SocketAddr, ResolveTargetError> {
         match &self.neighbor.peer {
             PeerId::Interface(iface) => {
-                let mgr = self.unnumbered_manager.as_ref()?;
-                if !mgr.interface_is_active(iface) {
-                    session_log_lite!(
-                        self,
-                        debug,
-                        "interface not active, skipping connection";
-                        "interface" => iface
-                    );
-                    return None;
-                }
-                match mgr.get_neighbor_by_interface(iface) {
-                    Ok(Some(neighbor)) => {
-                        Some(neighbor.to_socket_addr(self.neighbor.port.get()))
-                    }
-                    Ok(None) => {
-                        session_log_lite!(
-                            self,
-                            debug,
-                            "no NDP neighbor discovered yet";
-                            "interface" => iface
-                        );
-                        None
-                    }
-                    Err(e) => {
-                        session_log_lite!(
-                            self,
-                            warn,
-                            "failed to query neighbor for interface";
-                            "interface" => iface,
-                            "error" => e.to_string()
-                        );
-                        None
-                    }
-                }
+                let mgr = self
+                    .unnumbered_manager
+                    .as_ref()
+                    .ok_or(ResolveTargetError::NoUnnumberedManager)?;
+                let neighbor = mgr
+                    .get_neighbor_by_interface(iface)?
+                    .ok_or(ResolveTargetError::NoNeighbor)?;
+                Ok(neighbor.to_socket_addr(self.neighbor.port.get()))
             }
             PeerId::Ip(ip) => {
-                Some(SocketAddr::new(*ip, self.neighbor.port.get()))
+                Ok(SocketAddr::new(*ip, self.neighbor.port.get()))
             }
         }
     }
@@ -1919,16 +1903,20 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             // release lock before calling connect
         }
 
-        // Resolve peer address. For unnumbered peers, this verifies interface
-        // is active and queries NDP for the neighbor address.
-        let Some(peer_addr) = self.try_resolve_connect_addr() else {
-            session_log_lite!(
-                self,
-                debug,
-                "cannot resolve peer address, skipping connection attempt";
-                "peer" => format!("{:?}", self.neighbor.peer)
-            );
-            return;
+        // Resolve the peer address. For unnumbered peers this queries NDP for
+        // the neighbor on the peer's interface.
+        let peer_addr = match self.try_resolve_connect_addr() {
+            Ok(peer_addr) => peer_addr,
+            Err(e) => {
+                session_log_lite!(
+                    self,
+                    debug,
+                    "skipping connection attempt: {e}";
+                    "peer" => format!("{:?}", self.neighbor.peer),
+                    "reason" => e.to_string()
+                );
+                return;
+            }
         };
 
         let handle = match Cnx::Connector::connect(

--- a/bgp/src/test.rs
+++ b/bgp/src/test.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{
+    BGP_PORT,
     config::{PeerConfig, RouterConfig},
     connection::{BgpConnection, BgpListener},
     connection_channel::{BgpConnectionChannel, BgpListenerChannel},
@@ -30,6 +31,7 @@ use rdb::Asn;
 use std::{
     collections::BTreeSet,
     net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6},
+    num::NonZeroU16,
     sync::{
         Arc, Mutex,
         atomic::{AtomicU32, Ordering},
@@ -376,7 +378,9 @@ where
             let peer_config = PeerConfig {
                 name: neighbor.peer_name.clone(),
                 group: String::new(),
-                host: neighbor.remote_host,
+                id: PeerId::Ip((neighbor.remote_host).ip()),
+                port: NonZeroU16::new((neighbor.remote_host).port())
+                    .unwrap_or(BGP_PORT),
                 hold_time: 6,
                 idle_hold_time: 0,
                 delay_open: 0,
@@ -404,6 +408,7 @@ where
                     event_tx.clone(),
                     event_rx,
                     session_info,
+                    None,
                 )
                 .unwrap_or_else(|_| {
                     panic!("new session on router {}", logical_router.name)
@@ -733,7 +738,8 @@ fn basic_update_helper<
                 let peer_config = PeerConfig {
                     name: "r2".into(),
                     group: String::new(),
-                    host: r2_addr,
+                    id: PeerId::Ip((r2_addr).ip()),
+                    port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
                     hold_time: 6,
                     idle_hold_time: 0,
                     delay_open: 0,
@@ -796,7 +802,8 @@ fn basic_update_helper<
                 let peer_config = PeerConfig {
                     name: "r2".into(),
                     group: String::new(),
-                    host: r2_addr,
+                    id: PeerId::Ip((r2_addr).ip()),
+                    port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
                     hold_time: 6,
                     idle_hold_time: 0,
                     delay_open: 0,
@@ -874,7 +881,8 @@ fn basic_update_helper<
                 let peer_config = PeerConfig {
                     name: "r2".into(),
                     group: String::new(),
-                    host: r2_addr,
+                    id: PeerId::Ip((r2_addr).ip()),
+                    port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
                     hold_time: 6,
                     idle_hold_time: 0,
                     delay_open: 0,
@@ -972,7 +980,8 @@ fn three_router_chain_helper<
                 session_info: SessionInfo::from_peer_config(&PeerConfig {
                     name: "r2".into(),
                     group: String::new(),
-                    host: r2_addr,
+                    id: PeerId::Ip((r2_addr).ip()),
+                    port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
                     hold_time: 6,
                     idle_hold_time: 0,
                     delay_open: 0,
@@ -995,7 +1004,9 @@ fn three_router_chain_helper<
                     session_info: SessionInfo::from_peer_config(&PeerConfig {
                         name: "r1".into(),
                         group: String::new(),
-                        host: r1_addr,
+                        id: PeerId::Ip((r1_addr).ip()),
+                        port: NonZeroU16::new((r1_addr).port())
+                            .unwrap_or(BGP_PORT),
                         hold_time: 6,
                         idle_hold_time: 0,
                         delay_open: 0,
@@ -1010,7 +1021,9 @@ fn three_router_chain_helper<
                     session_info: SessionInfo::from_peer_config(&PeerConfig {
                         name: "r3".into(),
                         group: String::new(),
-                        host: r3_addr,
+                        id: PeerId::Ip((r3_addr).ip()),
+                        port: NonZeroU16::new((r3_addr).port())
+                            .unwrap_or(BGP_PORT),
                         hold_time: 6,
                         idle_hold_time: 0,
                         delay_open: 0,
@@ -1033,7 +1046,8 @@ fn three_router_chain_helper<
                 session_info: SessionInfo::from_peer_config(&PeerConfig {
                     name: "r2".into(),
                     group: String::new(),
-                    host: r2_addr,
+                    id: PeerId::Ip((r2_addr).ip()),
+                    port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
                     hold_time: 6,
                     idle_hold_time: 0,
                     delay_open: 0,
@@ -1210,8 +1224,8 @@ fn test_three_router_chain_tcp_ipv6() {
 #[test]
 #[serial_test::serial]
 fn test_neighbor_thread_lifecycle_no_leaks() {
-    let r1_addr = sockaddr!(&format!("127.0.0.10:{TEST_BGP_PORT}"));
-    let r2_addr = sockaddr!(&format!("127.0.0.11:{TEST_BGP_PORT}"));
+    let r1_addr: SocketAddr = sockaddr!(&format!("127.0.0.10:{TEST_BGP_PORT}"));
+    let r2_addr: SocketAddr = sockaddr!(&format!("127.0.0.11:{TEST_BGP_PORT}"));
 
     // Wait for baseline BGP thread count to reach 0
     // This handles the case where previous tests' threads are still being cleaned up by the OS.
@@ -1236,7 +1250,8 @@ fn test_neighbor_thread_lifecycle_no_leaks() {
     let r1_peer_config = PeerConfig {
         name: "r2".into(),
         group: String::new(),
-        host: r2_addr,
+        id: PeerId::Ip((r2_addr).ip()),
+        port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -1248,7 +1263,8 @@ fn test_neighbor_thread_lifecycle_no_leaks() {
     let r2_peer_config = PeerConfig {
         name: "r1".into(),
         group: String::new(),
-        host: r1_addr,
+        id: PeerId::Ip((r1_addr).ip()),
+        port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -1413,7 +1429,8 @@ fn test_import_export_policy_filtering() {
     let r1_peer_config = PeerConfig {
         name: "r2".into(),
         group: String::new(),
-        host: r2_addr,
+        id: PeerId::Ip((r2_addr).ip()),
+        port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -1434,7 +1451,8 @@ fn test_import_export_policy_filtering() {
     let r2_peer_config = PeerConfig {
         name: "r1".into(),
         group: String::new(),
-        host: r1_addr,
+        id: PeerId::Ip((r1_addr).ip()),
+        port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -1922,10 +1940,13 @@ fn unnumbered_peering_helper(
             false,
         );
 
+        let peer1_addr: SocketAddr =
+            sockaddr!(&format!("[fe80::2]:{TEST_BGP_PORT}"));
         let peer_config1 = PeerConfig {
             name: format!("peer_{}", iface),
             group: String::new(),
-            host: sockaddr!(&format!("[fe80::2]:{TEST_BGP_PORT}")),
+            id: PeerId::Ip(peer1_addr.ip()),
+            port: NonZeroU16::new(peer1_addr.port()).unwrap_or(BGP_PORT),
             hold_time: 6,
             idle_hold_time: 0,
             delay_open: 0,
@@ -1935,14 +1956,13 @@ fn unnumbered_peering_helper(
         };
 
         let result1 = router1
-            .ensure_unnumbered_session(
-                iface.clone(),
+            .ensure_session(
                 peer_config1,
                 Some(bind_addr1),
                 event_tx1.clone(),
                 event_rx1,
                 session_info1,
-                mock_ndp1.clone(),
+                Some(mock_ndp1.clone()),
             )
             .expect("create session1");
 
@@ -1973,10 +1993,13 @@ fn unnumbered_peering_helper(
             false,
         );
 
+        let peer2_addr: SocketAddr =
+            sockaddr!(&format!("[fe80::1]:{TEST_BGP_PORT}"));
         let peer_config2 = PeerConfig {
             name: format!("peer_{}", iface),
             group: String::new(),
-            host: sockaddr!(&format!("[fe80::1]:{TEST_BGP_PORT}")),
+            id: PeerId::Ip(peer2_addr.ip()),
+            port: NonZeroU16::new(peer2_addr.port()).unwrap_or(BGP_PORT),
             hold_time: 6,
             idle_hold_time: 0,
             delay_open: 0,
@@ -1986,14 +2009,13 @@ fn unnumbered_peering_helper(
         };
 
         let result2 = router2
-            .ensure_unnumbered_session(
-                iface.clone(),
+            .ensure_session(
                 peer_config2,
                 Some(bind_addr2),
                 event_tx2.clone(),
                 event_rx2,
                 session_info2,
-                mock_ndp2.clone(),
+                Some(mock_ndp2.clone()),
             )
             .expect("create session2");
 
@@ -2683,7 +2705,8 @@ fn unnumbered_pair(
     let peer_config1 = PeerConfig {
         name: format!("peer_{}", interface_name),
         group: String::new(),
-        host: r2_addr,
+        id: PeerId::Ip((r2_addr).ip()),
+        port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -2693,14 +2716,13 @@ fn unnumbered_pair(
     };
 
     let result1 = router1
-        .ensure_unnumbered_session(
-            interface_name.to_string(),
+        .ensure_session(
             peer_config1,
             Some(r1_addr),
             event_tx1.clone(),
             event_rx1,
             session_info1,
-            mock_ndp1.clone(),
+            Some(mock_ndp1.clone()),
         )
         .expect("create session1");
 
@@ -2715,7 +2737,8 @@ fn unnumbered_pair(
     let peer_config2 = PeerConfig {
         name: format!("peer_{}", interface_name),
         group: String::new(),
-        host: r1_addr,
+        id: PeerId::Ip((r1_addr).ip()),
+        port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -2725,14 +2748,13 @@ fn unnumbered_pair(
     };
 
     let result2 = router2
-        .ensure_unnumbered_session(
-            interface_name.to_string(),
+        .ensure_session(
             peer_config2,
             Some(r2_addr),
             event_tx2.clone(),
             event_rx2,
             session_info2,
-            mock_ndp2.clone(),
+            Some(mock_ndp2.clone()),
         )
         .expect("create session2");
 
@@ -2960,7 +2982,8 @@ fn unnumbered_three_router_chain(
     let peer_config1 = PeerConfig {
         name: format!("r1_to_r2_{}", r1_r2_interface),
         group: String::new(),
-        host: r2_eth0_addr,
+        id: PeerId::Ip((r2_eth0_addr).ip()),
+        port: NonZeroU16::new((r2_eth0_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -2969,14 +2992,13 @@ fn unnumbered_three_router_chain(
         resolution: 100,
     };
     let result1 = router1
-        .ensure_unnumbered_session(
-            r1_r2_interface.to_string(),
+        .ensure_session(
             peer_config1,
             Some(r1_addr),
             event_tx1.clone(),
             event_rx1,
             session_info1,
-            mock_ndp1.clone(),
+            Some(mock_ndp1.clone()),
         )
         .expect("create r1 session");
     let session1 = match result1 {
@@ -2991,7 +3013,8 @@ fn unnumbered_three_router_chain(
     let peer_config2_r1 = PeerConfig {
         name: format!("r2_to_r1_{}", r1_r2_interface),
         group: String::new(),
-        host: r1_addr,
+        id: PeerId::Ip((r1_addr).ip()),
+        port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -3000,14 +3023,13 @@ fn unnumbered_three_router_chain(
         resolution: 100,
     };
     let result2_r1 = router2
-        .ensure_unnumbered_session(
-            r1_r2_interface.to_string(),
+        .ensure_session(
             peer_config2_r1,
             Some(r2_eth0_addr),
             event_tx2_r1.clone(),
             event_rx2_r1,
             session_info2_r1,
-            mock_ndp2.clone(),
+            Some(mock_ndp2.clone()),
         )
         .expect("create r2-r1 session");
     let session2_r1 = match result2_r1 {
@@ -3022,7 +3044,8 @@ fn unnumbered_three_router_chain(
     let peer_config2_r3 = PeerConfig {
         name: format!("r2_to_r3_{}", r2_r3_interface),
         group: String::new(),
-        host: r3_addr,
+        id: PeerId::Ip((r3_addr).ip()),
+        port: NonZeroU16::new((r3_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -3031,14 +3054,13 @@ fn unnumbered_three_router_chain(
         resolution: 100,
     };
     let result2_r3 = router2
-        .ensure_unnumbered_session(
-            r2_r3_interface.to_string(),
+        .ensure_session(
             peer_config2_r3,
             Some(r2_eth1_addr),
             event_tx2_r3.clone(),
             event_rx2_r3,
             session_info2_r3,
-            mock_ndp2.clone(),
+            Some(mock_ndp2.clone()),
         )
         .expect("create r2-r3 session");
     let session2_r3 = match result2_r3 {
@@ -3052,7 +3074,8 @@ fn unnumbered_three_router_chain(
     let peer_config3 = PeerConfig {
         name: format!("r3_to_r2_{}", r2_r3_interface),
         group: String::new(),
-        host: r2_eth1_addr,
+        id: PeerId::Ip((r2_eth1_addr).ip()),
+        port: NonZeroU16::new((r2_eth1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -3061,14 +3084,13 @@ fn unnumbered_three_router_chain(
         resolution: 100,
     };
     let result3 = router3
-        .ensure_unnumbered_session(
-            r2_r3_interface.to_string(),
+        .ensure_session(
             peer_config3,
             Some(r3_addr),
             event_tx3.clone(),
             event_rx3,
             session_info3,
-            mock_ndp3.clone(),
+            Some(mock_ndp3.clone()),
         )
         .expect("create r3 session");
     let session3 = match result3 {
@@ -3908,7 +3930,8 @@ fn test_unnumbered_interface_lifecycle() {
     let peer_config1 = PeerConfig {
         name: "peer_eth0".to_string(),
         group: String::new(),
-        host: r2_addr,
+        id: PeerId::Ip((r2_addr).ip()),
+        port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -3918,14 +3941,13 @@ fn test_unnumbered_interface_lifecycle() {
     };
 
     let result1 = router1
-        .ensure_unnumbered_session(
-            "eth0".to_string(),
+        .ensure_session(
             peer_config1,
             Some(r1_addr),
             event_tx1.clone(),
             event_rx1,
             session_info1,
-            mock_ndp1.clone(),
+            Some(mock_ndp1.clone()),
         )
         .expect("create session1");
 
@@ -3944,7 +3966,8 @@ fn test_unnumbered_interface_lifecycle() {
     let peer_config2 = PeerConfig {
         name: "peer_eth0".to_string(),
         group: String::new(),
-        host: r1_addr,
+        id: PeerId::Ip((r1_addr).ip()),
+        port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
         delay_open: 0,
@@ -3954,14 +3977,13 @@ fn test_unnumbered_interface_lifecycle() {
     };
 
     let result2 = router2
-        .ensure_unnumbered_session(
-            "eth0".to_string(),
+        .ensure_session(
             peer_config2,
             Some(r2_addr),
             event_tx2.clone(),
             event_rx2,
             session_info2,
-            mock_ndp2.clone(),
+            Some(mock_ndp2.clone()),
         )
         .expect("create session2");
 

--- a/bgp/src/test.rs
+++ b/bgp/src/test.rs
@@ -1945,7 +1945,7 @@ fn unnumbered_peering_helper(
         let peer_config1 = PeerConfig {
             name: format!("peer_{}", iface),
             group: String::new(),
-            id: PeerId::Ip(peer1_addr.ip()),
+            id: PeerId::Interface(iface.clone()),
             port: NonZeroU16::new(peer1_addr.port()).unwrap_or(BGP_PORT),
             hold_time: 6,
             idle_hold_time: 0,
@@ -1998,7 +1998,7 @@ fn unnumbered_peering_helper(
         let peer_config2 = PeerConfig {
             name: format!("peer_{}", iface),
             group: String::new(),
-            id: PeerId::Ip(peer2_addr.ip()),
+            id: PeerId::Interface(iface.clone()),
             port: NonZeroU16::new(peer2_addr.port()).unwrap_or(BGP_PORT),
             hold_time: 6,
             idle_hold_time: 0,
@@ -2705,7 +2705,7 @@ fn unnumbered_pair(
     let peer_config1 = PeerConfig {
         name: format!("peer_{}", interface_name),
         group: String::new(),
-        id: PeerId::Ip((r2_addr).ip()),
+        id: PeerId::Interface(interface_name.to_string()),
         port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -2737,7 +2737,7 @@ fn unnumbered_pair(
     let peer_config2 = PeerConfig {
         name: format!("peer_{}", interface_name),
         group: String::new(),
-        id: PeerId::Ip((r1_addr).ip()),
+        id: PeerId::Interface(interface_name.to_string()),
         port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -2982,7 +2982,7 @@ fn unnumbered_three_router_chain(
     let peer_config1 = PeerConfig {
         name: format!("r1_to_r2_{}", r1_r2_interface),
         group: String::new(),
-        id: PeerId::Ip((r2_eth0_addr).ip()),
+        id: PeerId::Interface(r1_r2_interface.to_string()),
         port: NonZeroU16::new((r2_eth0_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -3013,7 +3013,7 @@ fn unnumbered_three_router_chain(
     let peer_config2_r1 = PeerConfig {
         name: format!("r2_to_r1_{}", r1_r2_interface),
         group: String::new(),
-        id: PeerId::Ip((r1_addr).ip()),
+        id: PeerId::Interface(r1_r2_interface.to_string()),
         port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -3044,7 +3044,7 @@ fn unnumbered_three_router_chain(
     let peer_config2_r3 = PeerConfig {
         name: format!("r2_to_r3_{}", r2_r3_interface),
         group: String::new(),
-        id: PeerId::Ip((r3_addr).ip()),
+        id: PeerId::Interface(r2_r3_interface.to_string()),
         port: NonZeroU16::new((r3_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -3074,7 +3074,7 @@ fn unnumbered_three_router_chain(
     let peer_config3 = PeerConfig {
         name: format!("r3_to_r2_{}", r2_r3_interface),
         group: String::new(),
-        id: PeerId::Ip((r2_eth1_addr).ip()),
+        id: PeerId::Interface(r2_r3_interface.to_string()),
         port: NonZeroU16::new((r2_eth1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -3930,7 +3930,7 @@ fn test_unnumbered_interface_lifecycle() {
     let peer_config1 = PeerConfig {
         name: "peer_eth0".to_string(),
         group: String::new(),
-        id: PeerId::Ip((r2_addr).ip()),
+        id: PeerId::Interface("eth0".to_string()),
         port: NonZeroU16::new((r2_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,
@@ -3966,7 +3966,7 @@ fn test_unnumbered_interface_lifecycle() {
     let peer_config2 = PeerConfig {
         name: "peer_eth0".to_string(),
         group: String::new(),
-        id: PeerId::Ip((r1_addr).ip()),
+        id: PeerId::Interface("eth0".to_string()),
         port: NonZeroU16::new((r1_addr).port()).unwrap_or(BGP_PORT),
         hold_time: 6,
         idle_hold_time: 0,

--- a/falcon-lab/README.md
+++ b/falcon-lab/README.md
@@ -7,9 +7,12 @@ configuration.
 
 ## Runtime cargo-bay contents
 
-Before running Junos topologies, `cargo-bay/` must contain:
+Before running any topology, `cargo-bay/` must contain:
 
 - `mgd` and `ddmd`, staged by local test setup or the Buildomat job.
+
+Junos topologies additionally require:
+
 - `falcon-juniper-license.key`, a Juniper license file. This file is a secret:
   do not commit it, print it, include it in diagnostics, or pass its contents in
   command-line arguments.

--- a/falcon-lab/README.md
+++ b/falcon-lab/README.md
@@ -1,0 +1,129 @@
+# Falcon lab
+
+`falcon-lab` runs Maghemite integration topologies under Falcon. The
+topologies use prebuilt Falcon base images for Helios, Debian/FRR, cEOS, and
+Junos/cRPD nodes, plus a per-run `cargo-bay/` 9p share for binaries and runtime
+configuration.
+
+## Runtime cargo-bay contents
+
+Before running Junos topologies, `cargo-bay/` must contain:
+
+- `mgd` and `ddmd`, staged by local test setup or the Buildomat job.
+- `falcon-juniper-license.key`, a Juniper license file. This file is a secret:
+  do not commit it, print it, include it in diagnostics, or pass its contents in
+  command-line arguments.
+
+`falcon-lab` writes non-secret Junos topology config as
+`cargo-bay/<node>-junos.set`. The staged file is a complete non-interactive
+Junos CLI input file: it starts with `configure`, contains `set ...` commands,
+and ends with `commit`.
+
+## Junos license source and connectivity assumptions
+
+CI fetches the Juniper license from:
+
+```text
+http://catacomb.eng.oxide.computer:12346/falcon/jl
+```
+
+That endpoint is reachable only from appropriate Oxide networks, such as the
+corporate network/VPN or CI runners with catacomb access. Developer machines or
+Falcon guests outside that network should not be expected to resolve or reach
+it.
+
+The division of ownership is:
+
+1. The CI runner or developer fetches the license and places it at
+   `cargo-bay/falcon-juniper-license.key` with restrictive permissions.
+2. `falcon-lab` verifies that the file exists and stages non-secret topology
+   config.
+3. The Junos guest consumes the file by path after mounting `cargo-bay`; the
+   license contents are never passed through falcon-lab logs or command-line
+   arguments.
+
+For local runs from a machine that can reach catacomb:
+
+```sh
+mkdir -p cargo-bay
+curl -sSfL --retry 10 --retry-all-errors \
+  -o cargo-bay/falcon-juniper-license.key \
+  http://catacomb.eng.oxide.computer:12346/falcon/jl
+chmod 0600 cargo-bay/falcon-juniper-license.key
+```
+
+## Junos image assumptions
+
+The Falcon image named `junos-23.2` is expected to be built by the experimental
+`voxel-image` tooling from the
+[`oxidecomputer/voxel`](https://github.com/oxidecomputer/voxel) repository. The
+portable artifact is uploaded alongside other Falcon assets as:
+
+```text
+https://oxide-falcon-assets.s3.us-west-2.amazonaws.com/junos-23.2_0.raw.xz
+```
+
+The image must already contain Docker and the Juniper cRPD image. It must not
+contain a license or topology-specific routing config.
+
+The image is also expected to contain these guest-side systemd services and
+helpers:
+
+- `voxel-crpd.service`: starts the `crpd1` container and attaches the data
+  interfaces.
+- `falcon-cargo-bay.service`: mounts the Falcon 9p share at `/opt/cargo-bay`.
+- `falcon-junos-apply.service`: waits for
+  `/opt/cargo-bay/falcon-juniper-license.key` and a non-empty
+  `/opt/cargo-bay/*-junos.set`, then stages them under `/var/run/juniper/`,
+  installs the license, and runs `cli -f /config/falcon-lab/topology.set` inside
+  the cRPD container.
+
+The apply service writes non-secret status/debug files:
+
+- `/run/falcon-junos-apply.status`
+- `/var/run/juniper/falcon-lab/apply.out`
+
+Falcon-lab diagnostics may collect those files, but must not collect license
+contents or unredacted logs/configuration that can include the license.
+
+## Building and publishing the Junos image
+
+On an illumos/Falcon-capable builder with `voxel` checked out:
+
+```sh
+cd ~/git/voxel
+FALCON_DATASET=DATA/falcon \
+  CAPTURE_MODE=zfs \
+  IMAGE_NAME=junos-23.2 \
+  ./voxel-image/build-junos.sh 23.2R1.13
+```
+
+`CAPTURE_MODE=zfs` registers the image directly into the local Falcon dataset
+for testing. To produce a portable artifact for S3, build in raw/artifact mode:
+
+```sh
+cd ~/git/voxel
+FALCON_DATASET=DATA/falcon \
+  CAPTURE_MODE=raw \
+  IMAGE_NAME=junos-23.2 \
+  OUT="$PWD/voxel-image/out" \
+  ./voxel-image/build-junos.sh 23.2R1.13
+```
+
+Upload the resulting `voxel-image/out/junos-23.2_0.raw.xz` to the Falcon assets
+bucket.
+
+After publishing a new image, local test machines may need the existing Falcon
+base-image dataset destroyed/replaced so the new image is used.
+
+## Running with diagnostics disabled
+
+Failure diagnostics are enabled by default. For faster local iteration while
+preserving the failed topology, use:
+
+```sh
+pfexec ./falcon-lab run --no-cleanup --no-diag-on-fail quartet-bfd-static-routing
+```
+
+Even with `--no-diag-on-fail`, quartet tests make a best-effort attempt to resume
+FRR's `bfdd` and unpause cEOS/cRPD before returning the failure.

--- a/falcon-lab/README.md
+++ b/falcon-lab/README.md
@@ -19,6 +19,12 @@ Before running Junos topologies, `cargo-bay/` must contain:
 Junos CLI input file: it starts with `configure`, contains `set ...` commands,
 and ends with `commit`.
 
+Junos topology config is per-run state. `falcon-lab` removes stale
+`cargo-bay/*-junos.set` files before launching a quartet topology so the
+guest-side apply service cannot consume configuration left behind by an earlier
+topology. Do not put persistent hand-written Junos config in files matching
+that pattern.
+
 ## Junos license source and connectivity assumptions
 
 CI fetches the Juniper license from:

--- a/falcon-lab/src/diagnostics.rs
+++ b/falcon-lab/src/diagnostics.rs
@@ -7,6 +7,22 @@ use libfalcon::{NodeRef, Runner};
 use slog::{info, warn};
 use std::path::Path;
 
+#[derive(Copy, Clone)]
+pub enum ProtocolDiagnostics {
+    Bgp,
+    Bfd,
+}
+
+impl ProtocolDiagnostics {
+    pub fn bgp(self) -> bool {
+        matches!(self, Self::Bgp)
+    }
+
+    pub fn bfd(self) -> bool {
+        matches!(self, Self::Bfd)
+    }
+}
+
 /// Run `cmd` on `node`, capture stdout, and persist it as an artifact
 /// labelled `<topo>-<label>.log`.
 pub async fn capture(

--- a/falcon-lab/src/eos.rs
+++ b/falcon-lab/src/eos.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use crate::linux::LinuxNode;
+use crate::{diagnostics::ProtocolDiagnostics, linux::LinuxNode};
 use anyhow::{Context, Result, anyhow};
 use colored::Colorize;
 use libfalcon::{NodeRef, Runner};
@@ -71,21 +71,31 @@ impl EosNode {
         LinuxNode(self.0)
     }
 
-    /// Capture BGP / BFD / routing state via the Arista CLI.
-    pub async fn collect_diagnostics(&self, d: &Runner, topo: &str) {
+    /// Capture protocol-specific state via the Arista CLI.
+    pub async fn collect_diagnostics(
+        &self,
+        d: &Runner,
+        topo: &str,
+        protocols: ProtocolDiagnostics,
+    ) {
         let name = self.name(d);
-        // `Cli -c` takes a single newline-separated script.
-        const SCRIPT: &str = "enable
-            show running-config
-            show ip interface brief
-            show ip bgp summary
-            show ip bgp
-            show ipv6 bgp
-            show ip route
-            show ipv6 route
-            show bfd peers
-        ";
-        match self.shell(d, SCRIPT).await {
+        // `Cli -c` takes a single newline-separated script. Linux diagnostics
+        // below collect host/container interfaces and routes for every test,
+        // so keep this focused on the protocol under test.
+        let script = if protocols.bgp() {
+            "enable
+                show running-config
+                show ip bgp summary
+                show ip bgp
+                show ipv6 bgp
+            "
+        } else {
+            "enable
+                show running-config
+                show bfd peers
+            "
+        };
+        match self.shell(d, script).await {
             Ok(out) => crate::diagnostics::write_artifact(
                 d,
                 topo,

--- a/falcon-lab/src/eos.rs
+++ b/falcon-lab/src/eos.rs
@@ -12,6 +12,8 @@ use slog::info;
 use std::collections::HashMap;
 use std::net::IpAddr;
 
+const CEOS_CONTAINER: &str = "ceos";
+
 #[derive(Copy, Clone)]
 pub struct EosNode(pub NodeRef);
 
@@ -31,7 +33,9 @@ impl EosNode {
             let status = d
                 .exec(
                     self.0,
-                    "docker inspect ceos --format '{{.State.Status}}'",
+                    &format!(
+                        "docker inspect {CEOS_CONTAINER} --format '{{{{.State.Status}}}}'"
+                    ),
                 )
                 .await?;
 
@@ -54,7 +58,10 @@ impl EosNode {
         );
 
         let response = d
-            .exec(self.0, &format!("docker exec ceos Cli -c '{script}'"))
+            .exec(
+                self.0,
+                &format!("docker exec {CEOS_CONTAINER} Cli -c '{script}'"),
+            )
             .await?;
 
         Ok(response)
@@ -88,19 +95,25 @@ impl EosNode {
             ),
             Err(e) => slog::warn!(d.log, "diagnostics {name}-cli: {e}"),
         }
+        self.linux().collect_diagnostics(d, topo, &name).await;
+        self.linux()
+            .collect_container_diagnostics(d, topo, &name, CEOS_CONTAINER)
+            .await;
     }
 
     /// Freeze the ceos container. BFD packets stop being processed without
     /// tearing down running-config, so `unpause` restores the session.
     pub async fn pause(&self, d: &Runner) -> Result<()> {
-        info!(d.log, "{}: pausing ceos", self.name(d));
-        d.exec(self.0, "docker pause ceos").await?;
+        info!(d.log, "{}: pausing {CEOS_CONTAINER}", self.name(d));
+        d.exec(self.0, &format!("docker pause {CEOS_CONTAINER}"))
+            .await?;
         Ok(())
     }
 
     pub async fn unpause(&self, d: &Runner) -> Result<()> {
-        info!(d.log, "{}: unpausing ceos", self.name(d));
-        d.exec(self.0, "docker unpause ceos").await?;
+        info!(d.log, "{}: unpausing {CEOS_CONTAINER}", self.name(d));
+        d.exec(self.0, &format!("docker unpause {CEOS_CONTAINER}"))
+            .await?;
         Ok(())
     }
 

--- a/falcon-lab/src/frr.rs
+++ b/falcon-lab/src/frr.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use crate::linux::LinuxNode;
+use crate::{diagnostics::ProtocolDiagnostics, linux::LinuxNode};
 use anyhow::{Context, Result};
 use colored::Colorize;
 use libfalcon::{NodeRef, Runner};
@@ -79,19 +79,28 @@ impl FrrNode {
             .any(|p| p.peer == peer && p.status.eq_ignore_ascii_case("up")))
     }
 
-    /// Capture BGP / BFD / routing state via vtysh, plus linux network state
-    pub async fn collect_diagnostics(&self, d: &Runner, topo: &str) {
+    /// Capture protocol-specific FRR state via vtysh, plus Linux network state.
+    pub async fn collect_diagnostics(
+        &self,
+        d: &Runner,
+        topo: &str,
+        protocols: ProtocolDiagnostics,
+    ) {
         let name = self.name(d);
-        const VTYSH: &str = "
-            show running-config
-            show ip bgp summary
-            show ip bgp
-            show ipv6 bgp
-            show ip route
-            show ipv6 route
-            show bfd peers
-        ";
-        match self.shell(d, VTYSH).await {
+        let commands = if protocols.bgp() {
+            "
+                show running-config
+                show ip bgp summary
+                show ip bgp
+                show ipv6 bgp
+            "
+        } else {
+            "
+                show running-config
+                show bfd peers
+            "
+        };
+        match self.shell(d, commands).await {
             Ok(out) => crate::diagnostics::write_artifact(
                 d,
                 topo,

--- a/falcon-lab/src/frr.rs
+++ b/falcon-lab/src/frr.rs
@@ -101,23 +101,7 @@ impl FrrNode {
             ),
             Err(e) => slog::warn!(d.log, "diagnostics {name}-vtysh: {e}"),
         }
-        // Plain `ip` snapshots (not a vtysh command, so issued directly).
-        for (suffix, cmd) in [
-            ("ip-link", "ip -d -s link show"),
-            ("ip-addr", "ip -d -s addr show"),
-            ("ip-neigh", "ip -d -s neigh show"),
-            ("ip-nexthop", "ip -d -s nexthop show"),
-            ("ip-route", "ip -d -s route show table all"),
-        ] {
-            crate::diagnostics::capture(
-                d,
-                self.0,
-                topo,
-                &format!("{name}-{suffix}"),
-                cmd,
-            )
-            .await;
-        }
+        self.linux().collect_diagnostics(d, topo, &name).await;
     }
 
     /// Execute a vtysh command and return the output.

--- a/falcon-lab/src/juniper.rs
+++ b/falcon-lab/src/juniper.rs
@@ -1,6 +1,6 @@
 //! Juniper cRPD machinery.
 
-use crate::linux::LinuxNode;
+use crate::{diagnostics::ProtocolDiagnostics, linux::LinuxNode};
 use anyhow::{Context, Result, anyhow};
 use colored::Colorize;
 use libfalcon::{NodeRef, Runner};
@@ -13,9 +13,41 @@ use std::path::{Path, PathBuf};
 const CRPD_CONTAINER: &str = "crpd1";
 const CARGO_BAY: &str = "cargo-bay";
 const LICENSE_PATH: &str = "falcon-juniper-license.key";
+const CONFIG_SUFFIX: &str = "-junos.set";
 
 #[derive(Copy, Clone)]
 pub struct JuniperNode(pub NodeRef);
+
+/// Remove non-secret Junos topology configs from previous runs.
+///
+/// The Junos image's guest-side apply service starts during boot and consumes
+/// the first `/opt/cargo-bay/*-junos.set` it sees. CI runs multiple Junos
+/// topologies against one cargo-bay, so stale config must be removed before a
+/// new Junos VM can boot and observe it.
+pub fn clear_staged_routing_configs() -> Result<()> {
+    let dir = Path::new(CARGO_BAY);
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in
+        fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("read {} entry", dir.display()))?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if name.ends_with(CONFIG_SUFFIX) {
+            fs::remove_file(&path)
+                .with_context(|| format!("remove stale {}", path.display()))?;
+        }
+    }
+    Ok(())
+}
 
 impl JuniperNode {
     pub fn name(&self, d: &Runner) -> String {
@@ -86,7 +118,7 @@ impl JuniperNode {
         let dir = Path::new(CARGO_BAY);
         fs::create_dir_all(dir)
             .with_context(|| format!("create {}", dir.display()))?;
-        let path = dir.join(format!("{node_name}-junos.set"));
+        let path = dir.join(format!("{node_name}{CONFIG_SUFFIX}"));
         let routing_config = routing_config
             .lines()
             .map(str::trim)
@@ -163,9 +195,14 @@ impl JuniperNode {
     /// directly or Junos/container logs here: the committed configuration
     /// contains the license key, and logs may include secret-bearing
     /// configuration activity.
-    pub async fn collect_diagnostics(&self, d: &Runner, topo: &str) {
+    pub async fn collect_diagnostics(
+        &self,
+        d: &Runner,
+        topo: &str,
+        protocols: ProtocolDiagnostics,
+    ) {
         let name = self.name(d);
-        const COMMANDS: [(&str, &str); 6] = [
+        let mut commands = vec![
             ("docker-ps", "docker ps -a"),
             ("docker-inspect", "docker inspect crpd1"),
             (
@@ -181,12 +218,26 @@ impl JuniperNode {
                 "show-interfaces-terse",
                 "docker exec crpd1 cli -c 'show interfaces terse | no-more'",
             ),
-            (
-                "show-bgp-summary",
-                "docker exec crpd1 cli -c 'show bgp summary | no-more'",
-            ),
         ];
-        for (suffix, command) in COMMANDS {
+        if protocols.bgp() {
+            commands.extend([
+                (
+                    "show-bgp-summary",
+                    "docker exec crpd1 cli -c 'show bgp summary | no-more'",
+                ),
+                (
+                    "show-bgp-neighbors-auto-discovered",
+                    "docker exec crpd1 cli -c 'show bgp neighbors auto-discovered | no-more'",
+                ),
+            ]);
+        }
+        if protocols.bfd() {
+            commands.push((
+                "show-bfd-session-detail",
+                "docker exec crpd1 cli -c 'show bfd session detail | no-more'",
+            ));
+        }
+        for (suffix, command) in commands {
             crate::diagnostics::capture(
                 d,
                 self.0,

--- a/falcon-lab/src/juniper.rs
+++ b/falcon-lab/src/juniper.rs
@@ -100,10 +100,10 @@ impl JuniperNode {
         // guest-side systemd services that mount cargo-bay, install the
         // license, and apply `<node>-junos.set`; see falcon-lab/README.md.
         self.stage_routing_config(d, routing_config)?;
-        self.stage_license()?;
+        self.verify_license_available()?;
         info!(
             d.log,
-            "{}: staged Juniper config and license for guest systemd services",
+            "{}: staged Juniper config and verified license for guest systemd services",
             self.name(d)
         );
         Ok(())
@@ -130,7 +130,7 @@ impl JuniperNode {
         Ok(path)
     }
 
-    fn stage_license(&self) -> Result<PathBuf> {
+    fn verify_license_available(&self) -> Result<PathBuf> {
         let path = Path::new(CARGO_BAY).join(LICENSE_PATH);
         let metadata = fs::metadata(&path).with_context(|| {
             format!(

--- a/falcon-lab/src/juniper.rs
+++ b/falcon-lab/src/juniper.rs
@@ -1,0 +1,312 @@
+//! Juniper cRPD machinery.
+
+use crate::linux::LinuxNode;
+use anyhow::{Context, Result, anyhow};
+use colored::Colorize;
+use libfalcon::{NodeRef, Runner};
+use serde::Deserialize;
+use slog::info;
+use std::fs;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+
+const CRPD_CONTAINER: &str = "crpd1";
+const CARGO_BAY: &str = "cargo-bay";
+const LICENSE_PATH: &str = "falcon-juniper-license.key";
+
+#[derive(Copy, Clone)]
+pub struct JuniperNode(pub NodeRef);
+
+impl JuniperNode {
+    pub fn name(&self, d: &Runner) -> String {
+        d.get_node(self.0).name.clone()
+    }
+
+    pub fn linux(&self) -> LinuxNode {
+        LinuxNode(self.0)
+    }
+
+    async fn exec_step(
+        &self,
+        d: &Runner,
+        step: &str,
+        command: &str,
+    ) -> Result<String> {
+        d.exec(self.0, command)
+            .await
+            .with_context(|| format!("{step}: {command}"))
+    }
+
+    /// Freeze the cRPD container. BFD packets stop being processed without
+    /// tearing down committed config, so `unpause` restores the session.
+    pub async fn pause(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: pausing {CRPD_CONTAINER}", self.name(d));
+        self.exec_step(
+            d,
+            "pause Juniper cRPD container",
+            &format!("docker pause {CRPD_CONTAINER}"),
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn unpause(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: unpausing {CRPD_CONTAINER}", self.name(d));
+        self.exec_step(
+            d,
+            "unpause Juniper cRPD container",
+            &format!("docker unpause {CRPD_CONTAINER}"),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Stage non-secret topology config and verify that the runtime license is
+    /// present for the guest-side systemd services to consume.
+    pub async fn setup(&self, d: &Runner, routing_config: &str) -> Result<()> {
+        // Falcon-lab only stages files. The Junos image is expected to run
+        // guest-side systemd services that mount cargo-bay, install the
+        // license, and apply `<node>-junos.set`; see falcon-lab/README.md.
+        self.stage_routing_config(d, routing_config)?;
+        self.stage_license()?;
+        info!(
+            d.log,
+            "{}: staged Juniper config and license for guest systemd services",
+            self.name(d)
+        );
+        Ok(())
+    }
+
+    fn stage_routing_config(
+        &self,
+        d: &Runner,
+        routing_config: &str,
+    ) -> Result<PathBuf> {
+        let node_name = self.name(d);
+        let dir = Path::new(CARGO_BAY);
+        fs::create_dir_all(dir)
+            .with_context(|| format!("create {}", dir.display()))?;
+        let path = dir.join(format!("{node_name}-junos.set"));
+        let routing_config = routing_config
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&path, format!("configure\n{routing_config}\ncommit\n"))
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(path)
+    }
+
+    fn stage_license(&self) -> Result<PathBuf> {
+        let path = Path::new(CARGO_BAY).join(LICENSE_PATH);
+        let metadata = fs::metadata(&path).with_context(|| {
+            format!(
+                "Juniper license missing at {}; fetch it into cargo-bay before running falcon-lab",
+                path.display()
+            )
+        })?;
+        if !metadata.is_file() {
+            return Err(anyhow!(
+                "Juniper license path is not a file: {}",
+                path.display()
+            ));
+        }
+        Ok(path)
+    }
+
+    pub async fn shell(&self, d: &Runner, script: &str) -> Result<String> {
+        info!(
+            d.log,
+            "{}: executing juniper script {}",
+            self.name(d),
+            script.dimmed()
+        );
+        d.exec(
+            self.0,
+            &format!(
+                "docker exec {CRPD_CONTAINER} cli -c {}",
+                shell_quote(script)
+            ),
+        )
+        .await
+        .context("juniper cli failed")
+    }
+
+    /// Returns true iff Junos has installed `prefix` from BGP.
+    pub async fn bgp_route_imported(
+        &self,
+        d: &Runner,
+        prefix: &str,
+    ) -> Result<bool> {
+        let output = self
+            .shell(d, &format!("show route {prefix} protocol bgp"))
+            .await?;
+        Ok(output.contains(prefix) && output.contains("BGP"))
+    }
+
+    /// Query cRPD for the local status of a BFD session to `peer`. Returns
+    /// true iff Junos reports the session as `Up`.
+    pub async fn bfd_peer_up(&self, d: &Runner, peer: IpAddr) -> Result<bool> {
+        let output = self.shell(d, "show bfd session | display json").await?;
+        let resp: JunosBfdResponse = serde_json::from_str(&output)
+            .context("parse juniper bfd session json")?;
+        let peer = peer.to_string();
+        Ok(resp
+            .bfd_session_information
+            .into_iter()
+            .flat_map(|info| info.bfd_session)
+            .any(|session| session.is_up_for(&peer)))
+    }
+
+    /// Capture non-secret Juniper diagnostics. Do not add `show configuration`
+    /// directly or Junos/container logs here: the committed configuration
+    /// contains the license key, and logs may include secret-bearing
+    /// configuration activity.
+    pub async fn collect_diagnostics(&self, d: &Runner, topo: &str) {
+        let name = self.name(d);
+        const COMMANDS: [(&str, &str); 6] = [
+            ("docker-ps", "docker ps -a"),
+            ("docker-inspect", "docker inspect crpd1"),
+            (
+                "show-configuration-redacted",
+                "docker exec crpd1 cli -c 'show configuration | display set | no-more' \
+                    | sed -E 's/(set system license keys key ).*/\\1<redacted>/'",
+            ),
+            (
+                "show-version",
+                "docker exec crpd1 cli -c 'show version | no-more'",
+            ),
+            (
+                "show-interfaces-terse",
+                "docker exec crpd1 cli -c 'show interfaces terse | no-more'",
+            ),
+            (
+                "show-bgp-summary",
+                "docker exec crpd1 cli -c 'show bgp summary | no-more'",
+            ),
+        ];
+        for (suffix, command) in COMMANDS {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{name}-{suffix}"),
+                &format!("timeout 5s {command} || true"),
+            )
+            .await;
+        }
+        for (suffix, command) in [
+            (
+                "junos-apply-status",
+                "cat /run/falcon-junos-apply.status 2>/dev/null || true",
+            ),
+            (
+                "junos-apply-output",
+                "cat /var/run/juniper/falcon-lab/apply.out 2>/dev/null || true",
+            ),
+        ] {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{name}-{suffix}"),
+                command,
+            )
+            .await;
+        }
+        self.linux().collect_diagnostics(d, topo, &name).await;
+        self.linux()
+            .collect_container_diagnostics(d, topo, &name, CRPD_CONTAINER)
+            .await;
+    }
+
+    /// Capture cRPD setup diagnostics for boot failures. Keep these strictly
+    /// non-secret: do not collect generated config, setup transcripts, or logs
+    /// that may include the Juniper license.
+    pub async fn collect_boot_diagnostics(&self, d: &Runner, topo: &str) {
+        let name = self.name(d);
+        const COMMANDS: [(&str, &str); 4] = [
+            ("docker-ps", "docker ps -a"),
+            ("docker-inspect", "docker inspect crpd1"),
+            (
+                "show-version",
+                "timeout 5s docker exec crpd1 cli -c 'show version | no-more' || true",
+            ),
+            (
+                "show-interfaces-terse",
+                "timeout 5s docker exec crpd1 cli -c 'show interfaces terse | no-more' || true",
+            ),
+        ];
+        for (suffix, command) in COMMANDS {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{name}-{suffix}"),
+                command,
+            )
+            .await;
+        }
+        for (suffix, command) in [
+            (
+                "junos-apply-status",
+                "cat /run/falcon-junos-apply.status 2>/dev/null || true",
+            ),
+            (
+                "junos-apply-output",
+                "cat /var/run/juniper/falcon-lab/apply.out 2>/dev/null || true",
+            ),
+        ] {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{name}-{suffix}"),
+                command,
+            )
+            .await;
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct JunosBfdResponse {
+    #[serde(rename = "bfd-session-information", default)]
+    bfd_session_information: Vec<JunosBfdSessionInformation>,
+}
+
+#[derive(Deserialize)]
+struct JunosBfdSessionInformation {
+    #[serde(rename = "bfd-session", default)]
+    bfd_session: Vec<JunosBfdSession>,
+}
+
+#[derive(Deserialize)]
+struct JunosBfdSession {
+    #[serde(rename = "session-neighbor", default)]
+    session_neighbor: Vec<JunosData>,
+    #[serde(rename = "session-state", default)]
+    session_state: Vec<JunosData>,
+}
+
+impl JunosBfdSession {
+    fn is_up_for(&self, peer: &str) -> bool {
+        self.session_neighbor
+            .first()
+            .is_some_and(|neighbor| neighbor.data == peer)
+            && self
+                .session_state
+                .first()
+                .is_some_and(|state| state.data.eq_ignore_ascii_case("up"))
+    }
+}
+
+#[derive(Deserialize)]
+struct JunosData {
+    data: String,
+}
+
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}

--- a/falcon-lab/src/linux.rs
+++ b/falcon-lab/src/linux.rs
@@ -18,6 +18,58 @@ impl LinuxNode {
 
         Ok(ipaddr.addr_info.iter().map(|x| x.local).collect())
     }
+
+    /// Capture host-side Linux network state for container-backed routers.
+    pub async fn collect_diagnostics(
+        &self,
+        d: &Runner,
+        topo: &str,
+        node_name: &str,
+    ) {
+        for (suffix, cmd) in Self::diagnostic_commands() {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{node_name}-{suffix}"),
+                cmd,
+            )
+            .await;
+        }
+    }
+
+    /// Capture container-side Linux network state for container-backed routers.
+    ///
+    /// Each command is executed separately to keep command runtime bounded and
+    /// make timeout/failure diagnostics specific to a single snapshot.
+    pub async fn collect_container_diagnostics(
+        &self,
+        d: &Runner,
+        topo: &str,
+        node_name: &str,
+        container_name: &str,
+    ) {
+        for (suffix, cmd) in Self::diagnostic_commands() {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{node_name}-{container_name}-{suffix}"),
+                &format!("docker exec {container_name} {cmd}"),
+            )
+            .await;
+        }
+    }
+
+    fn diagnostic_commands() -> [(&'static str, &'static str); 5] {
+        [
+            ("ip-link", "ip -d -s link show"),
+            ("ip-addr", "ip -d -s addr show"),
+            ("ip-neigh", "ip -d -s neigh show"),
+            ("ip-nexthop", "ip -d -s nexthop show"),
+            ("ip-route", "ip -d -s route show table all"),
+        ]
+    }
 }
 
 #[derive(Deserialize)]

--- a/falcon-lab/src/main.rs
+++ b/falcon-lab/src/main.rs
@@ -2,7 +2,8 @@
 
 use crate::dendrite::NpuvmCommits;
 use crate::test::{
-    cleanup_bfd_static_test, cleanup_unnumbered_test, run_trio_bfd_static_test,
+    cleanup_bfd_static_test, cleanup_mgd_unnumbered_test,
+    cleanup_unnumbered_test, run_mgd_unnumbered_test, run_trio_bfd_static_test,
     run_trio_unnumbered_test,
 };
 use clap::{Parser, Subcommand};
@@ -64,6 +65,7 @@ struct Serial {
 
 #[derive(Debug, Subcommand)]
 enum TestCommand {
+    MgdUnnumbered,
     TrioUnnumbered,
     TrioBfdStaticRouting,
 }
@@ -82,6 +84,9 @@ async fn run() -> anyhow::Result<()> {
                 sidecar_lite: cmd.sidecar_lite_commit,
             };
             match cmd.command {
+                TestCommand::MgdUnnumbered => {
+                    run_mgd_unnumbered_test(cmd.no_cleanup).await?
+                }
                 TestCommand::TrioUnnumbered => {
                     run_trio_unnumbered_test(cmd.no_cleanup, commits).await?
                 }
@@ -91,6 +96,7 @@ async fn run() -> anyhow::Result<()> {
             }
         }
         Command::Cleanup(cmd) => match cmd.command {
+            TestCommand::MgdUnnumbered => cleanup_mgd_unnumbered_test().await?,
             TestCommand::TrioUnnumbered => cleanup_unnumbered_test().await?,
             TestCommand::TrioBfdStaticRouting => {
                 cleanup_bfd_static_test().await?

--- a/falcon-lab/src/main.rs
+++ b/falcon-lab/src/main.rs
@@ -2,9 +2,9 @@
 
 use crate::dendrite::NpuvmCommits;
 use crate::test::{
-    cleanup_bfd_static_test, cleanup_mgd_unnumbered_test,
-    cleanup_unnumbered_test, run_mgd_unnumbered_test, run_trio_bfd_static_test,
-    run_trio_unnumbered_test,
+    cleanup_mgd_unnumbered_test, cleanup_quartet_bfd_static_test,
+    cleanup_quartet_unnumbered_test, run_mgd_unnumbered_test,
+    run_quartet_bfd_static_test, run_quartet_unnumbered_test,
 };
 use clap::{Parser, Subcommand};
 
@@ -15,6 +15,7 @@ mod diagnostics;
 mod eos;
 mod frr;
 mod illumos;
+mod juniper;
 mod linux;
 mod mgd;
 mod test;
@@ -42,6 +43,9 @@ struct Run {
     #[clap(long)]
     no_cleanup: bool,
 
+    #[clap(long)]
+    no_diag_on_fail: bool,
+
     #[clap(long, default_value = "fd2c726815cdb03c2687e1bf2912a9184905557b")]
     npuvm_commit: String,
 
@@ -66,8 +70,8 @@ struct Serial {
 #[derive(Debug, Subcommand)]
 enum TestCommand {
     MgdUnnumbered,
-    TrioUnnumbered,
-    TrioBfdStaticRouting,
+    QuartetUnnumbered,
+    QuartetBfdStaticRouting,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -85,21 +89,37 @@ async fn run() -> anyhow::Result<()> {
             };
             match cmd.command {
                 TestCommand::MgdUnnumbered => {
-                    run_mgd_unnumbered_test(cmd.no_cleanup).await?
+                    run_mgd_unnumbered_test(
+                        cmd.no_cleanup,
+                        !cmd.no_diag_on_fail,
+                    )
+                    .await?
                 }
-                TestCommand::TrioUnnumbered => {
-                    run_trio_unnumbered_test(cmd.no_cleanup, commits).await?
+                TestCommand::QuartetUnnumbered => {
+                    run_quartet_unnumbered_test(
+                        cmd.no_cleanup,
+                        !cmd.no_diag_on_fail,
+                        commits,
+                    )
+                    .await?
                 }
-                TestCommand::TrioBfdStaticRouting => {
-                    run_trio_bfd_static_test(cmd.no_cleanup, commits).await?
+                TestCommand::QuartetBfdStaticRouting => {
+                    run_quartet_bfd_static_test(
+                        cmd.no_cleanup,
+                        !cmd.no_diag_on_fail,
+                        commits,
+                    )
+                    .await?
                 }
             }
         }
         Command::Cleanup(cmd) => match cmd.command {
             TestCommand::MgdUnnumbered => cleanup_mgd_unnumbered_test().await?,
-            TestCommand::TrioUnnumbered => cleanup_unnumbered_test().await?,
-            TestCommand::TrioBfdStaticRouting => {
-                cleanup_bfd_static_test().await?
+            TestCommand::QuartetUnnumbered => {
+                cleanup_quartet_unnumbered_test().await?
+            }
+            TestCommand::QuartetBfdStaticRouting => {
+                cleanup_quartet_bfd_static_test().await?
             }
         },
         Command::Serial(cmd) => {

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -8,7 +8,7 @@ use crate::{
     eos::EosNode,
     frr::FrrNode,
     mgd::{MgdNode, wait_for_mgd},
-    topo::{Trio, trio},
+    topo::{MgdDuo, Trio, mgd_duo, trio},
     wait_for_eq,
 };
 use anyhow::{Context, Result};
@@ -39,8 +39,15 @@ use std::{
 };
 
 const TRIO_UNNUMBERED_TOPO_NAME: &str = "mgtriou";
+const MGD_UNNUMBERED_TOPO_NAME: &str = "mgduou";
 const TRIO_BFD_STATIC_TOPO_NAME: &str = "mgtriobfd";
 const OP_TIMEOUT: Duration = Duration::from_secs(10);
+
+// The mgd-duo topology creates the direct test link before each node's
+// management link, so the peer-facing viona interface is vioif0 and the DHCP
+// management interface is vioif1.
+const MGD_DUO_PEER_LINK: &str = "vioif0";
+const MGD_DUO_MGMT_ADDR: &str = "vioif1/dhcp";
 
 // BFD-static test addressing. `OX_*` addresses are configured on the helios
 // side of each softnpu link; `CR*` addresses are configured on the peer.
@@ -84,6 +91,17 @@ struct BootedTrio {
     topo_name: String,
 }
 
+/// Output of `boot_mgd_duo`: two Helios nodes with mgd admin clients ready for
+/// test-specific configuration.
+struct BootedMgdDuo {
+    ad: Arc<Runner>,
+    ox1: MgdNode,
+    ox2: MgdNode,
+    mgd1: MgdClient,
+    mgd2: MgdClient,
+    topo_name: String,
+}
+
 /// Run a test body against a booted topology and dump diagnostics from every
 /// VM if it fails. The body consumes the `BootedTrio`, so cache the bits
 /// `collect_diagnostics` needs before handing it off.
@@ -103,6 +121,69 @@ where
         collect_diagnostics(&ad, ox, cr1, cr2, &topo_name).await;
     }
     result
+}
+
+/// Run a test body against a booted mgd-duo topology and dump diagnostics from
+/// both Helios nodes if it fails.
+async fn run_mgd_duo_with_diagnostics<F, Fut>(
+    bt: BootedMgdDuo,
+    body: F,
+) -> Result<()>
+where
+    F: FnOnce(BootedMgdDuo) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let ad = bt.ad.clone();
+    let ox1 = bt.ox1;
+    let ox2 = bt.ox2;
+    let topo_name = bt.topo_name.clone();
+    let result = body(bt).await;
+    if let Err(e) = &result {
+        warn!(ad.log, "{topo_name} failed: {e:#}");
+        collect_mgd_duo_diagnostics(&ad, ox1, ox2, &topo_name).await;
+    }
+    result
+}
+
+/// Launch two Helios nodes with a direct link between them and obtain mgd
+/// admin clients over their management links.
+async fn boot_mgd_duo(
+    topo_name: &str,
+    persistent: bool,
+) -> Result<BootedMgdDuo> {
+    let MgdDuo { mut d, ox1, ox2 } = mgd_duo(topo_name)?;
+    d.persistent = persistent;
+    d.launch().await.context("launch failed")?;
+    let ad = Arc::new(d);
+
+    let result = async {
+        let ox1_illumos = ox1.illumos();
+        let ox2_illumos = ox2.illumos();
+        let (mgmt1, mgmt2) = tokio::try_join!(
+            ox1_illumos.dhcp(&ad, MGD_DUO_MGMT_ADDR),
+            ox2_illumos.dhcp(&ad, MGD_DUO_MGMT_ADDR),
+        )?;
+        let mgd1 = ox1.client(&ad, mgmt1).await?;
+        let mgd2 = ox2.client(&ad, mgmt2).await?;
+
+        Ok((mgd1, mgd2))
+    }
+    .await;
+
+    match result {
+        Ok((mgd1, mgd2)) => Ok(BootedMgdDuo {
+            ad,
+            ox1,
+            ox2,
+            mgd1,
+            mgd2,
+            topo_name: topo_name.to_string(),
+        }),
+        Err(e) => {
+            collect_mgd_duo_diagnostics(&ad, ox1, ox2, topo_name).await;
+            Err(e)
+        }
+    }
 }
 
 /// Launch the trio topology and complete the work shared by every trio-based
@@ -199,9 +280,123 @@ where
 }
 
 pub async fn cleanup_unnumbered_test() -> Result<()> {
-    // dropping this with out persistent set will destroy
-    // the topo
-    let _topo = trio(TRIO_UNNUMBERED_TOPO_NAME)?;
+    cleanup_topology(TRIO_UNNUMBERED_TOPO_NAME, |name| trio(name).map(drop))
+}
+
+pub async fn cleanup_mgd_unnumbered_test() -> Result<()> {
+    cleanup_topology(MGD_UNNUMBERED_TOPO_NAME, |name| mgd_duo(name).map(drop))
+}
+
+fn cleanup_topology(
+    topo_name: &str,
+    cleanup: impl FnOnce(&str) -> Result<()>,
+) -> Result<()> {
+    cleanup(topo_name)
+}
+
+pub async fn run_mgd_unnumbered_test(persistent: bool) -> Result<()> {
+    let bt = boot_mgd_duo(MGD_UNNUMBERED_TOPO_NAME, persistent).await?;
+
+    run_mgd_duo_with_diagnostics(bt, mgd_unnumbered_body).await
+}
+
+async fn mgd_unnumbered_body(bt: BootedMgdDuo) -> Result<()> {
+    let BootedMgdDuo {
+        ad,
+        ox1,
+        ox2,
+        mgd1,
+        mgd2,
+        ..
+    } = bt;
+
+    for ox in [ox1, ox2] {
+        let addr = format!("{MGD_DUO_PEER_LINK}/ll");
+        ox.illumos()
+            .addrconf(&ad, &addr)
+            .await
+            .context(format!("create {addr}"))?;
+    }
+
+    tokio::try_join!(ox1.run_mgd(&ad), ox2.run_mgd(&ad))?;
+    tokio::try_join!(
+        wait_for_mgd(&mgd1, OP_TIMEOUT, &ad.log),
+        wait_for_mgd(&mgd2, OP_TIMEOUT, &ad.log),
+    )?;
+
+    const OX1_ASN: u32 = 33;
+    const OX2_ASN: u32 = 44;
+
+    info!(ad.log, "adding BGP routers to both mgd nodes");
+    let ox1_router = Router {
+        asn: OX1_ASN,
+        graceful_shutdown: false,
+        id: 33,
+        listen: "[::]:179".to_owned(),
+    };
+    let ox2_router = Router {
+        asn: OX2_ASN,
+        graceful_shutdown: false,
+        id: 44,
+        listen: "[::]:179".to_owned(),
+    };
+    tokio::try_join!(
+        mgd1.create_router(&ox1_router),
+        mgd2.create_router(&ox2_router),
+    )
+    .context("mgd: create routers")?;
+
+    info!(ad.log, "adding unnumbered BGP neighbors to both mgd nodes");
+    let ox1_neighbor = basic_unnumbered_neighbor(
+        "ox2",
+        "mgd-duo",
+        MGD_DUO_PEER_LINK,
+        OX1_ASN,
+        0,
+    );
+    let ox2_neighbor = basic_unnumbered_neighbor(
+        "ox1",
+        "mgd-duo",
+        MGD_DUO_PEER_LINK,
+        OX2_ASN,
+        0,
+    );
+    tokio::try_join!(
+        mgd1.create_unnumbered_neighbor(&ox1_neighbor),
+        mgd2.create_unnumbered_neighbor(&ox2_neighbor),
+    )
+    .context("mgd: create unnumbered neighbors")?;
+
+    wait_for_eq!(
+        mgd1.get_neighbors(OX1_ASN)
+            .await
+            .map(|x| x.into_inner().len())
+            .unwrap_or(0),
+        1,
+        "mgd1 neighbor count"
+    );
+    wait_for_eq!(
+        mgd2.get_neighbors(OX2_ASN)
+            .await
+            .map(|x| x.into_inner().len())
+            .unwrap_or(0),
+        1,
+        "mgd2 neighbor count"
+    );
+
+    wait_for_eq!(
+        neighbor_fsm_state(&mgd1, OX1_ASN, "ox2").await,
+        Some(FsmStateKind::Established),
+        "mgd1 bgp ox2 established"
+    );
+    wait_for_eq!(
+        neighbor_fsm_state(&mgd2, OX2_ASN, "ox1").await,
+        Some(FsmStateKind::Established),
+        "mgd2 bgp ox1 established"
+    );
+
+    info!(ad.log, "mgd-to-mgd bgp unnumbered test passed 🎉");
+
     Ok(())
 }
 
@@ -428,6 +623,21 @@ async fn collect_diagnostics(
     cr2.collect_diagnostics(d, topo_name).await;
 }
 
+/// Snapshot logs and live state from both Helios mgd peers in the mgd-duo
+/// topology.
+async fn collect_mgd_duo_diagnostics(
+    d: &Runner,
+    ox1: MgdNode,
+    ox2: MgdNode,
+    topo_name: &str,
+) {
+    warn!(d.log, "collecting diagnostics for {topo_name}");
+    for ox in [ox1, ox2] {
+        ox.illumos().collect_diagnostics(d, topo_name).await;
+        ox.collect_diagnostics(d, topo_name).await;
+    }
+}
+
 async fn frr_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
     const BASE_CONFIG: &str = "
         configure
@@ -495,9 +705,7 @@ async fn eos_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
 }
 
 pub async fn cleanup_bfd_static_test() -> Result<()> {
-    // dropping this without persistent set will destroy the topo
-    let _topo = trio(TRIO_BFD_STATIC_TOPO_NAME)?;
-    Ok(())
+    cleanup_topology(TRIO_BFD_STATIC_TOPO_NAME, |name| trio(name).map(drop))
 }
 
 pub async fn run_trio_bfd_static_test(

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -157,6 +157,10 @@ where
     let result = body(bt).await;
     if let Err(e) = &result {
         warn!(ad.log, "{topo_name} failed: {e:#}");
+        // Some failure tests intentionally suspend routing daemons to verify
+        // convergence. Resume them before diagnostics so collection can use
+        // each vendor's normal CLI/API path rather than timing out on the
+        // fault we injected.
         restore_quartet_before_diagnostics(&ad, cr1, cr2, cr3).await;
         if diag_on_fail {
             collect_diagnostics(&ad, ox, cr1, cr2, cr3, &topo_name, protocols)

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -5,9 +5,10 @@
 use crate::{
     bgp::basic_unnumbered_neighbor,
     dendrite::{NpuvmCommits, softnpu_link_create, wait_for_dpd},
+    diagnostics::ProtocolDiagnostics,
     eos::EosNode,
     frr::FrrNode,
-    juniper::JuniperNode,
+    juniper::{JuniperNode, clear_staged_routing_configs},
     mgd::{MgdNode, wait_for_mgd},
     topo::{MgdDuo, Quartet, mgd_duo, quartet},
     wait_for_eq,
@@ -101,6 +102,7 @@ struct BootedQuartet {
     #[allow(dead_code)]
     mgmt_addr: IpAddr,
     topo_name: String,
+    protocols: ProtocolDiagnostics,
 }
 
 #[derive(Copy, Clone)]
@@ -151,12 +153,14 @@ where
     let cr2 = bt.cr2;
     let cr3 = bt.cr3;
     let topo_name = bt.topo_name.clone();
+    let protocols = bt.protocols;
     let result = body(bt).await;
     if let Err(e) = &result {
         warn!(ad.log, "{topo_name} failed: {e:#}");
         restore_quartet_before_diagnostics(&ad, cr1, cr2, cr3).await;
         if diag_on_fail {
-            collect_diagnostics(&ad, ox, cr1, cr2, cr3, &topo_name).await;
+            collect_diagnostics(&ad, ox, cr1, cr2, cr3, &topo_name, protocols)
+                .await;
         }
     }
     result
@@ -272,6 +276,7 @@ async fn boot_quartet<F>(
     persistent: bool,
     diag_on_fail: bool,
     commits: NpuvmCommits,
+    protocols: ProtocolDiagnostics,
     spawn_peer_setups: F,
 ) -> Result<BootedQuartet>
 where
@@ -290,6 +295,7 @@ where
         cr3,
     } = quartet(topo_name)?;
     d.persistent = persistent;
+    clear_staged_routing_configs().context("clear stale Junos config")?;
     info!(d.log, "{topo_name}: launching quartet topology");
     timeout(LAUNCH_TIMEOUT, d.launch())
         .await
@@ -316,6 +322,7 @@ where
             dpd,
             mgmt_addr,
             topo_name: topo_name.to_string(),
+            protocols,
         }),
         Err(e) => {
             warn!(ad.log, "{topo_name} boot failed: {e:#}");
@@ -378,6 +385,7 @@ where
 }
 
 pub async fn cleanup_quartet_unnumbered_test() -> Result<()> {
+    clear_staged_routing_configs().context("clear stale Junos config")?;
     cleanup_topology(QUARTET_UNNUMBERED_TOPO_NAME, |name| {
         quartet(name).map(drop)
     })
@@ -515,6 +523,7 @@ pub async fn run_quartet_unnumbered_test(
         persistent,
         diag_on_fail,
         commits,
+        ProtocolDiagnostics::Bgp,
         |cr1, cr2, cr3, ad| {
             let mut js = tokio::task::JoinSet::new();
             let cr1_ad = ad.clone();
@@ -772,6 +781,7 @@ async fn collect_diagnostics(
     cr2: EosNode,
     cr3: JuniperNode,
     topo_name: &str,
+    protocols: ProtocolDiagnostics,
 ) {
     warn!(d.log, "collecting diagnostics for {topo_name}");
     // ox VM: illumos network state, plus each daemon's log via its lens.
@@ -780,9 +790,9 @@ async fn collect_diagnostics(
     ox.ddm().collect_diagnostics(d, topo_name).await;
     ox.collect_diagnostics(d, topo_name).await;
     // Peer routers.
-    cr1.collect_diagnostics(d, topo_name).await;
-    cr2.collect_diagnostics(d, topo_name).await;
-    cr3.collect_diagnostics(d, topo_name).await;
+    cr1.collect_diagnostics(d, topo_name, protocols).await;
+    cr2.collect_diagnostics(d, topo_name, protocols).await;
+    cr3.collect_diagnostics(d, topo_name, protocols).await;
 }
 
 /// Boot/setup failures happen before the topology is fully configured, so avoid
@@ -963,6 +973,7 @@ async fn juniper_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
 }
 
 pub async fn cleanup_quartet_bfd_static_test() -> Result<()> {
+    clear_staged_routing_configs().context("clear stale Junos config")?;
     cleanup_topology(QUARTET_BFD_STATIC_TOPO_NAME, |name| {
         quartet(name).map(drop)
     })
@@ -978,6 +989,7 @@ pub async fn run_quartet_bfd_static_test(
         persistent,
         diag_on_fail,
         commits,
+        ProtocolDiagnostics::Bfd,
         |cr1, cr2, cr3, ad| {
             let mut js = tokio::task::JoinSet::new();
             let cr1_ad = ad.clone();

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -7,8 +7,9 @@ use crate::{
     dendrite::{NpuvmCommits, softnpu_link_create, wait_for_dpd},
     eos::EosNode,
     frr::FrrNode,
+    juniper::JuniperNode,
     mgd::{MgdNode, wait_for_mgd},
-    topo::{MgdDuo, Trio, mgd_duo, trio},
+    topo::{MgdDuo, Quartet, mgd_duo, quartet},
     wait_for_eq,
 };
 use anyhow::{Context, Result};
@@ -37,11 +38,13 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tokio::time::timeout;
 
-const TRIO_UNNUMBERED_TOPO_NAME: &str = "mgtriou";
+const QUARTET_UNNUMBERED_TOPO_NAME: &str = "mgquartetu";
 const MGD_UNNUMBERED_TOPO_NAME: &str = "mgduou";
-const TRIO_BFD_STATIC_TOPO_NAME: &str = "mgtriobfd";
+const QUARTET_BFD_STATIC_TOPO_NAME: &str = "mgquartetbfd";
 const OP_TIMEOUT: Duration = Duration::from_secs(10);
+const LAUNCH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 // The mgd-duo topology creates the direct test link before each node's
 // management link, so the peer-facing viona interface is vioif0 and the DHCP
@@ -55,19 +58,27 @@ const OX_CR1_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 const CR1_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
 const OX_CR2_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 1);
 const CR2_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 2);
+const OX_CR3_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 1);
+const CR3_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 2);
 const OX_CR1_V4_CIDR: &str = "10.0.0.1/24";
 const OX_CR2_V4_CIDR: &str = "10.0.1.1/24";
+const OX_CR3_V4_CIDR: &str = "10.0.2.1/24";
 const CR1_V4_CIDR: &str = "10.0.0.2/24";
 const CR2_V4_CIDR: &str = "10.0.1.2/24";
+const CR3_V4_CIDR: &str = "10.0.2.2/24";
 
 const OX_CR1_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 1, 0, 0, 0, 0, 0, 1); // fd00:1::1
 const CR1_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 1, 0, 0, 0, 0, 0, 2); // fd00:1::2
 const OX_CR2_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 2, 0, 0, 0, 0, 0, 1); // fd00:2::1
 const CR2_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 2, 0, 0, 0, 0, 0, 2); // fd00:2::2
+const OX_CR3_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 3, 0, 0, 0, 0, 0, 1); // fd00:3::1
+const CR3_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 3, 0, 0, 0, 0, 0, 2); // fd00:3::2
 const OX_CR1_V6_CIDR: &str = "fd00:1::1/64";
 const OX_CR2_V6_CIDR: &str = "fd00:2::1/64";
+const OX_CR3_V6_CIDR: &str = "fd00:3::1/64";
 const CR1_V6_CIDR: &str = "fd00:1::2/64";
 const CR2_V6_CIDR: &str = "fd00:2::2/64";
+const CR3_V6_CIDR: &str = "fd00:3::2/64";
 
 /// Destination prefixes with nexthops via both cr1 and cr2.
 const TEST_PREFIX_V4: &str = "192.168.100.0/24";
@@ -77,18 +88,38 @@ const TEST_PREFIX_V6: &str = "fd01::/64";
 const BFD_REQUIRED_RX_US: u64 = 300_000;
 const BFD_DETECTION_MULT: u8 = 3;
 
-/// Output of `boot_trio`: the running topology plus clients ready for
+/// Output of `boot_quartet`: the running topology plus clients ready for
 /// test-specific configuration.
-struct BootedTrio {
+struct BootedQuartet {
     ad: Arc<Runner>,
     ox: MgdNode,
     cr1: FrrNode,
     cr2: EosNode,
+    cr3: JuniperNode,
     mgd: MgdClient,
     dpd: DpdClient,
     #[allow(dead_code)]
     mgmt_addr: IpAddr,
     topo_name: String,
+}
+
+#[derive(Copy, Clone)]
+struct QuartetNodes {
+    cr1: FrrNode,
+    cr2: EosNode,
+    cr3: JuniperNode,
+}
+
+struct QuartetPeerStates<T> {
+    cr1: T,
+    cr2: T,
+    cr3: T,
+}
+
+impl<T> QuartetPeerStates<T> {
+    fn new(cr1: T, cr2: T, cr3: T) -> Self {
+        Self { cr1, cr2, cr3 }
+    }
 }
 
 /// Output of `boot_mgd_duo`: two Helios nodes with mgd admin clients ready for
@@ -103,30 +134,68 @@ struct BootedMgdDuo {
 }
 
 /// Run a test body against a booted topology and dump diagnostics from every
-/// VM if it fails. The body consumes the `BootedTrio`, so cache the bits
+/// VM if it fails. The body consumes the `BootedQuartet`, so cache the bits
 /// `collect_diagnostics` needs before handing it off.
-async fn run_with_diagnostics<F, Fut>(bt: BootedTrio, body: F) -> Result<()>
+async fn run_with_optional_diagnostics<F, Fut>(
+    bt: BootedQuartet,
+    diag_on_fail: bool,
+    body: F,
+) -> Result<()>
 where
-    F: FnOnce(BootedTrio) -> Fut,
+    F: FnOnce(BootedQuartet) -> Fut,
     Fut: std::future::Future<Output = Result<()>>,
 {
     let ad = bt.ad.clone();
     let ox = bt.ox;
     let cr1 = bt.cr1;
     let cr2 = bt.cr2;
+    let cr3 = bt.cr3;
     let topo_name = bt.topo_name.clone();
     let result = body(bt).await;
     if let Err(e) = &result {
         warn!(ad.log, "{topo_name} failed: {e:#}");
-        collect_diagnostics(&ad, ox, cr1, cr2, &topo_name).await;
+        restore_quartet_before_diagnostics(&ad, cr1, cr2, cr3).await;
+        if diag_on_fail {
+            collect_diagnostics(&ad, ox, cr1, cr2, cr3, &topo_name).await;
+        }
     }
     result
 }
 
+async fn restore_quartet_before_diagnostics(
+    ad: &Runner,
+    cr1: FrrNode,
+    cr2: EosNode,
+    cr3: JuniperNode,
+) {
+    match timeout(OP_TIMEOUT, cr1.resume_bfdd(ad)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!(ad.log, "failed to resume cr1 before diagnostics: {e:#}")
+        }
+        Err(_) => warn!(ad.log, "timed out resuming cr1 before diagnostics"),
+    }
+    match timeout(OP_TIMEOUT, cr2.unpause(ad)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!(ad.log, "failed to unpause cr2 before diagnostics: {e:#}")
+        }
+        Err(_) => warn!(ad.log, "timed out unpausing cr2 before diagnostics"),
+    }
+    match timeout(OP_TIMEOUT, cr3.unpause(ad)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            warn!(ad.log, "failed to unpause cr3 before diagnostics: {e:#}")
+        }
+        Err(_) => warn!(ad.log, "timed out unpausing cr3 before diagnostics"),
+    }
+}
+
 /// Run a test body against a booted mgd-duo topology and dump diagnostics from
 /// both Helios nodes if it fails.
-async fn run_mgd_duo_with_diagnostics<F, Fut>(
+async fn run_mgd_duo_with_optional_diagnostics<F, Fut>(
     bt: BootedMgdDuo,
+    diag_on_fail: bool,
     body: F,
 ) -> Result<()>
 where
@@ -140,7 +209,9 @@ where
     let result = body(bt).await;
     if let Err(e) = &result {
         warn!(ad.log, "{topo_name} failed: {e:#}");
-        collect_mgd_duo_diagnostics(&ad, ox1, ox2, &topo_name).await;
+        if diag_on_fail {
+            collect_mgd_duo_diagnostics(&ad, ox1, ox2, &topo_name).await;
+        }
     }
     result
 }
@@ -150,6 +221,7 @@ where
 async fn boot_mgd_duo(
     topo_name: &str,
     persistent: bool,
+    diag_on_fail: bool,
 ) -> Result<BootedMgdDuo> {
     let MgdDuo { mut d, ox1, ox2 } = mgd_duo(topo_name)?;
     d.persistent = persistent;
@@ -180,69 +252,88 @@ async fn boot_mgd_duo(
             topo_name: topo_name.to_string(),
         }),
         Err(e) => {
-            collect_mgd_duo_diagnostics(&ad, ox1, ox2, topo_name).await;
+            warn!(ad.log, "{topo_name} boot failed: {e:#}");
+            if diag_on_fail {
+                collect_mgd_duo_boot_diagnostics(&ad, ox1, ox2, topo_name)
+                    .await;
+            }
             Err(e)
         }
     }
 }
 
-/// Launch the trio topology and complete the work shared by every trio-based
+/// Launch the quartet topology and complete the work shared by every quartet-based
 /// test: dhcp mgmt, concurrent peer install + npuvm setup, dpd startup,
 /// softnpu link creation, and tfport readiness. The caller supplies a closure
 /// that populates a `JoinSet` with per-peer setup futures so that they run
 /// concurrently with the npuvm install.
-async fn boot_trio<F>(
+async fn boot_quartet<F>(
     topo_name: &str,
     persistent: bool,
+    diag_on_fail: bool,
     commits: NpuvmCommits,
     spawn_peer_setups: F,
-) -> Result<BootedTrio>
+) -> Result<BootedQuartet>
 where
     F: FnOnce(
         FrrNode,
         EosNode,
+        JuniperNode,
         Arc<Runner>,
     ) -> tokio::task::JoinSet<Result<()>>,
 {
-    let Trio {
+    let Quartet {
         mut d,
         ox,
         cr1,
         cr2,
-    } = trio(topo_name)?;
+        cr3,
+    } = quartet(topo_name)?;
     d.persistent = persistent;
-    d.launch().await.context("launch failed")?;
+    info!(d.log, "{topo_name}: launching quartet topology");
+    timeout(LAUNCH_TIMEOUT, d.launch())
+        .await
+        .context("launch timed out")?
+        .context("launch failed")?;
+    info!(d.log, "{topo_name}: quartet topology launch complete");
     let ad = Arc::new(d);
 
     // Any failure between launch and Ok needs to dump diagnostics from the
     // running deployment. Wrap the rest of boot in a closure so we have a
     // single Err path to hook.
     let result =
-        boot_trio_inner(&ad, ox, cr1, cr2, commits, spawn_peer_setups).await;
+        boot_quartet_inner(&ad, ox, cr1, cr2, cr3, commits, spawn_peer_setups)
+            .await;
 
     match result {
-        Ok((mgd, dpd, mgmt_addr)) => Ok(BootedTrio {
+        Ok((mgd, dpd, mgmt_addr)) => Ok(BootedQuartet {
             ad,
             ox,
             cr1,
             cr2,
+            cr3,
             mgd,
             dpd,
             mgmt_addr,
             topo_name: topo_name.to_string(),
         }),
         Err(e) => {
-            collect_diagnostics(&ad, ox, cr1, cr2, topo_name).await;
+            warn!(ad.log, "{topo_name} boot failed: {e:#}");
+            if diag_on_fail {
+                collect_boot_diagnostics(&ad, ox, cr1, cr2, cr3, topo_name)
+                    .await;
+            }
             Err(e)
         }
     }
 }
 
-async fn boot_trio_inner<F>(
+async fn boot_quartet_inner<F>(
     ad: &Arc<Runner>,
     ox: MgdNode,
     cr1: FrrNode,
     cr2: EosNode,
+    cr3: JuniperNode,
     commits: NpuvmCommits,
     spawn_peer_setups: F,
 ) -> Result<(MgdClient, DpdClient, IpAddr)>
@@ -250,13 +341,20 @@ where
     F: FnOnce(
         FrrNode,
         EosNode,
+        JuniperNode,
         Arc<Runner>,
     ) -> tokio::task::JoinSet<Result<()>>,
 {
     let mgmt_addr = ox.illumos().dhcp(ad, "vioif1/dhcp").await?;
 
-    let mut js = spawn_peer_setups(cr1, cr2, ad.clone());
-    js.spawn(ox.dendrite().npuvm(ad.clone(), 2, 0, commits));
+    let mut js = spawn_peer_setups(cr1, cr2, cr3, ad.clone());
+    let npuvm_ad = ad.clone();
+    js.spawn(async move {
+        ox.dendrite()
+            .npuvm(npuvm_ad, 3, 0, commits)
+            .await
+            .context("setup ox npuvm")
+    });
     for result in js.join_all().await.into_iter() {
         result?;
     }
@@ -267,20 +365,22 @@ where
         .await
         .context("wait_for_dpd")?;
 
-    for link in ["qsfp0", "qsfp1"] {
+    for link in ["qsfp0", "qsfp1", "qsfp2"] {
         softnpu_link_create(&dpd, link)
             .await
             .context(format!("create {link}"))?;
     }
-    for link in ["tfportqsfp0_0", "tfportqsfp1_0"] {
+    for link in ["tfportqsfp0_0", "tfportqsfp1_0", "tfportqsfp2_0"] {
         ox.illumos().wait_for_link(ad, link, OP_TIMEOUT).await?;
     }
 
     Ok((mgd, dpd, mgmt_addr))
 }
 
-pub async fn cleanup_unnumbered_test() -> Result<()> {
-    cleanup_topology(TRIO_UNNUMBERED_TOPO_NAME, |name| trio(name).map(drop))
+pub async fn cleanup_quartet_unnumbered_test() -> Result<()> {
+    cleanup_topology(QUARTET_UNNUMBERED_TOPO_NAME, |name| {
+        quartet(name).map(drop)
+    })
 }
 
 pub async fn cleanup_mgd_unnumbered_test() -> Result<()> {
@@ -294,10 +394,15 @@ fn cleanup_topology(
     cleanup(topo_name)
 }
 
-pub async fn run_mgd_unnumbered_test(persistent: bool) -> Result<()> {
-    let bt = boot_mgd_duo(MGD_UNNUMBERED_TOPO_NAME, persistent).await?;
+pub async fn run_mgd_unnumbered_test(
+    persistent: bool,
+    diag_on_fail: bool,
+) -> Result<()> {
+    let bt = boot_mgd_duo(MGD_UNNUMBERED_TOPO_NAME, persistent, diag_on_fail)
+        .await?;
 
-    run_mgd_duo_with_diagnostics(bt, mgd_unnumbered_body).await
+    run_mgd_duo_with_optional_diagnostics(bt, diag_on_fail, mgd_unnumbered_body)
+        .await
 }
 
 async fn mgd_unnumbered_body(bt: BootedMgdDuo) -> Result<()> {
@@ -400,38 +505,55 @@ async fn mgd_unnumbered_body(bt: BootedMgdDuo) -> Result<()> {
     Ok(())
 }
 
-pub async fn run_trio_unnumbered_test(
+pub async fn run_quartet_unnumbered_test(
     persistent: bool,
+    diag_on_fail: bool,
     commits: NpuvmCommits,
 ) -> Result<()> {
-    let bt = boot_trio(
-        TRIO_UNNUMBERED_TOPO_NAME,
+    let bt = boot_quartet(
+        QUARTET_UNNUMBERED_TOPO_NAME,
         persistent,
+        diag_on_fail,
         commits,
-        |cr1, cr2, ad| {
+        |cr1, cr2, cr3, ad| {
             let mut js = tokio::task::JoinSet::new();
-            js.spawn(frr_setup(cr1, ad.clone()));
-            js.spawn(eos_setup(cr2, ad.clone()));
+            let cr1_ad = ad.clone();
+            let cr2_ad = ad.clone();
+            let cr3_ad = ad;
+            js.spawn(async move {
+                frr_setup(cr1, cr1_ad).await.context("setup cr1 frr")
+            });
+            js.spawn(async move {
+                eos_setup(cr2, cr2_ad).await.context("setup cr2 eos")
+            });
+            js.spawn(async move {
+                juniper_setup(cr3, cr3_ad)
+                    .await
+                    .context("setup cr3 juniper")
+            });
             js
         },
     )
     .await?;
 
-    run_with_diagnostics(bt, trio_unnumbered_body).await
+    run_with_optional_diagnostics(bt, diag_on_fail, quartet_unnumbered_body)
+        .await
 }
 
-async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
-    let BootedTrio {
+async fn quartet_unnumbered_body(bt: BootedQuartet) -> Result<()> {
+    let BootedQuartet {
         ad,
         ox,
         cr1,
         cr2,
+        cr3,
         mgd,
         dpd,
         ..
     } = bt;
+    let peers = QuartetNodes { cr1, cr2, cr3 };
 
-    for link in ["tfportqsfp0_0", "tfportqsfp1_0"] {
+    for link in ["tfportqsfp0_0", "tfportqsfp1_0", "tfportqsfp2_0"] {
         let addr = format!("{link}/ll");
         ox.illumos()
             .addrconf(&ad, &addr)
@@ -443,10 +565,10 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
     ox.ddm().run_ddm(&ad).await?;
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
-    // Fanout of 2 so both peer paths survive best-path selection and we can
+    // Fanout of 3 so all peer paths survive best-path selection and we can
     // validate ECMP in loc_rib and dpd.
     mgd.update_bestpath_fanout(&BestpathFanoutRequest {
-        fanout: std::num::NonZeroU8::new(2).expect("fanout > 0"),
+        fanout: std::num::NonZeroU8::new(3).expect("fanout > 0"),
     })
     .await
     .context("mgd: set bestpath fanout")?;
@@ -484,6 +606,16 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
     .await
     .context("mgd: create cr2 unnumbered neighbor")?;
 
+    mgd.create_unnumbered_neighbor(&basic_unnumbered_neighbor(
+        "cr3",
+        "test",
+        "tfportqsfp2_0",
+        33,
+        1800,
+    ))
+    .await
+    .context("mgd: create cr3 unnumbered neighbor")?;
+
     mgd.create_origin4(&Origin4 {
         asn: 33,
         prefixes: vec!["4.5.6.0/24".parse().expect("parse ipv4 origin")],
@@ -509,54 +641,56 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
             .await
             .map(|x| x.into_inner().len())
             .unwrap_or(0),
-        2,
+        3,
         "mgd neighbor count"
     );
 
-    for name in ["cr1", "cr2"] {
-        let desc = format!("mgd bgp {name} established");
-        wait_for_eq!(
-            neighbor_fsm_state(&mgd, local_asn, name).await,
-            Some(FsmStateKind::Established),
-            &desc
-        );
-    }
+    expect_bgp_neighbor_states(
+        &mgd,
+        local_asn,
+        QuartetPeerStates::new(
+            FsmStateKind::Established,
+            FsmStateKind::Established,
+            FsmStateKind::Established,
+        ),
+    )
+    .await?;
 
-    // Both peers advertise the same prefix, so mgd should see a single
-    // imported entry per family with two paths, and — with fanout=2 — the
-    // same two paths should survive into the selected (loc) RIB.
+    // All peers advertise the same prefix, so mgd should see a single
+    // imported entry per family with three paths, and — with fanout=3 — the
+    // same three paths should survive into the selected (loc) RIB.
     wait_for_eq!(
         mgd_imported_paths(&mgd, AddressFamily::Ipv4, CR_V4_PREFIX).await,
-        Some(2),
+        Some(3),
         "mgd imported paths for 1.2.3.0/24"
     );
     wait_for_eq!(
         mgd_imported_paths(&mgd, AddressFamily::Ipv6, CR_V6_PREFIX).await,
-        Some(2),
+        Some(3),
         "mgd imported paths for fd99::/64"
     );
     wait_for_eq!(
         mgd_selected_paths(&mgd, AddressFamily::Ipv4, CR_V4_PREFIX).await,
-        Some(2),
+        Some(3),
         "mgd selected paths for 1.2.3.0/24"
     );
     wait_for_eq!(
         mgd_selected_paths(&mgd, AddressFamily::Ipv6, CR_V6_PREFIX).await,
-        Some(2),
+        Some(3),
         "mgd selected paths for fd99::/64"
     );
 
-    // dpd should have the specific prefixes, each with two ECMP targets.
+    // dpd should have the specific prefixes, each with three ECMP targets.
     let cr_v4: Ipv4Net = CR_V4_PREFIX.parse().expect("parse cr v4 prefix");
     let cr_v6: Ipv6Net = CR_V6_PREFIX.parse().expect("parse cr v6 prefix");
     wait_for_eq!(
         dpd_v4_targets(&dpd, &cr_v4).await.len(),
-        2,
+        3,
         "dpd ipv4 targets for 1.2.3.0/24"
     );
     wait_for_eq!(
         dpd_v6_targets(&dpd, &cr_v6).await.len(),
-        2,
+        3,
         "dpd ipv6 targets for fd99::/64"
     );
 
@@ -564,7 +698,9 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
     let ox_v4: Ipv4Net = OX_V4_ORIGIN.parse().expect("parse ox v4 origin");
     let ox_v6: Ipv6Net = OX_V6_ORIGIN.parse().expect("parse ox v6 origin");
     wait_for_eq!(
-        cr1.bgp_ipv4_imported(&ad)
+        peers
+            .cr1
+            .bgp_ipv4_imported(&ad)
             .await
             .map(|r| r.all().any(|(p, _)| *p == ox_v4))
             .unwrap_or(false),
@@ -572,7 +708,9 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
         "cr1 imported 4.5.6.0/24"
     );
     wait_for_eq!(
-        cr1.bgp_ipv6_imported(&ad)
+        peers
+            .cr1
+            .bgp_ipv6_imported(&ad)
             .await
             .map(|r| r.all().any(|(p, _)| *p == ox_v6))
             .unwrap_or(false),
@@ -580,7 +718,9 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
         "cr1 imported fdee::/64"
     );
     wait_for_eq!(
-        cr2.bgp_ipv4_imported(&ad)
+        peers
+            .cr2
+            .bgp_ipv4_imported(&ad)
             .await
             .map(|r| r.all().any(|(p, _)| *p == ox_v4))
             .unwrap_or(false),
@@ -588,20 +728,40 @@ async fn trio_unnumbered_body(bt: BootedTrio) -> Result<()> {
         "cr2 imported 4.5.6.0/24"
     );
     wait_for_eq!(
-        cr2.bgp_ipv6_imported(&ad)
+        peers
+            .cr2
+            .bgp_ipv6_imported(&ad)
             .await
             .map(|r| r.all().any(|(p, _)| *p == ox_v6))
             .unwrap_or(false),
         true,
         "cr2 imported fdee::/64"
     );
+    wait_for_eq!(
+        peers
+            .cr3
+            .bgp_route_imported(&ad, OX_V4_ORIGIN)
+            .await
+            .unwrap_or(false),
+        true,
+        "cr3 imported 4.5.6.0/24"
+    );
+    wait_for_eq!(
+        peers
+            .cr3
+            .bgp_route_imported(&ad, OX_V6_ORIGIN)
+            .await
+            .unwrap_or(false),
+        true,
+        "cr3 imported fdee::/64"
+    );
 
-    info!(ad.log, "trio bgp unnumbered test passed 🎉");
+    info!(ad.log, "quartet bgp unnumbered test passed 🎉");
 
     Ok(())
 }
 
-/// Snapshot logs and live state from every VM in the trio into `/work/` so
+/// Snapshot logs and live state from every VM in the quartet into `/work/` so
 /// a failed run preserves the evidence past deployment teardown. The actual
 /// per-daemon and per-peer collection lives on each node type's
 /// `collect_diagnostics` method; this function is just the composition.
@@ -610,6 +770,7 @@ async fn collect_diagnostics(
     ox: MgdNode,
     cr1: FrrNode,
     cr2: EosNode,
+    cr3: JuniperNode,
     topo_name: &str,
 ) {
     warn!(d.log, "collecting diagnostics for {topo_name}");
@@ -621,6 +782,53 @@ async fn collect_diagnostics(
     // Peer routers.
     cr1.collect_diagnostics(d, topo_name).await;
     cr2.collect_diagnostics(d, topo_name).await;
+    cr3.collect_diagnostics(d, topo_name).await;
+}
+
+/// Boot/setup failures happen before the topology is fully configured, so avoid
+/// network-state snapshots (`ip*`, `ipadm`, routes, neighbors). Collect only
+/// lightweight service/container state that explains which setup task failed.
+async fn collect_boot_diagnostics(
+    d: &Runner,
+    ox: MgdNode,
+    cr1: FrrNode,
+    cr2: EosNode,
+    cr3: JuniperNode,
+    topo_name: &str,
+) {
+    warn!(d.log, "collecting boot diagnostics for {topo_name}");
+    crate::diagnostics::capture(d, ox.0, topo_name, "ox-svcs-xv", "svcs -xv")
+        .await;
+    ox.dendrite().collect_diagnostics(d, topo_name).await;
+
+    crate::diagnostics::capture(
+        d,
+        cr1.0,
+        topo_name,
+        "cr1-frr-status",
+        "systemctl status frr --no-pager || true",
+    )
+    .await;
+    crate::diagnostics::capture(
+        d,
+        cr1.0,
+        topo_name,
+        "cr1-frr-journal",
+        "journalctl -u frr --no-pager -n 200 || true",
+    )
+    .await;
+
+    for (label, cmd) in [
+        ("cr2-docker-ps", "docker ps -a"),
+        (
+            "cr2-docker-logs",
+            "timeout 5s docker logs --tail 500 ceos || true",
+        ),
+    ] {
+        crate::diagnostics::capture(d, cr2.0, topo_name, label, cmd).await;
+    }
+
+    cr3.collect_boot_diagnostics(d, topo_name).await;
 }
 
 /// Snapshot logs and live state from both Helios mgd peers in the mgd-duo
@@ -635,6 +843,28 @@ async fn collect_mgd_duo_diagnostics(
     for ox in [ox1, ox2] {
         ox.illumos().collect_diagnostics(d, topo_name).await;
         ox.collect_diagnostics(d, topo_name).await;
+    }
+}
+
+/// Boot/setup diagnostics for the mgd-duo topology, intentionally excluding
+/// network snapshots because address/link setup may be the part that failed.
+async fn collect_mgd_duo_boot_diagnostics(
+    d: &Runner,
+    ox1: MgdNode,
+    ox2: MgdNode,
+    topo_name: &str,
+) {
+    warn!(d.log, "collecting boot diagnostics for {topo_name}");
+    for ox in [ox1, ox2] {
+        let name = d.get_node(ox.0).name.clone();
+        crate::diagnostics::capture(
+            d,
+            ox.0,
+            topo_name,
+            &format!("{name}-svcs-xv"),
+            "svcs -xv",
+        )
+        .await;
     }
 }
 
@@ -704,40 +934,91 @@ async fn eos_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
     Ok(())
 }
 
-pub async fn cleanup_bfd_static_test() -> Result<()> {
-    cleanup_topology(TRIO_BFD_STATIC_TOPO_NAME, |name| trio(name).map(drop))
+async fn juniper_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
+    info!(d.log, "{}: starting juniper unnumbered setup", r.name(&d));
+    const BASE_CONFIG: &str = "
+        set interfaces eth1 unit 0 family inet
+        set interfaces eth1 unit 0 family inet6
+        set protocols router-advertisement interface eth1
+        set routing-options router-id 1.2.3.2
+        set routing-options autonomous-system 46
+        set routing-options static route 1.2.3.0/24 discard
+        set routing-options rib inet6.0 static route fd99::/64 discard
+        set policy-options policy-statement expo term announce4 from route-filter 1.2.3.0/24 exact
+        set policy-options policy-statement expo term announce4 then accept
+        set policy-options policy-statement expo term announce6 from route-filter fd99::/64 exact
+        set policy-options policy-statement expo term announce6 then accept
+        set policy-options policy-statement expo then reject
+        set protocols bgp group unnumbered type external
+        set protocols bgp group unnumbered family inet unicast extended-nexthop
+        set protocols bgp group unnumbered family inet6 unicast
+        set protocols bgp group unnumbered peer-as 33
+        set protocols bgp group unnumbered export expo
+        set protocols bgp group unnumbered dynamic-neighbor bgp_unnumbered peer-auto-discovery family inet6 ipv6-nd
+        set protocols bgp group unnumbered dynamic-neighbor bgp_unnumbered peer-auto-discovery interface eth1
+    ";
+
+    r.setup(&d, BASE_CONFIG).await?;
+    Ok(())
 }
 
-pub async fn run_trio_bfd_static_test(
+pub async fn cleanup_quartet_bfd_static_test() -> Result<()> {
+    cleanup_topology(QUARTET_BFD_STATIC_TOPO_NAME, |name| {
+        quartet(name).map(drop)
+    })
+}
+
+pub async fn run_quartet_bfd_static_test(
     persistent: bool,
+    diag_on_fail: bool,
     commits: NpuvmCommits,
 ) -> Result<()> {
-    let bt = boot_trio(
-        TRIO_BFD_STATIC_TOPO_NAME,
+    let bt = boot_quartet(
+        QUARTET_BFD_STATIC_TOPO_NAME,
         persistent,
+        diag_on_fail,
         commits,
-        |cr1, cr2, ad| {
+        |cr1, cr2, cr3, ad| {
             let mut js = tokio::task::JoinSet::new();
-            js.spawn(frr_bfd_setup(cr1, ad.clone()));
-            js.spawn(eos_bfd_setup(cr2, ad.clone()));
+            let cr1_ad = ad.clone();
+            let cr2_ad = ad.clone();
+            let cr3_ad = ad;
+            js.spawn(async move {
+                frr_bfd_setup(cr1, cr1_ad)
+                    .await
+                    .context("setup cr1 frr bfd")
+            });
+            js.spawn(async move {
+                eos_bfd_setup(cr2, cr2_ad)
+                    .await
+                    .context("setup cr2 eos bfd")
+            });
+            js.spawn(async move {
+                juniper_bfd_setup(cr3, cr3_ad)
+                    .await
+                    .context("setup cr3 juniper bfd")
+            });
             js
         },
     )
     .await?;
 
-    run_with_diagnostics(bt, trio_bfd_static_body).await
+    run_with_optional_diagnostics(bt, diag_on_fail, quartet_bfd_static_body)
+        .await
 }
 
-async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
-    let BootedTrio {
+async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
+    let BootedQuartet {
         ad,
         ox,
         cr1,
         cr2,
+        cr3,
         mgd,
         dpd,
         ..
     } = bt;
+    let peers = QuartetNodes { cr1, cr2, cr3 };
 
     // Register each ox-side address with dpd so softnpu punts packets for
     // those destinations to the CPU port. Link-local v6 is handled
@@ -747,6 +1028,7 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
     for (qsfp, v4, v6) in [
         ("qsfp0", OX_CR1_V4, OX_CR1_V6),
         ("qsfp1", OX_CR2_V4, OX_CR2_V6),
+        ("qsfp2", OX_CR3_V4, OX_CR3_V6),
     ] {
         let port = PortId::Qsfp(qsfp.parse().expect("parse qsfp port"));
         let link = LinkId(0);
@@ -782,6 +1064,7 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
     for (link, v4_cidr, v6_cidr) in [
         ("tfportqsfp0_0", OX_CR1_V4_CIDR, OX_CR1_V6_CIDR),
         ("tfportqsfp1_0", OX_CR2_V4_CIDR, OX_CR2_V6_CIDR),
+        ("tfportqsfp2_0", OX_CR3_V4_CIDR, OX_CR3_V6_CIDR),
     ] {
         let ll = format!("{link}/ll");
         ox.illumos()
@@ -804,11 +1087,11 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
     ox.ddm().run_ddm(&ad).await?;
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
-    // Default fanout is 1, which collapses the two static paths into a single
-    // selected nexthop. Bump to 2 so both paths propagate through best-path
+    // Default fanout is 1, which collapses the static paths into a single
+    // selected nexthop. Bump to 3 so all paths propagate through best-path
     // selection and land in dpd as ECMP.
     mgd.update_bestpath_fanout(&BestpathFanoutRequest {
-        fanout: std::num::NonZeroU8::new(2).expect("fanout > 0"),
+        fanout: std::num::NonZeroU8::new(3).expect("fanout > 0"),
     })
     .await
     .context("mgd: set bestpath fanout")?;
@@ -821,7 +1104,7 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
     info!(ad.log, "installing static v4 route {TEST_PREFIX_V4}");
     mgd.static_add_v4_route(&AddStaticRoute4Request {
         routes: StaticRoute4List {
-            list: [CR1_V4, CR2_V4]
+            list: [CR1_V4, CR2_V4, CR3_V4]
                 .into_iter()
                 .map(|nh| StaticRoute4 {
                     prefix: prefix_v4,
@@ -838,7 +1121,7 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
     info!(ad.log, "installing static v6 route {TEST_PREFIX_V6}");
     mgd.static_add_v6_route(&AddStaticRoute6Request {
         routes: StaticRoute6List {
-            list: [CR1_V6, CR2_V6]
+            list: [CR1_V6, CR2_V6, CR3_V6]
                 .into_iter()
                 .map(|nh| StaticRoute6 {
                     prefix: prefix_v6,
@@ -852,12 +1135,17 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
     .await
     .context("mgd: add v6 static route")?;
 
-    info!(ad.log, "adding BFD peers for cr1 and cr2 (dual-stack)");
+    info!(
+        ad.log,
+        "adding BFD peers for cr1, cr2, and cr3 (dual-stack)"
+    );
     for (peer, listen) in [
         (IpAddr::V4(CR1_V4), IpAddr::V4(OX_CR1_V4)),
         (IpAddr::V4(CR2_V4), IpAddr::V4(OX_CR2_V4)),
+        (IpAddr::V4(CR3_V4), IpAddr::V4(OX_CR3_V4)),
         (IpAddr::V6(CR1_V6), IpAddr::V6(OX_CR1_V6)),
         (IpAddr::V6(CR2_V6), IpAddr::V6(OX_CR2_V6)),
+        (IpAddr::V6(CR3_V6), IpAddr::V6(OX_CR3_V6)),
     ] {
         mgd.add_bfd_peer(&BfdPeerConfig {
             peer,
@@ -872,32 +1160,52 @@ async fn trio_bfd_static_body(bt: BootedTrio) -> Result<()> {
 
     use BfdPeerState::{Down, Up};
 
-    info!(ad.log, "phase 1: both peers up");
-    expect_bfd(&mgd, cr1, cr2, &ad, Up, Up).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, "phase 1").await?;
+    info!(ad.log, "phase 1: all peers up");
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Up, Up)).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 1")
+        .await?;
 
     info!(ad.log, "phase 2: pause bfdd on cr1");
     cr1.pause_bfdd(&ad).await?;
-    expect_bfd(&mgd, cr1, cr2, &ad, Down, Up).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, false, true, "phase 2").await?;
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Up, Up)).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, false, true, true, "phase 2")
+        .await?;
 
     info!(ad.log, "phase 3: pause ceos on cr2");
     cr2.pause(&ad).await?;
-    expect_bfd(&mgd, cr1, cr2, &ad, Down, Down).await?;
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Down, Up))
+        .await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, false, false, true, "phase 3")
+        .await?;
+
+    info!(ad.log, "phase 4: pause cRPD on cr3");
+    cr3.pause(&ad).await?;
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Down, Down))
+        .await?;
     // With every nexthop shutdown, all shutdown nexthops are reinstated.
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, "phase 3").await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 4")
+        .await?;
 
-    info!(ad.log, "phase 4: resume bfdd on cr1");
+    info!(ad.log, "phase 5: resume bfdd on cr1");
     cr1.resume_bfdd(&ad).await?;
-    expect_bfd(&mgd, cr1, cr2, &ad, Up, Down).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, false, "phase 4").await?;
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Down, Down))
+        .await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, false, false, "phase 5")
+        .await?;
 
-    info!(ad.log, "phase 5: unpause ceos on cr2");
+    info!(ad.log, "phase 6: unpause ceos on cr2");
     cr2.unpause(&ad).await?;
-    expect_bfd(&mgd, cr1, cr2, &ad, Up, Up).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, "phase 5").await?;
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Up, Down)).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, false, "phase 6")
+        .await?;
 
-    info!(ad.log, "trio bfd static routing test passed 🎉");
+    info!(ad.log, "phase 7: unpause cRPD on cr3");
+    cr3.unpause(&ad).await?;
+    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Up, Up)).await?;
+    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 7")
+        .await?;
+
+    info!(ad.log, "quartet bfd static routing test passed 🎉");
 
     Ok(())
 }
@@ -978,6 +1286,40 @@ async fn eos_bfd_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
     Ok(())
 }
 
+async fn juniper_bfd_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
+    info!(d.log, "{}: starting juniper bfd setup", r.name(&d));
+    // Address the softnpu-facing link (v4 + v6) and install dummy
+    // BFD-tracked static routes whose nexthops are the ox side of the link.
+    // Junos creates BFD sessions for those nexthops; mgd creates matching
+    // sessions toward the Junos addresses in the test body. Disable Junos BFD
+    // timer adaptation for now: mgd has known RFC 5880 timer-negotiation bugs
+    // (oxidecomputer/maghemite#798), and Junos adaptive backoff can otherwise
+    // make this interop test flap.
+    let rx_ms = BFD_REQUIRED_RX_US / 1000;
+    let config = format!(
+        "
+        set interfaces eth1 unit 0 family inet address {cr_v4_cidr}
+        set interfaces eth1 unit 0 family inet6 address {cr_v6_cidr}
+        set routing-options static route 100.65.0.0/24 next-hop {ox_v4}
+        set routing-options static route 100.65.0.0/24 bfd-liveness-detection minimum-interval {rx_ms}
+        set routing-options static route 100.65.0.0/24 bfd-liveness-detection multiplier {mult}
+        set routing-options static route 100.65.0.0/24 bfd-liveness-detection no-adaptation
+        set routing-options rib inet6.0 static route 3ffe::/64 next-hop {ox_v6}
+        set routing-options rib inet6.0 static route 3ffe::/64 bfd-liveness-detection minimum-interval {rx_ms}
+        set routing-options rib inet6.0 static route 3ffe::/64 bfd-liveness-detection multiplier {mult}
+        set routing-options rib inet6.0 static route 3ffe::/64 bfd-liveness-detection no-adaptation
+        ",
+        cr_v4_cidr = CR3_V4_CIDR,
+        cr_v6_cidr = CR3_V6_CIDR,
+        ox_v4 = OX_CR3_V4,
+        ox_v6 = OX_CR3_V6,
+        mult = BFD_DETECTION_MULT,
+    );
+
+    r.setup(&d, &config).await?;
+    Ok(())
+}
+
 /// Expect a scalar BFD state per peer. Since failure injection targets the
 /// peer daemon as a whole, the v4 and v6 sessions to a given peer always
 /// share the same state.
@@ -987,37 +1329,47 @@ async fn eos_bfd_setup(r: EosNode, d: Arc<Runner>) -> Result<()> {
 /// `Down` phases have no observable peer-side truth.
 async fn expect_bfd(
     mgd: &MgdClient,
-    cr1: FrrNode,
-    cr2: EosNode,
+    peers: QuartetNodes,
     d: &Runner,
-    cr1_state: BfdPeerState,
-    cr2_state: BfdPeerState,
+    states: QuartetPeerStates<BfdPeerState>,
 ) -> Result<()> {
     for (peer, want) in [
-        (IpAddr::V4(CR1_V4), cr1_state),
-        (IpAddr::V6(CR1_V6), cr1_state),
-        (IpAddr::V4(CR2_V4), cr2_state),
-        (IpAddr::V6(CR2_V6), cr2_state),
+        (IpAddr::V4(CR1_V4), states.cr1),
+        (IpAddr::V6(CR1_V6), states.cr1),
+        (IpAddr::V4(CR2_V4), states.cr2),
+        (IpAddr::V6(CR2_V6), states.cr2),
+        (IpAddr::V4(CR3_V4), states.cr3),
+        (IpAddr::V6(CR3_V6), states.cr3),
     ] {
         let desc = format!("mgd bfd {peer} -> {want:?}");
         wait_for_eq!(bfd_state(mgd, peer).await, Some(want), &desc);
     }
 
-    if matches!(cr1_state, BfdPeerState::Up) {
+    if matches!(states.cr1, BfdPeerState::Up) {
         for peer in [IpAddr::V4(OX_CR1_V4), IpAddr::V6(OX_CR1_V6)] {
             let desc = format!("cr1 bfd {peer} -> Up");
             wait_for_eq!(
-                cr1.bfd_peer_up(d, peer).await.unwrap_or(false),
+                peers.cr1.bfd_peer_up(d, peer).await.unwrap_or(false),
                 true,
                 &desc
             );
         }
     }
-    if matches!(cr2_state, BfdPeerState::Up) {
+    if matches!(states.cr2, BfdPeerState::Up) {
         for peer in [IpAddr::V4(OX_CR2_V4), IpAddr::V6(OX_CR2_V6)] {
             let desc = format!("cr2 bfd {peer} -> Up");
             wait_for_eq!(
-                cr2.bfd_peer_up(d, peer).await.unwrap_or(false),
+                peers.cr2.bfd_peer_up(d, peer).await.unwrap_or(false),
+                true,
+                &desc
+            );
+        }
+    }
+    if matches!(states.cr3, BfdPeerState::Up) {
+        for peer in [IpAddr::V4(OX_CR3_V4), IpAddr::V6(OX_CR3_V6)] {
+            let desc = format!("cr3 bfd {peer} -> Up");
+            wait_for_eq!(
+                peers.cr3.bfd_peer_up(d, peer).await.unwrap_or(false),
                 true,
                 &desc
             );
@@ -1034,6 +1386,7 @@ async fn expect_route(
     prefix_v6: &Ipv6Net,
     cr1_in: bool,
     cr2_in: bool,
+    cr3_in: bool,
     phase: &str,
 ) -> Result<()> {
     // Push cr1 before cr2 so the list is already in the sorted order that
@@ -1047,6 +1400,10 @@ async fn expect_route(
     if cr2_in {
         want_v4.push(IpAddr::V4(CR2_V4));
         want_v6.push(IpAddr::V6(CR2_V6));
+    }
+    if cr3_in {
+        want_v4.push(IpAddr::V4(CR3_V4));
+        want_v6.push(IpAddr::V6(CR3_V6));
     }
 
     let desc_v4 = format!("{phase} v4");
@@ -1070,6 +1427,26 @@ async fn bfd_state(mgd: &MgdClient, peer: IpAddr) -> Option<BfdPeerState> {
         .into_iter()
         .find(|p| p.config.peer == peer)
         .map(|p| p.state)
+}
+
+async fn expect_bgp_neighbor_states(
+    mgd: &MgdClient,
+    local_asn: u32,
+    states: QuartetPeerStates<FsmStateKind>,
+) -> Result<()> {
+    for (name, want) in [
+        ("cr1", states.cr1),
+        ("cr2", states.cr2),
+        ("cr3", states.cr3),
+    ] {
+        let desc = format!("mgd bgp {name} -> {want:?}");
+        wait_for_eq!(
+            neighbor_fsm_state(mgd, local_asn, name).await,
+            Some(want),
+            &desc
+        );
+    }
+    Ok(())
 }
 
 /// Look up the FSM state of the neighbor with the given `name`. The

--- a/falcon-lab/src/topo.rs
+++ b/falcon-lab/src/topo.rs
@@ -5,11 +5,38 @@ use libfalcon::{Runner, node, unit::gb};
 
 use crate::{eos::EosNode, frr::FrrNode, mgd::MgdNode};
 
+pub struct MgdDuo {
+    pub d: Runner,
+    pub ox1: MgdNode,
+    pub ox2: MgdNode,
+}
+
 pub struct Trio {
     pub d: Runner,
     pub ox: MgdNode,
     pub cr1: FrrNode,
     pub cr2: EosNode,
+}
+
+pub fn mgd_duo(name: &str) -> Result<MgdDuo> {
+    let mut d = Runner::new(name);
+
+    node!(d, ox1, "helios-3.0", 4, gb(4));
+    node!(d, ox2, "helios-3.0", 4, gb(4));
+
+    d.link(ox1, ox2);
+
+    d.default_ext_link(ox1)?;
+    d.default_ext_link(ox2)?;
+
+    d.mount("cargo-bay", "/opt/cargo-bay", ox1)?;
+    d.mount("cargo-bay", "/opt/cargo-bay", ox2)?;
+
+    Ok(MgdDuo {
+        d,
+        ox1: MgdNode(ox1),
+        ox2: MgdNode(ox2),
+    })
 }
 
 pub fn trio(name: &str) -> Result<Trio> {

--- a/falcon-lab/src/topo.rs
+++ b/falcon-lab/src/topo.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use libfalcon::{Runner, node, unit::gb};
 
-use crate::{eos::EosNode, frr::FrrNode, mgd::MgdNode};
+use crate::{eos::EosNode, frr::FrrNode, juniper::JuniperNode, mgd::MgdNode};
 
 pub struct MgdDuo {
     pub d: Runner,
@@ -11,11 +11,12 @@ pub struct MgdDuo {
     pub ox2: MgdNode,
 }
 
-pub struct Trio {
+pub struct Quartet {
     pub d: Runner,
     pub ox: MgdNode,
     pub cr1: FrrNode,
     pub cr2: EosNode,
+    pub cr3: JuniperNode,
 }
 
 pub fn mgd_duo(name: &str) -> Result<MgdDuo> {
@@ -39,13 +40,14 @@ pub fn mgd_duo(name: &str) -> Result<MgdDuo> {
     })
 }
 
-pub fn trio(name: &str) -> Result<Trio> {
+pub fn quartet(name: &str) -> Result<Quartet> {
     let mut d = Runner::new(name);
 
     // nodes
     node!(d, ox, "helios-3.0", 4, gb(4));
     node!(d, cr1, "debian-13.2", 4, gb(4));
     node!(d, cr2, "eos-4.35", 4, gb(4));
+    node!(d, cr3, "junos-23.2", 4, gb(4));
 
     // links
     let mut mac_counter = 0;
@@ -56,19 +58,27 @@ pub fn trio(name: &str) -> Result<Trio> {
 
     d.softnpu_link(ox, cr1, Some(new_mac()), None);
     d.softnpu_link(ox, cr2, Some(new_mac()), None);
+    d.softnpu_link(ox, cr3, Some(new_mac()), None);
 
     d.default_ext_link(ox)?;
     d.default_ext_link(cr1)?;
     d.default_ext_link(cr2)?;
+    d.default_ext_link(cr3)?;
 
     d.mount("cargo-bay", "/opt/cargo-bay", ox)?;
-    d.mount("cargo-bay", "/opt/cargo-bay", cr1)?;
+    d.mount_linux("cargo-bay", "/opt/cargo-bay", cr1)?;
     d.mount("cargo-bay", "/opt/cargo-bay", cr2)?;
+    d.mount_linux("cargo-bay", "/opt/cargo-bay", cr3)?;
+    // The Junos image mounts cargo-bay and applies staged configuration from
+    // guest-side systemd services. Keep the 9p device in the spec, but avoid
+    // Falcon's serial-driven setup/mount path for this node.
+    d.do_setup(cr3, false);
 
-    Ok(Trio {
+    Ok(Quartet {
         d,
         ox: MgdNode(ox),
         cr1: FrrNode(cr1),
         cr2: EosNode(cr2),
+        cr3: JuniperNode(cr3),
     })
 }

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -64,8 +64,12 @@ use std::sync::{
 use std::time::{Duration, Instant, SystemTime};
 
 const UNIT_BGP: &str = "bgp";
-const DEFAULT_BGP_LISTEN: SocketAddr =
-    SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, BGP_PORT, 0, 0));
+const DEFAULT_BGP_LISTEN: SocketAddr = SocketAddr::V6(SocketAddrV6::new(
+    Ipv6Addr::UNSPECIFIED,
+    BGP_PORT.get(),
+    0,
+    0,
+));
 
 #[derive(Clone)]
 pub struct BgpContext {
@@ -335,9 +339,9 @@ pub async fn read_neighbor(
                 asn: result.asn,
                 name: result.name,
                 group: result.group,
-                host: std::net::SocketAddr::new(
-                    std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
-                    179,
+                host: SocketAddr::new(
+                    IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                    BGP_PORT.get(),
                 )
                 .into(),
                 parameters: result.parameters,
@@ -2159,12 +2163,8 @@ pub(crate) mod helpers {
         let info = SessionInfo::from(&rq.parameters);
 
         // XXX: remove this when PeerConfig no longer requires a SocketAddr
-        let placeholder_host = std::net::SocketAddrV6::new(
-            std::net::Ipv6Addr::UNSPECIFIED,
-            BGP_PORT,
-            0,
-            0,
-        );
+        let placeholder_host =
+            SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, BGP_PORT.get(), 0, 0);
 
         let start_session = if ensure {
             match get_router!(&ctx, rq.asn)?.ensure_unnumbered_session(
@@ -2644,6 +2644,7 @@ mod tests {
     use crate::{
         admin::HandlerContext, bfd_admin::BfdContext, bgp_admin::BgpContext,
     };
+    use bgp::BGP_PORT;
     use bgp::router::SessionMap;
     use client_common::println_nopipe;
     use mg_api_types_versions::v1::bgp::config::{
@@ -2697,7 +2698,10 @@ mod tests {
         peers.insert(
             String::from("qsfp0"),
             vec![BgpPeerConfig {
-                host: SocketAddr::new("203.0.113.1".parse().unwrap(), 179),
+                host: SocketAddr::new(
+                    "203.0.113.1".parse().unwrap(),
+                    BGP_PORT.get(),
+                ),
                 name: String::from("bob"),
                 parameters: BgpPeerParameters {
                     hold_time: 3,
@@ -2725,7 +2729,10 @@ mod tests {
         peers.insert(
             String::from("qsfp1"),
             vec![BgpPeerConfig {
-                host: SocketAddr::new("203.0.113.2".parse().unwrap(), 179),
+                host: SocketAddr::new(
+                    "203.0.113.2".parse().unwrap(),
+                    BGP_PORT.get(),
+                ),
                 name: String::from("alice"),
                 parameters: BgpPeerParameters {
                     hold_time: 3,

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -84,7 +84,7 @@ impl BgpContext {
         log: Logger,
     ) -> Self {
         let router = Arc::new(Mutex::new(BTreeMap::new()));
-        let unnumbered_manager = UnnumberedManagerNdp::new(router.clone(), log);
+        let unnumbered_manager = UnnumberedManagerNdp::new(log);
         Self {
             router,
             sessions,
@@ -1967,6 +1967,7 @@ pub(crate) mod helpers {
                 event_tx.clone(),
                 event_rx,
                 info,
+                None,
             )? {
                 EnsureSessionResult::New(_) => true,
                 EnsureSessionResult::Updated(_) => false,
@@ -1978,6 +1979,7 @@ pub(crate) mod helpers {
                 event_tx.clone(),
                 event_rx,
                 info,
+                None,
             )?;
             true
         };
@@ -2056,6 +2058,7 @@ pub(crate) mod helpers {
                 event_tx.clone(),
                 event_rx,
                 info,
+                None,
             )? {
                 EnsureSessionResult::New(_) => true,
                 EnsureSessionResult::Updated(_) => false,
@@ -2067,6 +2070,7 @@ pub(crate) mod helpers {
                 event_tx.clone(),
                 event_rx,
                 info,
+                None,
             )?;
             true
         };
@@ -2162,32 +2166,26 @@ pub(crate) mod helpers {
         let (event_tx, event_rx) = channel();
         let info = SessionInfo::from(&rq.parameters);
 
-        // XXX: remove this when PeerConfig no longer requires a SocketAddr
-        let placeholder_host =
-            SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, BGP_PORT.get(), 0, 0);
-
         let start_session = if ensure {
-            match get_router!(&ctx, rq.asn)?.ensure_unnumbered_session(
-                rq.interface.clone(),
-                PeerConfig::from_unnumbered_neighbor(&rq, placeholder_host),
+            match get_router!(&ctx, rq.asn)?.ensure_session(
+                PeerConfig::from_unnumbered_neighbor(&rq),
                 None,
                 event_tx.clone(),
                 event_rx,
                 info,
-                ctx.bgp.unnumbered_manager.clone(),
+                Some(ctx.bgp.unnumbered_manager.clone()),
             )? {
                 EnsureSessionResult::New(_) => true,
                 EnsureSessionResult::Updated(_) => false,
             }
         } else {
-            get_router!(&ctx, rq.asn)?.new_unnumbered_session(
-                rq.interface.clone(),
-                PeerConfig::from_unnumbered_neighbor(&rq, placeholder_host),
+            get_router!(&ctx, rq.asn)?.new_session(
+                PeerConfig::from_unnumbered_neighbor(&rq),
                 None,
                 event_tx.clone(),
                 event_rx,
                 info,
-                ctx.bgp.unnumbered_manager.clone(),
+                Some(ctx.bgp.unnumbered_manager.clone()),
             )?;
             true
         };
@@ -2379,13 +2377,9 @@ pub(crate) mod helpers {
             "op" => format!("{op:?}")
         );
 
-        let session = ctx
-            .bgp
-            .unnumbered_manager
-            .get_neighbor_session(asn, interface)?
-            .ok_or(Error::NotFound(
-                "session for unnumbered neighbor not found".into(),
-            ))?;
+        let session = get_router!(ctx, asn)?.get_session(interface).ok_or(
+            Error::NotFound("session for unnumbered neighbor not found".into()),
+        )?;
 
         reset_session(&session, op)?;
         Ok(HttpResponseUpdatedNoContent())

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -2161,7 +2161,7 @@ pub(crate) mod helpers {
         // XXX: remove this when PeerConfig no longer requires a SocketAddr
         let placeholder_host = std::net::SocketAddrV6::new(
             std::net::Ipv6Addr::UNSPECIFIED,
-            0,
+            BGP_PORT,
             0,
             0,
         );

--- a/mgd/src/unnumbered_manager.rs
+++ b/mgd/src/unnumbered_manager.rs
@@ -2,19 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use bgp::{
-    connection_tcp::BgpConnectionTcp,
-    router::Router,
-    session::SessionRunner,
-    unnumbered::{NdpNeighbor, ScopeMap},
-};
+use bgp::unnumbered::{NdpNeighbor, ScopeMap};
 use mg_common::lock;
 use mg_common::thread::ManagedThread;
 use ndp::{Ipv6NetworkInterface, NdpManager, NewInterfaceNdpManagerError};
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use slog::{Logger, o, warn};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     net::{IpAddr, Ipv6Addr, SocketAddr},
     sync::{
         Arc, Condvar, Mutex,
@@ -36,7 +31,6 @@ struct PendingInterfaceConfig {
 }
 
 pub struct UnnumberedManagerNdp {
-    routers: Arc<Mutex<BTreeMap<u32, Arc<Router<BgpConnectionTcp>>>>>,
     ndp_mgr: Arc<NdpManager>,
     /// Bidirectional scope_id ↔ interface name mapping for Dispatcher routing
     interface_scope_map: Mutex<ScopeMap>,
@@ -84,10 +78,7 @@ pub enum AddNeighborError {
 }
 
 impl UnnumberedManagerNdp {
-    pub fn new(
-        routers: Arc<Mutex<BTreeMap<u32, Arc<Router<BgpConnectionTcp>>>>>,
-        log: Logger,
-    ) -> Arc<Self> {
+    pub fn new(log: Logger) -> Arc<Self> {
         let log = log.new(o!(
             "component" => crate::COMPONENT_MGD,
             "unit" => crate::UNIT_DAEMON,
@@ -100,7 +91,6 @@ impl UnnumberedManagerNdp {
         let dropped = monitor_thread.dropped_flag();
 
         let manager = Arc::new(Self {
-            routers,
             interface_scope_map: Mutex::new(ScopeMap::new()),
             ndp_mgr: NdpManager::new(log.clone()),
             log,
@@ -432,22 +422,6 @@ impl UnnumberedManagerNdp {
         );
 
         Ok(())
-    }
-
-    pub fn get_neighbor_session(
-        self: &Arc<Self>,
-        asn: u32,
-        interface: impl AsRef<str>,
-    ) -> Result<
-        Option<Arc<SessionRunner<BgpConnectionTcp>>>,
-        ResolveNeighborError,
-    > {
-        if let Some(rtr) = lock!(self.routers).get(&asn)
-            && let Some(session) = rtr.get_session(interface.as_ref())
-        {
-            return Ok(Some(session));
-        };
-        Ok(None)
     }
 
     // =========================================================================


### PR DESCRIPTION
Fixes the use of a zero port in the bgp unnumbered placeholder SocketAddr by replacing it with `BGP_PORT`.
Moves BGP_PORT from u16 to NonZeroU16 in anticipation of the configurable value becoming a NonZeroU16.
Proactively adds the use of `IPV6_BOUND_IF` (Illumos) / `SO_BINDTOIFINDEX` (Linux) to BgpConnections to avoid issues with packets showing up on the wrong socket.
Unifies un/numbered *session codepaths to reduce code duplication.

Fixes: #782