### PR TITLE
Fix router solicitation parsing issue

### DIFF
--- a/.github/buildomat/jobs/test-ndp.sh
+++ b/.github/buildomat/jobs/test-ndp.sh
@@ -15,7 +15,4 @@ set -e
 
 source .github/buildomat/test-common.sh
 
-pushd rdb
 cargo nextest run -p ndp
-cp ./*.log /work/
-popd

--- a/.github/buildomat/jobs/test-ndp.sh
+++ b/.github/buildomat/jobs/test-ndp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#:
+#: name = "test-ndp"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "/work/*.log",
+#:   "/tmp/*.db",
+#: ]
+#:
+
+set -x
+set -e
+
+source .github/buildomat/test-common.sh
+
+pushd rdb
+cargo nextest run -p ndp
+cp ./*.log /work/
+popd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,7 +3295,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 [[package]]
 name = "ispf"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/ispf#f78443a98397f7818b1e7a487dbb7d5cad625496"
+source = "git+https://github.com/oxidecomputer/ispf#2e04bbfe8547b95e92f0dcdd85e08efb974eda0a"
 dependencies = [
  "serde",
 ]

--- a/ndp/src/manager.rs
+++ b/ndp/src/manager.rs
@@ -437,7 +437,7 @@ mod test {
 
     #[test]
     fn router_solicitation_with_link_layer_addr() {
-        // Attempt to parse a anICMPv6 router solicitation with a link-layer
+        // Attempt to parse an ICMPv6 router solicitation with a link-layer
         // address as a router advertisement. This should produce an error. It
         // should not successfully parse, and it should not panic.
         //

--- a/ndp/src/manager.rs
+++ b/ndp/src/manager.rs
@@ -430,3 +430,60 @@ pub struct InterfaceAdvertisementInfo {
     /// Thread state for rx/tx loops (None if interface not active)
     pub thread_state: Option<InterfaceThreadState>,
 }
+
+#[cfg(test)]
+mod test {
+    use crate::packet::{Icmp6RouterAdvertisement, Icmp6RouterSolicitation};
+
+    #[test]
+    fn router_solicitation_with_link_layer_addr() {
+        // Attempt to parse a anICMPv6 router solicitation with a link-layer
+        // address as a router advertisement. This should produce an error. It
+        // should not successfully parse, and it should not panic.
+        //
+        //     0                   1                   2                   3
+        //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |     Type      |     Code      |          Checksum             |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                            Reserved                           |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |     Type      |    Length     |    Link-Layer Address ...
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //           .... Link-Layer address                               |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+        let data: [u8; 16] = [
+            133, 0, 11, 22, // type, code checksum
+            0, 0, 0, 0, // reserved
+            1, 1, 0xab, 0xbb, // Link layer addr
+            0xcc, 0xdd, 0xee, 0xff,
+        ];
+
+        if Icmp6RouterAdvertisement::from_wire(&data).is_ok() {
+            panic!("expected error")
+        }
+        Icmp6RouterSolicitation::from_wire(&data).expect("parsed solicitation");
+    }
+
+    #[test]
+    fn minimum_router_solicitation() {
+        // Attempt to parse a minimal ICMPv6 router solicitation as a
+        // router advertisement. This should produce an error. It should not
+        // successfully parse, and it should not panic.
+        //
+        //     0                   1                   2                   3
+        //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |     Type      |     Code      |          Checksum             |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                            Reserved                           |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+        let data: [u8; 8] = [133, 0, 11, 22, 0, 0, 0, 0];
+        if Icmp6RouterAdvertisement::from_wire(&data).is_ok() {
+            panic!("expected error")
+        }
+        Icmp6RouterSolicitation::from_wire(&data).expect("parsed solicitation");
+    }
+}

--- a/ndp/src/manager.rs
+++ b/ndp/src/manager.rs
@@ -460,9 +460,8 @@ mod test {
             0xcc, 0xdd, 0xee, 0xff,
         ];
 
-        if Icmp6RouterAdvertisement::from_wire(&data).is_ok() {
-            panic!("expected error")
-        }
+        Icmp6RouterAdvertisement::from_wire(&data)
+            .expect_err("RS should not parse as RA");
         Icmp6RouterSolicitation::from_wire(&data).expect("parsed solicitation");
     }
 
@@ -481,9 +480,38 @@ mod test {
         // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
         let data: [u8; 8] = [133, 0, 11, 22, 0, 0, 0, 0];
-        if Icmp6RouterAdvertisement::from_wire(&data).is_ok() {
-            panic!("expected error")
-        }
+        Icmp6RouterAdvertisement::from_wire(&data)
+            .expect_err("RS should not parse as RA");
         Icmp6RouterSolicitation::from_wire(&data).expect("parsed solicitation");
+    }
+
+    #[test]
+    fn minimum_router_advertisement() {
+        // Attempt to parse a minimal ICMPv6 router advertisement as a
+        // router solicitation. This should produce an error. It should not
+        // successfully parse, and it should not panic.
+        //
+        //     0                   1                   2                   3
+        //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |     Type      |     Code      |          Checksum             |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // | Cur Hop Limit |M|O|  Reserved |       Router Lifetime         |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                         Reachable Time                        |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        // |                          Retrans Timer                        |
+        // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+        let data: [u8; 16] = [
+            134, 0, 11, 22, // type, code, checksum
+            255, 0, 0, 30, // hop limit, flags, lifetime
+            0, 0, 0, 0, // reachable time
+            0, 0, 0, 0, // retrans timer
+        ];
+        Icmp6RouterSolicitation::from_wire(&data)
+            .expect_err("RA should not parse as RS");
+        Icmp6RouterAdvertisement::from_wire(&data)
+            .expect("parsed advertisement");
     }
 }


### PR DESCRIPTION
The following code attempts to parse an ICMPv6 message first as an ICMPv6 router advertisement and then as an ICMPv6 router solicitation.

https://github.com/oxidecomputer/maghemite/blob/2f90f709dd9916ad145c919871a9efc1c6e17887/ndp/src/manager.rs#L292-L307

Router solicitations can be 8 bytes when they don't have a link-layer address in the payload. This causes a buffer overrun in ISPF versions prior to oxidecomputer/ispf#4.

This PR

1. Adds test to reproduce this issue. See run failure [here](https://github.com/oxidecomputer/maghemite/pull/797/checks?check_run_id=82015467364)
2. Squashes the bug by updating ISPF.