### PR TITLE
buildomat: disable build-interop

### DIFF
--- a/.github/buildomat/jobs/build-dhcp-server.sh
+++ b/.github/buildomat/jobs/build-dhcp-server.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 #:
-#: name = "build-interop"
+#: name = "build-dhcp-server"
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: skip_clone = true
-#:
-#: enable = false
-#:
-#: access_repos = [
-#:   "oxidecomputer/testbed",
-#: ]
 #: output_rules = [
-#:   "=/work/testbed.tar.gz",
 #:   "=/work/dhcp-server",
 #: ]
 
@@ -36,38 +29,6 @@ fi
 
 cargo --version
 rustc --version
-
-banner 'clone'
-mkdir -p "${WORK}/ci"
-git clone https://github.com/oxidecomputer/testbed "${WORK}/ci/testbed"
-
-banner 'build'
-cd "${WORK}/ci/testbed"
-cargo build \
-    -p interop-lab \
-    -p wrangler
-cargo build --tests
-
-banner 'prep'
-
-mkdir -p out
-cp target/debug/{interop,wrangler} out/
-# grab just the file ending in the hash, not the file ending in ".d"
-TEST=$(find target/debug/deps -maxdepth 1 -type f -name 'baseline-*' -exec ls -t {} + | grep -v -E '.*\.d$' | head -1)
-mv "${TEST}" 'out/baseline'
-
-banner 'archive'
-
-cd "${WORK}/ci"
-cat <<EOF > exclude-file.txt
-testbed/.git
-testbed/a4x2
-testbed/archive
-testbed/target
-EOF
-tar cvzXf exclude-file.txt \
-    "${WORK}/testbed.tar.gz" \
-    testbed
 
 banner 'dhcp-server'
 

--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -8,8 +8,8 @@
 #:   "/work/*",
 #: ]
 #:
-#: [dependencies.build-interop]
-#: job = "build-interop"
+#: [dependencies.build-dhcp-server]
+#: job = "build-dhcp-server"
 #:
 #: [dependencies.build]
 #: job = "build"
@@ -43,7 +43,7 @@ export FALCON_DATASET="cpool/falcon"
 
 banner 'setup'
 
-cp /input/build-interop/work/dhcp-server .
+cp /input/build-dhcp-server/work/dhcp-server .
 cp /input/build/work/release/falcon-lab .
 cp /input/build/work/release/mgd .
 cp /input/build/work/release/ddmd .


### PR DESCRIPTION
If we're not going run test-interop, then why run build-interop? This is all moving over to falcon-lab anyway.