### PR TITLE
falcon-lab: make bfd tests stable with juniper present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "anyhow",
  "bgp",
  "clap",
+ "client-common",
  "colored",
  "ddm-admin-client",
  "dpd-client",

--- a/falcon-lab/Cargo.toml
+++ b/falcon-lab/Cargo.toml
@@ -19,3 +19,4 @@ oxide-tokio-rt.workspace = true
 bgp.workspace = true
 colored.workspace = true
 mg-api-types.workspace = true
+client-common.workspace = true

--- a/falcon-lab/config/cr1-bfd-frr.conf
+++ b/falcon-lab/config/cr1-bfd-frr.conf
@@ -1,0 +1,28 @@
+frr version 10.3
+frr defaults traditional
+hostname cr1
+log syslog informational
+service integrated-vtysh-config
+!
+interface enp0s8
+ ip address 10.0.0.2/24
+ ipv6 address fd00:1::2/64
+ no shutdown
+exit
+!
+bfd
+ peer 10.0.0.1 local-address 10.0.0.2
+  detect-multiplier 3
+  receive-interval 1000
+  transmit-interval 1000
+  no shutdown
+ exit
+ peer fd00:1::1 local-address fd00:1::2
+  detect-multiplier 3
+  receive-interval 1000
+  transmit-interval 1000
+  no shutdown
+ exit
+exit
+!
+end

--- a/falcon-lab/src/frr.rs
+++ b/falcon-lab/src/frr.rs
@@ -10,9 +10,13 @@ use oxnet::{Ipv4Net, Ipv6Net};
 use serde::Deserialize;
 use slog::info;
 use std::collections::HashMap;
+use std::fs;
 use std::net::IpAddr;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::time::sleep;
+
+const CARGO_BAY: &str = "cargo-bay";
 
 #[derive(Copy, Clone)]
 pub struct FrrNode(pub NodeRef);
@@ -63,6 +67,37 @@ impl FrrNode {
         d.exec(self.0, "systemctl start frr").await?;
         // XXX do better than arbitrary wait
         sleep(Duration::from_secs(5)).await;
+        Ok(())
+    }
+
+    pub fn stage_config(
+        &self,
+        config_name: &str,
+        config: &str,
+    ) -> Result<PathBuf> {
+        let dir = Path::new(CARGO_BAY);
+        fs::create_dir_all(dir)
+            .with_context(|| format!("create {}", dir.display()))?;
+        let path = dir.join(config_name);
+        fs::write(&path, config)
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(path)
+    }
+
+    pub async fn install_staged_config(
+        &self,
+        d: &Runner,
+        config_name: &str,
+    ) -> Result<()> {
+        info!(d.log, "{}: installing frr startup config", self.name(d));
+        d.exec(
+            self.0,
+            &format!(
+                "cp /opt/cargo-bay/{config_name} /etc/frr/frr.conf && chown frr:frrvty /etc/frr/frr.conf && chmod 640 /etc/frr/frr.conf"
+            ),
+        )
+        .await
+        .context("install frr startup config")?;
         Ok(())
     }
 

--- a/falcon-lab/src/frr.rs
+++ b/falcon-lab/src/frr.rs
@@ -35,9 +35,8 @@ impl FrrNode {
             )
             .await?;
         }
-        d.exec(self.0, "systemctl restart frr").await?;
-        // XXX do better than arbitrary wait
-        sleep(Duration::from_secs(5)).await;
+        self.stop_frr(d).await?;
+        self.start_frr(d).await?;
         Ok(())
     }
 
@@ -53,18 +52,17 @@ impl FrrNode {
         LinuxNode(self.0)
     }
 
