### PR TITLE
[4/n] bgp: scope router teardown to the router's own sessions

### DIFF
--- a/bgp/src/router.rs
+++ b/bgp/src/router.rs
@@ -27,10 +27,11 @@ use rhai::AST;
 use slog::Logger;
 use std::{
     collections::BTreeSet,
+    fmt,
     net::SocketAddr,
     sync::{
         Arc, Mutex, MutexGuard, RwLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         mpsc::{Receiver, Sender},
     },
     time::Duration,
@@ -99,12 +100,37 @@ impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
         self.0.iter().map(|h| &h.0)
     }
 
+    /// Return the drivers corresponding to the given router.
+    ///
+    /// A session map may be shared across routers (mgd uses one daemon-wide
+    /// map), so any work that is scoped to an individual router should use
+    /// this rather than `drivers()`.
+    pub fn drivers_of(
+        &self,
+        router: &Router<Cnx>,
+    ) -> impl Iterator<Item = &Arc<FsmDriver<Cnx>>> {
+        self.drivers()
+            .filter(move |d| d.runner().belongs_to(router))
+    }
+
     pub fn iter(
         &self,
     ) -> impl Iterator<Item = (&PeerId, &Arc<SessionRunner<Cnx>>)> {
         self.0
             .iter()
             .map(|h| (&h.0.runner().neighbor.peer, h.0.runner()))
+    }
+
+    /// Return the sessions corresponding to the given router.
+    ///
+    /// A session map may be shared across routers (mgd uses one daemon-wide
+    /// map), so any work that is scoped to an individual router should use
+    /// this rather than `iter()`.
+    pub fn sessions_of(
+        &self,
+        router: &Router<Cnx>,
+    ) -> impl Iterator<Item = (&PeerId, &Arc<SessionRunner<Cnx>>)> {
+        self.iter().filter(move |(_, s)| s.belongs_to(router))
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &PeerId> {
@@ -118,6 +144,34 @@ impl<Cnx: BgpConnection + 'static> SessionMap<Cnx> {
 
 const UNIT_SESSION_RUNNER: &str = "session_runner";
 
+/// Process-unique identity of a [`Router`] instance.
+///
+/// This is used to scope operations to a single router (see
+/// `SessionRunner::belongs_to`).
+///
+/// Note that this is not the BGP router ID (`RouterConfig::id`), and in
+/// particular, recreating a router with identical configuration yields a fresh
+/// `RouterInstanceId`.
+///
+/// IDs are allocated from a monotonic counter and never reused within a
+/// process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RouterInstanceId(u64);
+
+impl RouterInstanceId {
+    /// Allocate the next process-unique id.
+    fn next() -> Self {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        Self(NEXT.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl fmt::Display for RouterInstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 pub struct Router<Cnx: BgpConnection + 'static> {
     /// The underlying routing information base (RIB) databse this router
     /// will update in response to BGP update messages (imported routes)
@@ -126,6 +180,10 @@ pub struct Router<Cnx: BgpConnection + 'static> {
 
     /// The static configuration associated with this router.
     pub config: RouterConfig,
+
+    /// Process-unique identity of this router instance (see
+    /// [`RouterInstanceId`]).
+    instance_id: RouterInstanceId,
 
     /// A set of BGP session runners indexed by PeerId (IP or interface).
     /// Shared with the Dispatcher for connection routing.
@@ -172,8 +230,11 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         db: Db,
         sessions: Arc<Mutex<SessionMap<Cnx>>>,
     ) -> Router<Cnx> {
+        let instance_id = RouterInstanceId::next();
+        let log = log.new(slog::o!("router_instance_id" => instance_id.0));
         Self {
             config,
+            instance_id,
             sessions,
             log,
             shutdown: AtomicBool::new(false),
@@ -183,6 +244,11 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
             fanout6: Arc::new(RwLock::new(Fanout6::<Cnx>::default())),
             policy: Policy::default(),
         }
+    }
+
+    /// Return the process-unique identity of this router instance.
+    pub(crate) fn instance_id(&self) -> RouterInstanceId {
+        self.instance_id
     }
 
     // Get the session runner mapped to the peer id
@@ -217,28 +283,47 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
             .expect("failed to spawn BGP FSM thread");
     }
 
-    /// Stop all session threads but retain session metadata.
+    /// Stop all of this router's session threads but retain session metadata.
     /// This allows the router to be restarted via run().
     /// Also cleans up fanout entries for all stopped sessions.
     fn stop_all_sessions(&self) {
         let sessions = lock!(self.sessions);
-        for (peer, s) in sessions.iter() {
+        for (peer, s) in sessions.sessions_of(self) {
             self.remove_fanout(peer.clone());
             s.shutdown();
         }
     }
 
-    /// Delete all sessions, clearing the SessionRunner and SessionEndpoint maps.
-    /// This signals SessionRunner threads to exit and releases Arc<SessionRunner>
-    /// references, allowing BgpConnections to drop and their threads to clean up.
-    fn delete_all_sessions(&self) {
-        let sessions = std::mem::take(&mut *lock!(self.sessions));
-        for (peer, s) in sessions.iter() {
-            self.remove_fanout(peer.clone());
-            s.shutdown();
-        }
-    }
-
+    /// Shut down this router, stopping all of its sessions.
+    ///
+    /// This does not delete sessions from the `self.sessions` map; doing so is
+    /// the caller's job (mgd does it per-neighbor before deleting a router).
+    ///
+    /// # Notes
+    ///
+    /// There is no `Drop` impl that calls `shutdown`. Why? Because any `Drop`
+    /// impl that only calls `shutdown` would necessarily be vacuous. Let's say
+    /// we have a router R and suppose one of R's sessions is in the map. Then:
+    ///
+    /// - The map holds an `Arc<FsmDriver>` for it, which in turn holds an
+    ///   `Arc<SessionRunner>`, so the runner's strong count >= 1. This keeps
+    ///   the runner alive.
+    /// - That live runner holds an `Arc<Router>` pointing at R, which keeps R
+    ///   alive.
+    ///
+    /// So, while one of R's sessions is in the map, R is alive and `R::drop`
+    /// (if it existed) would not run. The contrapositive is that if `R::drop`
+    /// is running, none of R's sessions are in the map (other routers'
+    /// sessions might be). But the only externally-visible thing `shutdown`
+    /// does is iterate over R's sessions in the map, stopping each and
+    /// removing its fanout entries -- with none of R's sessions present, that
+    /// iteration is empty. (`shutdown` also logs and sets the shutdown flag,
+    /// but while `R::drop` runs, no reference to R exists that could observe
+    /// the flag.) So `R::drop` is vacuous.
+    ///
+    /// (This argument would no longer hold if any of these `Arc` references
+    /// became weak, breaking the cycle -- or if we got rid of `Arc` and
+    /// switched to using actors.)
     pub fn shutdown(&self) {
         slog::info!(
             self.log,
@@ -254,15 +339,25 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         self.shutdown.store(true, Ordering::Release);
     }
 
-    pub fn run(&self) {
+    /// Run this router, spawning FSM threads for each of this router's
+    /// sessions.
+    ///
+    /// Returns how many FSM threads were spawned. Note that this counts spawn
+    /// attempts: a spawned thread exits immediately (with a warning) if
+    /// another thread still owns the session's event receiver, so the count
+    /// can overstate how many FSMs are actually running.
+    pub fn run(&self) -> usize {
         // Clear shutdown flag to allow router to restart
         self.shutdown.store(false, Ordering::Release);
 
         // Hold lock during entire iteration to prevent concurrent modifications
         let sessions = lock!(self.sessions);
-        for driver in sessions.drivers() {
+        let mut spawned = 0;
+        for driver in sessions.drivers_of(self) {
             self.spawn_session_thread(driver.clone());
+            spawned += 1;
         }
+        spawned
     }
 
     pub fn add_fanout4(
@@ -769,15 +864,6 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
         }
 
         Ok(())
-    }
-}
-
-impl<Cnx: BgpConnection + 'static> Drop for Router<Cnx> {
-    fn drop(&mut self) {
-        // Stop all sessions when router is dropped to prevent thread leaks.
-        // We don't set the shutdown flag here because it's not relevant during drop
-        // (the router is being destroyed, not temporarily shutdown).
-        self.delete_all_sessions();
     }
 }
 

--- a/bgp/src/session.rs
+++ b/bgp/src/session.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     policy::{CheckerResult, ShaperResult, shape_outgoing_update},
     recv_event_loop, recv_event_return,
-    router::Router,
+    router::{Router, RouterInstanceId},
     unnumbered::{UnnumberedError, UnnumberedManager},
 };
 use mg_api_types::bgp::config::{
@@ -1739,7 +1739,15 @@ pub struct SessionRunner<Cnx: BgpConnection + 'static> {
     db: Db,
     fanout4: Arc<RwLock<Fanout4<Cnx>>>,
     fanout6: Arc<RwLock<Fanout6<Cnx>>>,
+    // This must remain a strong Arc: the no-`Drop` argument on
+    // `Router::shutdown` relies on sessions in the map keeping their router
+    // alive, and the runner dereferences it on live paths (policy, base
+    // attributes). Turning it into a Weak would need `upgrade()` plus
+    // dead-router handling at each use.
     router: Arc<Router<Cnx>>,
+
+    /// Identity of the router this session belongs to (see `belongs_to`).
+    router_instance_id: RouterInstanceId,
 
     /// Registry of active connections with typestate enforcement
     /// Ensures at most 2 connections (primary + collision during negotiation)
@@ -1855,6 +1863,7 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             shutdown_state: AtomicShutdownState::new(),
             fanout4: router.fanout4.clone(),
             fanout6: router.fanout6.clone(),
+            router_instance_id: router.instance_id(),
             router: router.clone(),
             message_history: Arc::new(Mutex::new(MessageHistory::default())),
             fsm_event_history: Arc::new(Mutex::new(FsmEventHistory::new())),
@@ -1948,6 +1957,21 @@ impl<Cnx: BgpConnection + 'static> SessionRunner<Cnx> {
             self.peer_id();
         );
         self.shutdown_state.request_shutdown();
+    }
+
+    // (cfg(test) since nothing outside tests reads this yet.)
+    #[cfg(test)]
+    pub(crate) fn shutdown_state(&self) -> ShutdownState {
+        self.shutdown_state.load()
+    }
+
+    /// Return true if this session belongs to the given router.
+    ///
+    /// Ownership is compared by [`RouterInstanceId`], so a router deleted and
+    /// created with the same ASN does not claim the old router's sessions
+    /// (re-creation yields a fresh instance ID).
+    pub(crate) fn belongs_to(&self, router: &Router<Cnx>) -> bool {
+        self.router_instance_id == router.instance_id()
     }
 
     /// Join a connector thread and handle any panic, logging appropriately

--- a/bgp/src/test.rs
+++ b/bgp/src/test.rs
@@ -12,7 +12,7 @@ use crate::{
     router::{EnsureSessionResult, Router, SessionMap},
     session::{
         AdminEvent, ConnectionKind, FsmEvent, FsmStateKind, PeerId,
-        SessionInfo, SessionRunner,
+        SessionInfo, SessionRunner, ShutdownState,
     },
     unnumbered::UnnumberedManager,
     unnumbered_mock::UnnumberedManagerMock,
@@ -4237,4 +4237,257 @@ fn test_unnumbered_interface_lifecycle() {
     router2.shutdown();
     disp1.shutdown();
     disp2.shutdown();
+}
+
+#[test]
+#[serial_test::parallel]
+fn router_teardown_leaves_other_routers_sessions_alone() {
+    let test_name = "router_teardown_leaves_other_routers_sessions_alone";
+    let log = init_file_logger(&format!("{test_name}.log"));
+
+    // Create a database and single (shared) session map for both routers.
+    let db = rdb::test::get_test_db(test_name, log.clone())
+        .expect("created test db");
+    let sessions: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+
+    let router_a = Arc::new(Router::new(
+        RouterConfig {
+            asn: Asn::FourOctet(64512),
+            id: 1,
+        },
+        log.clone(),
+        db.db().clone(),
+        sessions.clone(),
+    ));
+    let router_b = Arc::new(Router::new(
+        RouterConfig {
+            asn: Asn::FourOctet(64513),
+            id: 2,
+        },
+        log.clone(),
+        db.db().clone(),
+        sessions.clone(),
+    ));
+
+    let bind_addr: SocketAddr =
+        sockaddr!(&format!("[fe80::1]:{TEST_BGP_PORT}"));
+    let peer_addr: SocketAddr =
+        sockaddr!(&format!("[fe80::2]:{TEST_BGP_PORT}"));
+    let (event_tx, event_rx) = channel();
+
+    let result = router_b
+        .ensure_session(
+            PeerConfig {
+                name: "peer-b".to_string(),
+                group: String::new(),
+                id: PeerId::Ip(peer_addr.ip()),
+                port: NonZeroU16::new(peer_addr.port()).unwrap_or(BGP_PORT),
+                hold_time: TEST_HOLD_TIME_SECS,
+                idle_hold_time: 0,
+                delay_open: 0,
+                connect_retry: TEST_CONNECT_RETRY_SECS,
+                keepalive: 3,
+                resolution: 100,
+            },
+            Some(bind_addr),
+            event_tx,
+            event_rx,
+            create_test_session_info(
+                RouteExchange::Ipv6 { nexthop: None },
+                bind_addr,
+                peer_addr,
+                // passive = true so the connector thread doesn't run.
+                //
+                // What happens if we set passive = false? The big risk would be
+                // the connector thread perturbing other tests. But as of this
+                // writing, bind_addr and peer_addr have scope ID 0, and the
+                // other tests bind against fe80::1/2 with a non-zero scope ID.
+                // (The BgpConnectionChannel `NET` static keys endpoints by
+                // exact SocketAddr, including scope_id.) So the worst that can
+                // happen is that the connector would fail forever, spamming the
+                // log and the process-global CONNECTION_ATTEMPTS list. But
+                // passive also stays robust if a future test ever binds these
+                // exact endpoints with scope ID 0.
+                true,
+            ),
+            None,
+        )
+        .expect("created session on router b");
+
+    let session_b = match result {
+        EnsureSessionResult::New(s) => s,
+        EnsureSessionResult::Updated(s) => s,
+    };
+    let peer_b = session_b.peer_id();
+
+    let assert_b_intact = |after: &str| {
+        let state = session_b.shutdown_state();
+        let unaltered = match state {
+            ShutdownState::NotRequested => true,
+            ShutdownState::Requested | ShutdownState::Complete => false,
+        };
+        assert!(
+            unaltered,
+            "{after} shouldn't alter router b's session (shutdown state {state:?})"
+        );
+        assert!(
+            lock!(sessions).contains_key(&peer_b),
+            "{after} shouldn't remove router b's session from the shared map"
+        );
+    };
+
+    assert_b_intact("creating router b's session");
+
+    // run() reports the spawn count.
+    assert_eq!(
+        router_a.run(),
+        0,
+        "router a's run() shouldn't spawn threads for sessions it does not own"
+    );
+    assert_b_intact("router a's run()");
+
+    router_a.shutdown();
+    assert_b_intact("router a's shutdown");
+
+    drop(router_a);
+    assert_b_intact("dropping router a");
+
+    // Delete the session -- don't just shut it down. delete_session both
+    // removes the map entry (breaking the router Arc cycle) and requests FSM
+    // shutdown, so that once the FSM thread exits and this test's own Arc
+    // drops, nothing keeps the runner (and via it, the clock thread) alive.
+    router_b.delete_session(peer_b);
+}
+
+#[test]
+#[serial_test::parallel]
+fn recreated_router_does_not_claim_predecessors_sessions() {
+    let test_name = "recreated_router_does_not_claim_predecessors_sessions";
+    let log = init_file_logger(&format!("{test_name}.log"));
+
+    let db = rdb::test::get_test_db(test_name, log.clone())
+        .expect("created test db");
+    let sessions: Arc<Mutex<SessionMap<BgpConnectionChannel>>> =
+        Arc::new(Mutex::new(SessionMap::new()));
+
+    // Ensure that multiple routers with the same config aren't confused with
+    // each other (that is, we use RouterInstanceId to distinguish between
+    // them).
+    let config = RouterConfig {
+        asn: Asn::FourOctet(64514),
+        id: 3,
+    };
+
+    let old_router = Arc::new(Router::new(
+        config,
+        log.clone(),
+        db.db().clone(),
+        sessions.clone(),
+    ));
+
+    let bind_addr: SocketAddr =
+        sockaddr!(&format!("[fe80::3]:{TEST_BGP_PORT}"));
+    let peer_addr: SocketAddr =
+        sockaddr!(&format!("[fe80::4]:{TEST_BGP_PORT}"));
+    let (event_tx, event_rx) = channel();
+
+    let result = old_router
+        .ensure_session(
+            PeerConfig {
+                name: "peer-old".to_string(),
+                group: String::new(),
+                id: PeerId::Ip(peer_addr.ip()),
+                port: NonZeroU16::new(peer_addr.port()).unwrap_or(BGP_PORT),
+                hold_time: TEST_HOLD_TIME_SECS,
+                idle_hold_time: 0,
+                delay_open: 0,
+                connect_retry: TEST_CONNECT_RETRY_SECS,
+                keepalive: 3,
+                resolution: 100,
+            },
+            Some(bind_addr),
+            event_tx,
+            event_rx,
+            create_test_session_info(
+                RouteExchange::Ipv6 { nexthop: None },
+                bind_addr,
+                peer_addr,
+                // See router_teardown_leaves_other_routers_sessions_alone for
+                // why passive = true.
+                true,
+            ),
+            None,
+        )
+        .expect("created session on the old router");
+
+    let session_old = match result {
+        EnsureSessionResult::New(s) => s,
+        EnsureSessionResult::Updated(s) => s,
+    };
+    let peer_old = session_old.peer_id();
+
+    // Recreate the router with an identical config, sharing the map. This
+    // mirrors mgd's delete-and-recreate flow, where a stale handle to the old
+    // instance can outlive creation of the new one.
+    let new_router = Arc::new(Router::new(
+        config,
+        log.clone(),
+        db.db().clone(),
+        sessions.clone(),
+    ));
+
+    assert_eq!(
+        new_router.run(),
+        0,
+        "recreated router's run() shouldn't spawn threads for the old \
+         instance's sessions"
+    );
+
+    new_router.shutdown();
+    let state = session_old.shutdown_state();
+    let unaltered = match state {
+        ShutdownState::NotRequested => true,
+        ShutdownState::Requested | ShutdownState::Complete => false,
+    };
+    assert!(
+        unaltered,
+        "recreated router's shutdown shouldn't stop the old instance's \
+         session (shutdown state {state:?})"
+    );
+    assert!(
+        lock!(sessions).contains_key(&peer_old),
+        "recreated router's shutdown shouldn't remove the old instance's \
+         session from the shared map"
+    );
+
+    // Ensure that the owning instance's run() and shutdown() do reach
+    // its own session.
+    //
+    // run() counts spawn attempts -- the duplicate thread exits immediately
+    // because the original FSM thread owns the event receiver.
+    assert_eq!(
+        old_router.run(),
+        1,
+        "owning router's run() should spawn a thread for its session"
+    );
+    old_router.shutdown();
+    let state = session_old.shutdown_state();
+    let stopped = match state {
+        ShutdownState::NotRequested => false,
+        ShutdownState::Requested | ShutdownState::Complete => true,
+    };
+    assert!(
+        stopped,
+        "owning router's shutdown should stop its session \
+         (shutdown state {state:?})"
+    );
+    assert!(
+        lock!(sessions).contains_key(&peer_old),
+        "shutdown stops sessions but shouldn't remove them from the map"
+    );
+
+    // See router_teardown_leaves_other_routers_sessions_alone for why
+    // deletion (not just shutdown) is needed for cleanup.
+    old_router.delete_session(peer_old);
 }

--- a/mgd/src/bgp_admin.rs
+++ b/mgd/src/bgp_admin.rs
@@ -1983,6 +1983,9 @@ pub(crate) mod helpers {
             true
         };
 
+        // XXX Note that if this fails, we'll have an orphaned session that's
+        // live without a DB row. This should either use a prepare-and-commit
+        // pattern or rollbacks.
         ctx.db.add_bgp_neighbor(
             mg_api_types::rdb::neighbor::BgpNeighborInfo {
                 asn: rq.asn,
@@ -2103,6 +2106,9 @@ pub(crate) mod helpers {
                 ),
             };
 
+        // XXX Note that if this fails, we'll have an orphaned session that's
+        // live without a DB row. This should either use a prepare-and-commit
+        // pattern or rollbacks.
         ctx.db.add_bgp_neighbor(
             mg_api_types::rdb::neighbor::BgpNeighborInfo {
                 asn: rq.asn,


### PR DESCRIPTION
Sessions are stored in a shared map -- previously, `stop_all_sessions` would work across all sessions in the shared map, not just the ones corresponding to the particular router. This caused #867 among other failures.

Change this to only stop sessions related to this router, using a globally incrementing `RouterInstanceId` to identify a router.

This isn't a complete/systemic fix -- we should rewrite this to use actors at some point. But it should resolve some of the more common cases of routers trampling over each other.

Fixes #867. (Though there are more upcoming fixes in subsequent commits in the stack.)