### PR TITLE
lab: add error wrapper to fix build warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ version = "0.1.0"
 dependencies = [
  "libfalcon",
  "oxide-tokio-rt",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/lab/Cargo.toml
+++ b/lab/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 libfalcon = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 oxide-tokio-rt.workspace = true
+thiserror.workspace = true
 
 [[bin]]
 name = "solo"

--- a/lab/src/2x2/main.rs
+++ b/lab/src/2x2/main.rs
@@ -4,9 +4,9 @@
 
 // Copyright 2021 Oxide Computer Company
 
+use lab::error::Error;
 use libfalcon::Runner;
 use libfalcon::cli::run;
-use libfalcon::error::Error;
 use libfalcon::unit::gb;
 
 fn main() -> Result<(), Error> {

--- a/lab/src/duo/main.rs
+++ b/lab/src/duo/main.rs
@@ -4,10 +4,10 @@
 
 // Copyright 2021 Oxide Computer Company
 
+use lab::error::Error;
 use libfalcon::Runner;
 use libfalcon::cli::RunMode;
 use libfalcon::cli::run;
-use libfalcon::error::Error;
 use libfalcon::unit::gb;
 
 fn main() -> Result<(), Error> {

--- a/lab/src/error.rs
+++ b/lab/src/error.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2026 Oxide Computer Company
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(Box<libfalcon::error::Error>);
+
+impl From<libfalcon::error::Error> for Error {
+    fn from(e: libfalcon::error::Error) -> Self {
+        Error(Box::new(e))
+    }
+}

--- a/lab/src/error.rs
+++ b/lab/src/error.rs
@@ -8,6 +8,18 @@
 #[error(transparent)]
 pub struct Error(Box<libfalcon::error::Error>);
 
+impl Error {
+    /// Returns the underlying Falcon error.
+    pub fn as_inner(&self) -> &libfalcon::error::Error {
+        &self.0
+    }
+
+    /// Consumes this wrapper and returns the underlying Falcon error.
+    pub fn into_inner(self) -> libfalcon::error::Error {
+        *self.0
+    }
+}
+
 impl From<libfalcon::error::Error> for Error {
     fn from(e: libfalcon::error::Error) -> Self {
         Error(Box::new(e))

--- a/lab/src/lib.rs
+++ b/lab/src/lib.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2026 Oxide Computer Company
+
+pub mod error;

--- a/lab/src/quartet/main.rs
+++ b/lab/src/quartet/main.rs
@@ -4,10 +4,10 @@
 
 // Copyright 2021 Oxide Computer Company
 
+use lab::error::Error;
 use libfalcon::Runner;
 use libfalcon::cli::RunMode;
 use libfalcon::cli::run;
-use libfalcon::error::Error;
 use libfalcon::unit::gb;
 
 fn main() -> Result<(), Error> {

--- a/lab/src/solo/main.rs
+++ b/lab/src/solo/main.rs
@@ -4,9 +4,9 @@
 
 // Copyright 2021 Oxide Computer Company
 
+use lab::error::Error;
 use libfalcon::Runner;
 use libfalcon::cli::run;
-use libfalcon::error::Error;
 use libfalcon::unit::gb;
 
 fn main() -> Result<(), Error> {

--- a/lab/src/trio/main.rs
+++ b/lab/src/trio/main.rs
@@ -4,10 +4,10 @@
 
 // Copyright 2021 Oxide Computer Company
 
+use lab::error::Error;
 use libfalcon::Runner;
 use libfalcon::cli::RunMode;
 use libfalcon::cli::run;
-use libfalcon::error::Error;
 use libfalcon::unit::gb;
 
 fn main() -> Result<(), Error> {


### PR DESCRIPTION
Adds a pointer-sized wrapper around libfalcon::error::Error. This avoids using large amount of stack memory for large error variants, e.g. libfalcon::error::Error::Propolis, which clippy complains about because it's 176+ bytes. Wrapping it in a `Box` keeps the stack cost to just one ptr while preserving the full error chain via #[error(transparent)].