-    /// Freeze the BFD daemon. Control packets stop flowing without disturbing
-    /// the peer's configuration or interfaces, so `resume_bfdd` restores the
-    /// session without reapplying config.
-    pub async fn pause_bfdd(&self, d: &Runner) -> Result<()> {
-        info!(d.log, "{}: pausing frr bfdd", self.name(d));
-        d.exec(self.0, "pkill -STOP bfdd").await?;
+    pub async fn stop_frr(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: stopping frr", self.name(d));
+        d.exec(self.0, "systemctl stop frr").await?;
         Ok(())
     }
 
-    pub async fn resume_bfdd(&self, d: &Runner) -> Result<()> {
-        info!(d.log, "{}: resuming frr bfdd", self.name(d));
-        d.exec(self.0, "pkill -CONT bfdd").await?;
+    pub async fn start_frr(&self, d: &Runner) -> Result<()> {
+        info!(d.log, "{}: starting frr", self.name(d));
+        d.exec(self.0, "systemctl start frr").await?;
+        // XXX do better than arbitrary wait
+        sleep(Duration::from_secs(5)).await;
         Ok(())
     }
 

--- a/falcon-lab/src/juniper.rs
+++ b/falcon-lab/src/juniper.rs
@@ -9,11 +9,15 @@ use slog::info;
 use std::fs;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 const CRPD_CONTAINER: &str = "crpd1";
 const CARGO_BAY: &str = "cargo-bay";
 const LICENSE_PATH: &str = "falcon-juniper-license.key";
 const CONFIG_SUFFIX: &str = "-junos.set";
+const APPLY_STATUS_PATH: &str = "/run/falcon-junos-apply.status";
+const APPLY_STATUS_READY: &str = "applied";
+const APPLY_STATUS_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Copy, Clone)]
 pub struct JuniperNode(pub NodeRef);
