### PR TITLE
[6/n] bgp: carry the peer id in Error::PeerExists

### DIFF
--- a/bgp/src/error.rs
+++ b/bgp/src/error.rs
@@ -125,8 +125,8 @@ pub enum Error {
     #[error("Connection attempt from unknown peer: {0}")]
     UnknownPeer(PeerId),
 
-    #[error("Session for peer already exists")]
-    PeerExists,
+    #[error("Session for peer {0} already exists")]
+    PeerExists(PeerId),
 
     #[error("Capability not supported {0:?}")]
     UnsupportedCapability(crate::messages::Capability),

--- a/bgp/src/router.rs
+++ b/bgp/src/router.rs
@@ -456,7 +456,7 @@ impl<Cnx: BgpConnection + 'static> Router<Cnx> {
     ) -> Result<Arc<SessionRunner<Cnx>>, Error> {
         let sessions = lock!(self.sessions);
         if sessions.contains_key(&peer.id) {
-            Err(Error::PeerExists)
+            Err(Error::PeerExists(peer.id))
         } else {
             self.new_session_locked(
                 sessions,

--- a/mgd/src/error.rs
+++ b/mgd/src/error.rs
@@ -48,9 +48,9 @@ impl From<Error> for HttpError {
             ),
             Error::NotFound(_) => Self::for_not_found(None, value.to_string()),
             Error::Bgp(ref err) => match err {
-                bgp::error::Error::PeerExists => {
+                bgp::error::Error::PeerExists(_) => {
                     Self::for_client_error_with_status(
-                        Some("bgp peer exists".into()),
+                        Some(err.to_string()),
                         ClientErrorStatusCode::CONFLICT,
                     )
                 }


### PR DESCRIPTION
Previously, mgd only said "bgp peer exists", leaving out which peer the conflict is about.

Change this to carry the `PeerId` in the variant, mirroring bfd's `AddPeerError::PeerExists`.

This is preparation for the next change in the stack, which adds a second instance of `PeerExists`.