@@ -100,13 +104,63 @@ impl JuniperNode {
         // guest-side systemd services that mount cargo-bay, install the
         // license, and apply `<node>-junos.set`; see falcon-lab/README.md.
         self.stage_routing_config(d, routing_config)?;
-        self.verify_license_available()?;
+        self.stage_license()?;
         info!(
             d.log,
-            "{}: staged Juniper config and verified license for guest systemd services",
+            "{}: staged Juniper config and license for guest systemd services",
             self.name(d)
         );
+        self.wait_for_apply(d).await?;
         Ok(())
+    }
+
+    async fn wait_for_apply(&self, d: &Runner) -> Result<()> {
+        info!(
+            d.log,
+            "{}: waiting for Juniper guest config apply",
+            self.name(d)
+        );
+        let start = std::time::Instant::now();
+        let mut last_status = String::new();
+        loop {
+            let status = self
+                .exec_step(
+                    d,
+                    "read Juniper apply status",
+                    &format!("cat {APPLY_STATUS_PATH} 2>/dev/null || true"),
+                )
+                .await?
+                .trim()
+                .to_owned();
+            if status == APPLY_STATUS_READY {
+                info!(d.log, "{}: Juniper guest config applied", self.name(d));
+                return Ok(());
+            }
+            if status != last_status {
+                info!(
+                    d.log,
+                    "{}: Juniper apply status: {}",
+                    self.name(d),
+                    if status.is_empty() {
+                        "<empty>"
+                    } else {
+                        &status
+                    }
+                );
+                last_status = status;
+            }
+            if start.elapsed() >= APPLY_STATUS_TIMEOUT {
+                return Err(anyhow!(
+                    "timed out waiting for Juniper guest config apply; last status: {}",
+                    if last_status.is_empty() {
+                        "<empty>"
+                    } else {
+                        &last_status
+                    }
+                ));
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
     }
 
     fn stage_routing_config(
@@ -130,7 +184,7 @@ impl JuniperNode {
         Ok(path)
     }
 
-    fn verify_license_available(&self) -> Result<PathBuf> {
+    fn stage_license(&self) -> Result<PathBuf> {
         let path = Path::new(CARGO_BAY).join(LICENSE_PATH);
         let metadata = fs::metadata(&path).with_context(|| {
             format!(

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -44,6 +44,7 @@ use tokio::time::timeout;
 const QUARTET_UNNUMBERED_TOPO_NAME: &str = "mgquartetu";
 const MGD_UNNUMBERED_TOPO_NAME: &str = "mgduou";
 const QUARTET_BFD_STATIC_TOPO_NAME: &str = "mgquartetbfd";
+const CR1_BFD_FRR_CONFIG: &str = "cr1-bfd-frr.conf";
 const OP_TIMEOUT: Duration = Duration::from_secs(10);
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
@@ -64,7 +65,6 @@ const CR3_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 2);
 const OX_CR1_V4_CIDR: &str = "10.0.0.1/24";
 const OX_CR2_V4_CIDR: &str = "10.0.1.1/24";
 const OX_CR3_V4_CIDR: &str = "10.0.2.1/24";
-const CR1_V4_CIDR: &str = "10.0.0.2/24";
 const CR2_V4_CIDR: &str = "10.0.1.2/24";
 const CR3_V4_CIDR: &str = "10.0.2.2/24";
 
@@ -77,7 +77,6 @@ const CR3_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 3, 0, 0, 0, 0, 0, 2); // fd00:3::
 const OX_CR1_V6_CIDR: &str = "fd00:1::1/64";
 const OX_CR2_V6_CIDR: &str = "fd00:2::1/64";
 const OX_CR3_V6_CIDR: &str = "fd00:3::1/64";
-const CR1_V6_CIDR: &str = "fd00:1::2/64";
 const CR2_V6_CIDR: &str = "fd00:2::2/64";
 const CR3_V6_CIDR: &str = "fd00:3::2/64";
 
@@ -1239,43 +1238,15 @@ async fn frr_bfd_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
     // Address the softnpu-facing link (v4 + v6) and bring up passive BFD peers
     // for each family. Once mgd initiates BFD to these addresses the sessions
     // establish bidirectionally.
-    let rx_ms = BFD_REQUIRED_RX_US / 1000;
-    let config = format!(
-        "
-        configure
-        interface enp0s8
-          ip address {cr_v4_cidr}
-          ipv6 address {cr_v6_cidr}
-          no shutdown
-        exit
-        bfd
-          peer {ox_v4} local-address {cr_v4}
-            detect-multiplier {mult}
-            receive-interval {rx_ms}
-            transmit-interval {rx_ms}
-            no shutdown
-          exit
-          peer {ox_v6} local-address {cr_v6}
-            detect-multiplier {mult}
-            receive-interval {rx_ms}
-            transmit-interval {rx_ms}
-            no shutdown
-          exit
-        exit
-        write memory
-        ",
-        cr_v4_cidr = CR1_V4_CIDR,
-        cr_v6_cidr = CR1_V6_CIDR,
-        ox_v4 = OX_CR1_V4,
-        ox_v6 = OX_CR1_V6,
-        cr_v4 = CR1_V4,
-        cr_v6 = CR1_V6,
-        mult = BFD_DETECTION_MULT,
-    );
-
     r.install(&d).await?;
+    r.stage_config(
+        CR1_BFD_FRR_CONFIG,
+        include_str!("../config/cr1-bfd-frr.conf"),
+    )?;
     r.enable_daemons(&d, &["bfdd"]).await?;
-    r.shell(&d, &config).await?;
+    r.stop_frr(&d).await?;
+    r.install_staged_config(&d, CR1_BFD_FRR_CONFIG).await?;
+    r.start_frr(&d).await?;
     Ok(())
 }
 

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -11,7 +11,7 @@ use crate::{
     juniper::{JuniperNode, clear_staged_routing_configs},
     mgd::{MgdNode, wait_for_mgd},
     topo::{MgdDuo, Quartet, mgd_duo, quartet},
-    wait_for_eq,
+    wait_for_eq, wait_for_eq_stable,
 };
 use anyhow::{Context, Result};
 use dpd_client::{
@@ -85,8 +85,13 @@ const CR3_V6_CIDR: &str = "fd00:3::2/64";
 const TEST_PREFIX_V4: &str = "192.168.100.0/24";
 const TEST_PREFIX_V6: &str = "fd01::/64";
 
-/// BFD detection time: 300ms * 3 = 900ms.
-const BFD_REQUIRED_RX_US: u64 = 300_000;
+/// BFD detection time: 1s * 3 = 3s.
+///
+/// mgd currently advertises a fixed 1s desired transmit interval, regardless of
+/// its configured required receive interval. Keep the lab's receive interval at
+/// 1s so peers that honor mgd's advertised desired transmit interval do not
+/// send too slowly for mgd's detection time.
+const BFD_REQUIRED_RX_US: u64 = 1_000_000;
 const BFD_DETECTION_MULT: u8 = 3;
 
 /// Output of `boot_quartet`: the running topology plus clients ready for
@@ -178,12 +183,14 @@ async fn restore_quartet_before_diagnostics(
     cr2: EosNode,
     cr3: JuniperNode,
 ) {
-    match timeout(OP_TIMEOUT, cr1.resume_bfdd(ad)).await {
+    match timeout(OP_TIMEOUT, cr1.start_frr(ad)).await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
-            warn!(ad.log, "failed to resume cr1 before diagnostics: {e:#}")
+            warn!(ad.log, "failed to start cr1 frr before diagnostics: {e:#}")
         }
-        Err(_) => warn!(ad.log, "timed out resuming cr1 before diagnostics"),
+        Err(_) => {
+            warn!(ad.log, "timed out starting cr1 frr before diagnostics")
+        }
     }
     match timeout(OP_TIMEOUT, cr2.unpause(ad)).await {
         Ok(Ok(())) => {}
@@ -1183,8 +1190,8 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
     expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 1")
         .await?;
 
-    info!(ad.log, "phase 2: pause bfdd on cr1");
-    cr1.pause_bfdd(&ad).await?;
+    info!(ad.log, "phase 2: stop frr on cr1");
+    cr1.stop_frr(&ad).await?;
     expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Up, Up)).await?;
     expect_route(&dpd, &prefix_v4, &prefix_v6, false, true, true, "phase 2")
         .await?;
@@ -1204,8 +1211,8 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
     expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 4")
         .await?;
 
-    info!(ad.log, "phase 5: resume bfdd on cr1");
-    cr1.resume_bfdd(&ad).await?;
+    info!(ad.log, "phase 5: start frr on cr1");
+    cr1.start_frr(&ad).await?;
     expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Down, Down))
         .await?;
     expect_route(&dpd, &prefix_v4, &prefix_v6, true, false, false, "phase 5")
@@ -1255,6 +1262,7 @@ async fn frr_bfd_setup(r: FrrNode, d: Arc<Runner>) -> Result<()> {
             no shutdown
           exit
         exit
+        write memory
         ",
         cr_v4_cidr = CR1_V4_CIDR,
         cr_v6_cidr = CR1_V6_CIDR,
@@ -1345,6 +1353,8 @@ async fn juniper_bfd_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
 /// mgd-side state is always checked. Peer-side state is checked only when
 /// the peer is expected `Up`: a paused daemon cannot answer queries, so
 /// `Down` phases have no observable peer-side truth.
+const BFD_STABLE_SAMPLES: usize = 3;
+
 async fn expect_bfd(
     mgd: &MgdClient,
     peers: QuartetNodes,
@@ -1360,15 +1370,21 @@ async fn expect_bfd(
         (IpAddr::V6(CR3_V6), states.cr3),
     ] {
         let desc = format!("mgd bfd {peer} -> {want:?}");
-        wait_for_eq!(bfd_state(mgd, peer).await, Some(want), &desc);
+        wait_for_eq_stable!(
+            bfd_state(mgd, peer).await,
+            Some(want),
+            BFD_STABLE_SAMPLES,
+            &desc
+        );
     }
 
     if matches!(states.cr1, BfdPeerState::Up) {
         for peer in [IpAddr::V4(OX_CR1_V4), IpAddr::V6(OX_CR1_V6)] {
             let desc = format!("cr1 bfd {peer} -> Up");
-            wait_for_eq!(
+            wait_for_eq_stable!(
                 peers.cr1.bfd_peer_up(d, peer).await.unwrap_or(false),
                 true,
+                BFD_STABLE_SAMPLES,
                 &desc
             );
         }
@@ -1376,9 +1392,10 @@ async fn expect_bfd(
     if matches!(states.cr2, BfdPeerState::Up) {
         for peer in [IpAddr::V4(OX_CR2_V4), IpAddr::V6(OX_CR2_V6)] {
             let desc = format!("cr2 bfd {peer} -> Up");
-            wait_for_eq!(
+            wait_for_eq_stable!(
                 peers.cr2.bfd_peer_up(d, peer).await.unwrap_or(false),
                 true,
+                BFD_STABLE_SAMPLES,
                 &desc
             );
         }
@@ -1386,9 +1403,10 @@ async fn expect_bfd(
     if matches!(states.cr3, BfdPeerState::Up) {
         for peer in [IpAddr::V4(OX_CR3_V4), IpAddr::V6(OX_CR3_V6)] {
             let desc = format!("cr3 bfd {peer} -> Up");
-            wait_for_eq!(
+            wait_for_eq_stable!(
                 peers.cr3.bfd_peer_up(d, peer).await.unwrap_or(false),
                 true,
+                BFD_STABLE_SAMPLES,
                 &desc
             );
         }

--- a/falcon-lab/src/test.rs
+++ b/falcon-lab/src/test.rs
@@ -1324,7 +1324,7 @@ async fn juniper_bfd_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
 /// mgd-side state is always checked. Peer-side state is checked only when
 /// the peer is expected `Up`: a paused daemon cannot answer queries, so
 /// `Down` phases have no observable peer-side truth.
-const BFD_STABLE_SAMPLES: usize = 3;
+const BFD_STABLE_SAMPLES: usize = 5;
 
 async fn expect_bfd(
     mgd: &MgdClient,

--- a/falcon-lab/src/util.rs
+++ b/falcon-lab/src/util.rs
@@ -7,6 +7,14 @@ macro_rules! wait_for_eq {
             if measured == expected {
                 break;
             }
+            client_common::println_nopipe!(
+                "{}: iteration {}/{}: expected {:?}, got {:?}",
+                $desc,
+                i + 1,
+                $count,
+                expected,
+                measured
+            );
             if i == $count - 1 {
                 anyhow::bail!(
                     "{}: expected {:?}, got {:?}",
@@ -20,5 +28,69 @@ macro_rules! wait_for_eq {
     };
     ($measure:expr, $expect:expr, $desc:expr) => {
         wait_for_eq!($measure, $expect, 1, 20, $desc);
+    };
+}
+
+#[macro_export]
+macro_rules! wait_for_eq_stable {
+    ($measure:expr, $expect:expr, $stable_count:expr, $period:expr, $count:expr, $desc:expr) => {
+        let stable_count: usize = $stable_count;
+        let mut consecutive = 0usize;
+        for i in 0..$count {
+            let measured = $measure;
+            let expected = $expect;
+            if measured == expected {
+                consecutive += 1;
+                if consecutive >= stable_count {
+                    break;
+                }
+                client_common::println_nopipe!(
+                    "{}: iteration {}/{}: matched {:?} ({}/{} consecutive)",
+                    $desc,
+                    i + 1,
+                    $count,
+                    measured,
+                    consecutive,
+                    stable_count
+                );
+            } else {
+                if consecutive == 0 {
+                    client_common::println_nopipe!(
+                        "{}: iteration {}/{}: expected {:?}, got {:?}",
+                        $desc,
+                        i + 1,
+                        $count,
+                        expected,
+                        measured
+                    );
+                } else {
+                    client_common::println_nopipe!(
+                        "{}: iteration {}/{}: expected {:?}, got {:?} (reset after {}/{} consecutive)",
+                        $desc,
+                        i + 1,
+                        $count,
+                        expected,
+                        measured,
+                        consecutive,
+                        stable_count
+                    );
+                }
+                consecutive = 0;
+            }
+            if i == $count - 1 {
+                anyhow::bail!(
+                    "{}: expected {:?} for {} consecutive samples, got {:?} ({} consecutive)",
+                    $desc,
+                    expected,
+                    stable_count,
+                    measured,
+                    consecutive
+                );
+            }
+            tokio::time::sleep(Duration::from_secs($period)).await;
+        }
+    };
+    ($measure:expr, $expect:expr, $stable_count:expr, $desc:expr) => {
+        wait_for_eq_stable!($measure, $expect, $stable_count, 1, 20, $desc);
     };
 }

--- a/falcon-lab/src/util.rs
+++ b/falcon-lab/src/util.rs
@@ -41,9 +41,6 @@ macro_rules! wait_for_eq_stable {
             let expected = $expect;
             if measured == expected {
                 consecutive += 1;
-                if consecutive >= stable_count {
-                    break;
-                }
                 client_common::println_nopipe!(
                     "{}: iteration {}/{}: matched {:?} ({}/{} consecutive)",
                     $desc,
@@ -53,6 +50,9 @@ macro_rules! wait_for_eq_stable {
                     consecutive,
                     stable_count
                 );
+                if consecutive >= stable_count {
+                    break;
+                }
             } else {
                 if consecutive == 0 {
                     client_common::println_nopipe!(


### PR DESCRIPTION
Stabilizes the BFD tests with juniper, since we have bugs that are incompatible with their adaptive BFD timers