### PR TITLE
falcon-lab: separate topologies from scenarios

### DIFF
--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -100,18 +100,20 @@ clear_falcon_workspace_files() {
 }
 
 run_test() {
-	local test_name=$1
+	local topology=$1
+	local scenario=$2
+	local test_name="${topology}-${scenario}"
 	local status=0
 
 	clear_falcon_workspace_files
-	RUST_LOG=debug pfexec ./falcon-lab run --no-cleanup "${test_name}" || status=$?
+	RUST_LOG=debug pfexec ./falcon-lab run "${topology}" "${scenario}" --no-cleanup || status=$?
 	if (( status != 0 )); then
 		collect_falcon_artifacts "${test_name}"
 	fi
-	pfexec ./falcon-lab cleanup "${test_name}" || true
+	pfexec ./falcon-lab cleanup "${topology}" "${scenario}" || true
 	return "${status}"
 }
 
-run_test mgd-unnumbered
-run_test quartet-unnumbered
-run_test quartet-bfd-static-routing
+run_test mgd-duo bgp-unnumbered
+run_test interop bgp-unnumbered
+run_test interop bfd-static-routing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
+ "strum 0.27.2",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 clap = { version = "4.6.6", features = ["derive", "unstable-styles", "env"] }
 tabwriter = { version = "1", features = ["ansi_formatting"] }
 colored = "3.1"
+strum = { version = "0.27", features = ["derive"] }
 ztest = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 libfalcon = { git = "https://github.com/oxidecomputer/falcon", branch = "main" }
 anstyle = "1.0.14"

--- a/falcon-lab/Cargo.toml
+++ b/falcon-lab/Cargo.toml
@@ -18,5 +18,6 @@ oxnet.workspace = true
 oxide-tokio-rt.workspace = true
 bgp.workspace = true
 colored.workspace = true
+strum.workspace = true
 mg-api-types.workspace = true
 client-common.workspace = true

--- a/falcon-lab/README.md
+++ b/falcon-lab/README.md
@@ -1,8 +1,34 @@
 # Falcon lab
 
-`falcon-lab` runs Maghemite integration topologies under Falcon. The
+`falcon-lab` runs Maghemite integration topologies under Falcon. A topology
+defines the VM graph, while a scenario configures and tests that topology. The
 topologies use prebuilt Falcon base images for Helios, Debian/FRR, cEOS, and
 Junos/cRPD nodes, plus a per-run `cargo-bay/` 9p share for binaries and runtime
+configuration.
+
+## Topologies and scenarios
+
+Supported topology/scenario pairs are:
+
+```text
+mgd-duo  bare
+mgd-duo  bgp-unnumbered
+interop  bare
+interop  bgp-unnumbered
+interop  bfd-static-routing
+```
+
+`mgd-duo` connects two Maghemite nodes. `interop` connects a Maghemite DUT to
+FRR, Arista EOS, Juniper cRPD, and a second Maghemite node.
+
+Run and cleanup commands both take a topology and scenario:
+
+```sh
+pfexec target/release/falcon-lab run interop bgp-unnumbered --no-cleanup
+pfexec target/release/falcon-lab cleanup interop bgp-unnumbered
+```
+
+The `bare` scenarios launch their topology without applying protocol
 configuration.
 
 ## Runtime cargo-bay contents
@@ -11,7 +37,7 @@ Before running any topology, `cargo-bay/` must contain:
 
 - `mgd` and `ddmd`, staged by local test setup or the Buildomat job.
 
-Junos topologies additionally require:
+The interop topology additionally requires:
 
 - `falcon-juniper-license.key`, a Juniper license file. This file is a secret:
   do not commit it, print it, include it in diagnostics, or pass its contents in
@@ -23,10 +49,10 @@ Junos CLI input file: it starts with `configure`, contains `set ...` commands,
 and ends with `commit`.
 
 Junos topology config is per-run state. `falcon-lab` removes stale
-`cargo-bay/*-junos.set` files before launching a quartet topology so the
-guest-side apply service cannot consume configuration left behind by an earlier
-topology. Do not put persistent hand-written Junos config in files matching
-that pattern.
+`cargo-bay/*-junos.set` files before launching or cleaning up an interop
+topology so the guest-side apply service cannot consume configuration left by
+an earlier topology. Do not put persistent hand-written Junos config in files
+matching that pattern.
 
 ## Junos license source and connectivity assumptions
 
@@ -131,8 +157,9 @@ Failure diagnostics are enabled by default. For faster local iteration while
 preserving the failed topology, use:
 
 ```sh
-pfexec ./falcon-lab run --no-cleanup --no-diag-on-fail quartet-bfd-static-routing
+pfexec target/release/falcon-lab run interop bfd-static-routing \
+  --no-cleanup --no-diag-on-fail
 ```
 
-Even with `--no-diag-on-fail`, quartet tests make a best-effort attempt to resume
-FRR's `bfdd` and unpause cEOS/cRPD before returning the failure.
+Even with `--no-diag-on-fail`, interop scenarios make a best-effort attempt to
+restart FRR and unpause cEOS/cRPD before returning the failure.

--- a/falcon-lab/src/main.rs
+++ b/falcon-lab/src/main.rs
@@ -1,12 +1,10 @@
 //! Falcon test lab
 
 use crate::dendrite::NpuvmCommits;
-use crate::test::{
-    cleanup_mgd_unnumbered_test, cleanup_quartet_bfd_static_test,
-    cleanup_quartet_unnumbered_test, run_mgd_unnumbered_test,
-    run_quartet_bfd_static_test, run_quartet_unnumbered_test,
+use crate::scenario::{
+    InteropScenario, MgdDuoScenario, Scenario, ScenarioOptions,
 };
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 mod bgp;
 mod ddm;
@@ -18,60 +16,91 @@ mod illumos;
 mod juniper;
 mod linux;
 mod mgd;
-mod test;
+mod scenario;
 mod topo;
 mod util;
 
+const DEFAULT_NPUVM_COMMIT: &str = "fd2c726815cdb03c2687e1bf2912a9184905557b";
+
 #[derive(Debug, Parser)]
 struct Cli {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    Run(Run),
-    Cleanup(Cleanup),
+    Run(TopologyRun),
+    Cleanup(TopologyCleanup),
     Serial(Serial),
 }
 
-#[derive(Debug, Parser)]
-struct Run {
-    #[clap(subcommand)]
-    command: TestCommand,
-
-    #[clap(long)]
-    no_cleanup: bool,
-
-    #[clap(long)]
-    no_diag_on_fail: bool,
-
-    #[clap(long, default_value = "fd2c726815cdb03c2687e1bf2912a9184905557b")]
-    npuvm_commit: String,
-
-    #[clap(long)]
-    dendrite_commit: Option<String>,
-
-    #[clap(long)]
-    sidecar_lite_commit: Option<String>,
-}
-
-#[derive(Debug, Parser)]
-struct Cleanup {
-    #[clap(subcommand)]
-    command: TestCommand,
-}
-
-#[derive(Debug, Parser)]
-struct Serial {
-    node: String,
+#[derive(Debug, Args)]
+struct TopologyRun {
+    #[command(subcommand)]
+    topology: RunTopology,
 }
 
 #[derive(Debug, Subcommand)]
-enum TestCommand {
-    MgdUnnumbered,
-    QuartetUnnumbered,
-    QuartetBfdStaticRouting,
+enum RunTopology {
+    MgdDuo(ScenarioRun<MgdDuoScenario>),
+    Interop(ScenarioRun<InteropScenario>),
+}
+
+#[derive(Debug, Args)]
+struct ScenarioRun<S: ValueEnum + Send + Sync + 'static> {
+    #[arg(value_enum)]
+    scenario: S,
+    #[command(flatten)]
+    options: RunOptions,
+}
+
+#[derive(Debug, Args)]
+struct RunOptions {
+    #[arg(long)]
+    no_cleanup: bool,
+    #[arg(long)]
+    no_diag_on_fail: bool,
+    #[arg(long, default_value = DEFAULT_NPUVM_COMMIT)]
+    npuvm_commit: String,
+    #[arg(long)]
+    dendrite_commit: Option<String>,
+    #[arg(long)]
+    sidecar_lite_commit: Option<String>,
+}
+
+impl RunOptions {
+    fn scenario_options(self) -> ScenarioOptions {
+        let commits = NpuvmCommits {
+            npuvm: self.npuvm_commit,
+            dendrite: self.dendrite_commit,
+            sidecar_lite: self.sidecar_lite_commit,
+        };
+        ScenarioOptions::new(self.no_cleanup, !self.no_diag_on_fail, commits)
+    }
+}
+
+#[derive(Debug, Args)]
+struct TopologyCleanup {
+    #[command(subcommand)]
+    topology: CleanupTopology,
+}
+
+#[derive(Debug, Subcommand)]
+enum CleanupTopology {
+    MgdDuo(ScenarioCleanup<MgdDuoScenario>),
+    Interop(ScenarioCleanup<InteropScenario>),
+}
+
+#[derive(Debug, Args)]
+struct ScenarioCleanup<S: ValueEnum + Send + Sync + 'static> {
+    #[arg(value_enum)]
+    scenario: S,
+}
+
+#[derive(Debug, Args)]
+struct Serial {
+    node: String,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -79,47 +108,21 @@ fn main() -> anyhow::Result<()> {
 }
 
 async fn run() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-    match cli.command {
-        Command::Run(cmd) => {
-            let commits = NpuvmCommits {
-                npuvm: cmd.npuvm_commit,
-                dendrite: cmd.dendrite_commit,
-                sidecar_lite: cmd.sidecar_lite_commit,
-            };
-            match cmd.command {
-                TestCommand::MgdUnnumbered => {
-                    run_mgd_unnumbered_test(
-                        cmd.no_cleanup,
-                        !cmd.no_diag_on_fail,
-                    )
-                    .await?
-                }
-                TestCommand::QuartetUnnumbered => {
-                    run_quartet_unnumbered_test(
-                        cmd.no_cleanup,
-                        !cmd.no_diag_on_fail,
-                        commits,
-                    )
-                    .await?
-                }
-                TestCommand::QuartetBfdStaticRouting => {
-                    run_quartet_bfd_static_test(
-                        cmd.no_cleanup,
-                        !cmd.no_diag_on_fail,
-                        commits,
-                    )
-                    .await?
-                }
+    match Cli::parse().command {
+        Command::Run(cmd) => match cmd.topology {
+            RunTopology::MgdDuo(cmd) => {
+                cmd.scenario.run(cmd.options.scenario_options()).await?;
             }
-        }
-        Command::Cleanup(cmd) => match cmd.command {
-            TestCommand::MgdUnnumbered => cleanup_mgd_unnumbered_test().await?,
-            TestCommand::QuartetUnnumbered => {
-                cleanup_quartet_unnumbered_test().await?
+            RunTopology::Interop(cmd) => {
+                cmd.scenario.run(cmd.options.scenario_options()).await?;
             }
-            TestCommand::QuartetBfdStaticRouting => {
-                cleanup_quartet_bfd_static_test().await?
+        },
+        Command::Cleanup(cmd) => match cmd.topology {
+            CleanupTopology::MgdDuo(cmd) => {
+                cmd.scenario.cleanup()?;
+            }
+            CleanupTopology::Interop(cmd) => {
+                cmd.scenario.cleanup()?;
             }
         },
         Command::Serial(cmd) => {
@@ -127,4 +130,67 @@ async fn run() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_options_follow_scenario() {
+        let cli = Cli::try_parse_from([
+            "falcon-lab",
+            "run",
+            "interop",
+            "bare",
+            "--no-cleanup",
+        ])
+        .expect("parse interop bare scenario");
+
+        assert!(matches!(
+            cli.command,
+            Command::Run(TopologyRun {
+                topology: RunTopology::Interop(ScenarioRun {
+                    scenario: InteropScenario::Bare,
+                    options: RunOptions {
+                        no_cleanup: true,
+                        ..
+                    },
+                }),
+            })
+        ));
+    }
+
+    #[test]
+    fn cleanup_uses_topology_and_scenario() {
+        let cli = Cli::try_parse_from([
+            "falcon-lab",
+            "cleanup",
+            "mgd-duo",
+            "bgp-unnumbered",
+        ])
+        .expect("parse mgd-duo cleanup scenario");
+
+        assert!(matches!(
+            cli.command,
+            Command::Cleanup(TopologyCleanup {
+                topology: CleanupTopology::MgdDuo(ScenarioCleanup {
+                    scenario: MgdDuoScenario::BgpUnnumbered,
+                }),
+            })
+        ));
+    }
+
+    #[test]
+    fn scenario_is_rejected_by_wrong_topology() {
+        assert!(
+            Cli::try_parse_from([
+                "falcon-lab",
+                "run",
+                "mgd-duo",
+                "bfd-static-routing",
+            ])
+            .is_err()
+        );
+    }
 }

--- a/falcon-lab/src/mgd.rs
+++ b/falcon-lab/src/mgd.rs
@@ -30,6 +30,11 @@ impl MgdNode {
         Ok(())
     }
 
+    pub async fn stop_mgd(&self, d: &Runner) -> Result<()> {
+        d.exec(self.0, "pkill -x mgd").await?;
+        Ok(())
+    }
+
     pub async fn client(&self, d: &Runner, addr: IpAddr) -> Result<Client> {
         Ok(Client::new(&format!("http://{addr}:4676"), d.log.clone()))
     }

--- a/falcon-lab/src/scenario.rs
+++ b/falcon-lab/src/scenario.rs
@@ -1,4 +1,4 @@
-//! Tests
+//! Scenario setup, assertions, and failure diagnostics.
 
 #![allow(clippy::iter_nth_zero)]
 
@@ -10,10 +10,11 @@ use crate::{
     frr::FrrNode,
     juniper::{JuniperNode, clear_staged_routing_configs},
     mgd::{MgdNode, wait_for_mgd},
-    topo::{MgdDuo, Quartet, mgd_duo, quartet},
+    topo::{Interop, MgdDuo, Topology},
     wait_for_eq, wait_for_eq_stable,
 };
 use anyhow::{Context, Result};
+use clap::ValueEnum;
 use dpd_client::{
     Client as DpdClient,
     types::{Ipv4Entry, Ipv6Entry, LinkId, PortId},
@@ -42,32 +43,188 @@ use std::{
 };
 use tokio::time::timeout;
 
-const QUARTET_UNNUMBERED_TOPO_NAME: &str = "mgquartetu";
-const MGD_UNNUMBERED_TOPO_NAME: &str = "mgduou";
-const QUARTET_BFD_STATIC_TOPO_NAME: &str = "mgquartetbfd";
+// Falcon derives dladm link names from the deployment name by appending the
+// node, endpoint kind, and link type, and illumos reserves one byte of
+// MAXLINKNAMELEN (32) for the NUL terminator. Check every deployment name at
+// compile time so an incompatible name fails the build rather than a lab run.
+const fn assert_falcon_compatible(name: &str) {
+    let name = name.as_bytes();
+    assert!(!name.is_empty() && name[0].is_ascii_alphabetic());
+    let mut i = 0;
+    while i < name.len() {
+        assert!(name[i].is_ascii_alphanumeric() || name[i] == b'_');
+        i += 1;
+    }
+    assert!(name.len() + "_peer_vn_vnic0".len() < 32);
+}
+
+const _: () = {
+    use strum::VariantArray;
+    let mut i = 0;
+    while i < MgdDuoScenario::VARIANTS.len() {
+        assert_falcon_compatible(MgdDuoScenario::VARIANTS[i].name());
+        i += 1;
+    }
+    let mut i = 0;
+    while i < InteropScenario::VARIANTS.len() {
+        assert_falcon_compatible(InteropScenario::VARIANTS[i].name());
+        i += 1;
+    }
+};
+
+pub(crate) struct ScenarioOptions {
+    persistent: bool,
+    diag_on_fail: bool,
+    commits: NpuvmCommits,
+}
+
+impl ScenarioOptions {
+    pub(crate) fn new(
+        persistent: bool,
+        diag_on_fail: bool,
+        commits: NpuvmCommits,
+    ) -> Self {
+        Self {
+            persistent,
+            diag_on_fail,
+            commits,
+        }
+    }
+}
+
+pub(crate) trait Scenario: Sized + Copy {
+    type Topology: Topology<Scenario = Self>;
+
+    async fn run(self, options: ScenarioOptions) -> Result<()>;
+
+    async fn run_bare(self, persistent: bool) -> Result<()> {
+        let mut topology = Self::Topology::build(self)?;
+        let runner = topology.runner_mut();
+        runner.persistent = persistent;
+        timeout(LAUNCH_TIMEOUT, runner.launch())
+            .await
+            .context("launch timed out")?
+            .context("launch failed")
+    }
+
+    fn cleanup(self) -> Result<()> {
+        Self::Topology::build(self).map(drop)
+    }
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum, strum::VariantArray)]
+pub(crate) enum MgdDuoScenario {
+    Bare,
+    BgpUnnumbered,
+}
+
+impl MgdDuoScenario {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Bare => "mgdduo_bare",
+            Self::BgpUnnumbered => "mgdduo_bgpu",
+        }
+    }
+}
+
+impl Scenario for MgdDuoScenario {
+    type Topology = MgdDuo;
+
+    async fn run(self, options: ScenarioOptions) -> Result<()> {
+        match self {
+            Self::Bare => self.run_bare(options.persistent).await,
+            Self::BgpUnnumbered => {
+                run_mgd_unnumbered(
+                    self,
+                    options.persistent,
+                    options.diag_on_fail,
+                )
+                .await
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum, strum::VariantArray)]
+pub(crate) enum InteropScenario {
+    Bare,
+    BgpUnnumbered,
+    BfdStaticRouting,
+}
+
+impl InteropScenario {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Bare => "interop_bare",
+            Self::BgpUnnumbered => "interop_bgpu",
+            Self::BfdStaticRouting => "interop_bfd",
+        }
+    }
+}
+
+impl Scenario for InteropScenario {
+    type Topology = Interop;
+
+    async fn run(self, options: ScenarioOptions) -> Result<()> {
+        match self {
+            Self::Bare => {
+                clear_staged_routing_configs()
+                    .context("clear stale Junos config")?;
+                self.run_bare(options.persistent).await
+            }
+            Self::BgpUnnumbered => {
+                run_interop_unnumbered(
+                    self,
+                    options.persistent,
+                    options.diag_on_fail,
+                    options.commits,
+                )
+                .await
+            }
+            Self::BfdStaticRouting => {
+                run_interop_bfd_static(
+                    self,
+                    options.persistent,
+                    options.diag_on_fail,
+                    options.commits,
+                )
+                .await
+            }
+        }
+    }
+
+    fn cleanup(self) -> Result<()> {
+        cleanup_interop_deployment(self)
+    }
+}
+
 const CR1_BFD_FRR_CONFIG: &str = "cr1-bfd-frr.conf";
 const OP_TIMEOUT: Duration = Duration::from_secs(10);
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
-// The mgd-duo topology creates the direct test link before each node's
-// management link, so the peer-facing viona interface is vioif0 and the DHCP
-// management interface is vioif1.
-const MGD_DUO_PEER_LINK: &str = "vioif0";
-const MGD_DUO_MGMT_ADDR: &str = "vioif1/dhcp";
+// Helios nodes create a direct test link before their management link, so the
+// peer-facing viona interface is vioif0 and the DHCP management interface is
+// vioif1.
+const HELIOS_PEER_LINK: &str = "vioif0";
+const HELIOS_MGMT_ADDR: &str = "vioif1/dhcp";
 
-// BFD-static test addressing. `OX_*` addresses are configured on the helios
-// side of each softnpu link; `CR*` addresses are configured on the peer.
+// BFD-static test addressing. `OX_*` addresses are configured on the softnpu
+// side of each link; the other addresses are configured on its peer.
 const OX_CR1_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 const CR1_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
 const OX_CR2_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 1);
 const CR2_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 2);
 const OX_CR3_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 1);
 const CR3_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 2, 2);
+const OX_PEER_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 3, 1);
+const PEER_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 3, 2);
 const OX_CR1_V4_CIDR: &str = "10.0.0.1/24";
 const OX_CR2_V4_CIDR: &str = "10.0.1.1/24";
 const OX_CR3_V4_CIDR: &str = "10.0.2.1/24";
+const OX_PEER_V4_CIDR: &str = "10.0.3.1/24";
 const CR2_V4_CIDR: &str = "10.0.1.2/24";
 const CR3_V4_CIDR: &str = "10.0.2.2/24";
+const PEER_V4_CIDR: &str = "10.0.3.2/24";
 
 const OX_CR1_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 1, 0, 0, 0, 0, 0, 1); // fd00:1::1
 const CR1_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 1, 0, 0, 0, 0, 0, 2); // fd00:1::2
@@ -75,13 +232,17 @@ const OX_CR2_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 2, 0, 0, 0, 0, 0, 1); // fd00:
 const CR2_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 2, 0, 0, 0, 0, 0, 2); // fd00:2::2
 const OX_CR3_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 3, 0, 0, 0, 0, 0, 1); // fd00:3::1
 const CR3_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 3, 0, 0, 0, 0, 0, 2); // fd00:3::2
+const OX_PEER_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 4, 0, 0, 0, 0, 0, 1); // fd00:4::1
+const PEER_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 4, 0, 0, 0, 0, 0, 2); // fd00:4::2
 const OX_CR1_V6_CIDR: &str = "fd00:1::1/64";
 const OX_CR2_V6_CIDR: &str = "fd00:2::1/64";
 const OX_CR3_V6_CIDR: &str = "fd00:3::1/64";
+const OX_PEER_V6_CIDR: &str = "fd00:4::1/64";
 const CR2_V6_CIDR: &str = "fd00:2::2/64";
 const CR3_V6_CIDR: &str = "fd00:3::2/64";
+const PEER_V6_CIDR: &str = "fd00:4::2/64";
 
-/// Destination prefixes with nexthops via both cr1 and cr2.
+/// Destination prefixes with nexthops via every interop peer.
 const TEST_PREFIX_V4: &str = "192.168.100.0/24";
 const TEST_PREFIX_V6: &str = "fd01::/64";
 
@@ -94,38 +255,45 @@ const TEST_PREFIX_V6: &str = "fd01::/64";
 const BFD_REQUIRED_RX_US: u64 = 1_000_000;
 const BFD_DETECTION_MULT: NonZeroU8 = NonZeroU8::new(3).unwrap();
 
-/// Output of `boot_quartet`: the running topology plus clients ready for
-/// test-specific configuration.
-struct BootedQuartet {
+/// Running interop topology plus clients ready for scenario configuration.
+struct BootedInterop {
     ad: Arc<Runner>,
     ox: MgdNode,
+    peer: MgdNode,
     cr1: FrrNode,
     cr2: EosNode,
     cr3: JuniperNode,
     mgd: MgdClient,
+    peer_mgd: MgdClient,
     dpd: DpdClient,
     #[allow(dead_code)]
     mgmt_addr: IpAddr,
-    topo_name: String,
+    scenario: InteropScenario,
     protocols: ProtocolDiagnostics,
 }
 
 #[derive(Copy, Clone)]
-struct QuartetNodes {
+struct InteropRouters {
     cr1: FrrNode,
     cr2: EosNode,
     cr3: JuniperNode,
 }
 
-struct QuartetPeerStates<T> {
+struct InteropPeerStates<T> {
     cr1: T,
     cr2: T,
     cr3: T,
+    peer: T,
 }
 
-impl<T> QuartetPeerStates<T> {
-    fn new(cr1: T, cr2: T, cr3: T) -> Self {
-        Self { cr1, cr2, cr3 }
+impl<T> InteropPeerStates<T> {
+    fn new(cr1: T, cr2: T, cr3: T, peer: T) -> Self {
+        Self {
+            cr1,
+            cr2,
+            cr3,
+            peer,
+        }
     }
 }
 
@@ -137,28 +305,32 @@ struct BootedMgdDuo {
     ox2: MgdNode,
     mgd1: MgdClient,
     mgd2: MgdClient,
-    topo_name: String,
+    scenario: MgdDuoScenario,
 }
 
 /// Run a test body against a booted topology and dump diagnostics from every
-/// VM if it fails. The body consumes the `BootedQuartet`, so cache the bits
+/// VM if it fails. The body consumes the `BootedInterop`, so cache the bits
 /// `collect_diagnostics` needs before handing it off.
 async fn run_with_optional_diagnostics<F, Fut>(
-    bt: BootedQuartet,
+    bt: BootedInterop,
     diag_on_fail: bool,
     body: F,
 ) -> Result<()>
 where
-    F: FnOnce(BootedQuartet) -> Fut,
+    F: FnOnce(BootedInterop) -> Fut,
     Fut: std::future::Future<Output = Result<()>>,
 {
     let ad = bt.ad.clone();
     let ox = bt.ox;
-    let cr1 = bt.cr1;
-    let cr2 = bt.cr2;
-    let cr3 = bt.cr3;
+    let peer = bt.peer;
+    let routers = InteropRouters {
+        cr1: bt.cr1,
+        cr2: bt.cr2,
+        cr3: bt.cr3,
+    };
     let mgd = bt.mgd.clone();
-    let topo_name = bt.topo_name.clone();
+    let peer_mgd = bt.peer_mgd.clone();
+    let topo_name = bt.scenario.name();
     let protocols = bt.protocols;
     let result = body(bt).await;
     if let Err(e) = &result {
@@ -167,22 +339,25 @@ where
         // convergence. Resume them before diagnostics so collection can use
         // each vendor's normal CLI/API path rather than timing out on the
         // fault we injected.
-        restore_quartet_before_diagnostics(&ad, cr1, cr2, cr3).await;
+        restore_interop_before_diagnostics(&ad, routers).await;
         if diag_on_fail {
-            collect_diagnostics(&ad, ox, cr1, cr2, cr3, &topo_name, protocols)
+            collect_interop_diagnostics(
+                &ad, ox, peer, routers, topo_name, protocols,
+            )
+            .await;
+            ox.collect_ndp_diagnostics(&ad, &mgd, topo_name).await;
+            peer.collect_ndp_diagnostics(&ad, &peer_mgd, topo_name)
                 .await;
-            ox.collect_ndp_diagnostics(&ad, &mgd, &topo_name).await;
         }
     }
     result
 }
 
-async fn restore_quartet_before_diagnostics(
+async fn restore_interop_before_diagnostics(
     ad: &Runner,
-    cr1: FrrNode,
-    cr2: EosNode,
-    cr3: JuniperNode,
+    routers: InteropRouters,
 ) {
+    let InteropRouters { cr1, cr2, cr3 } = routers;
     match timeout(OP_TIMEOUT, cr1.start_frr(ad)).await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
@@ -222,12 +397,12 @@ where
     let ad = bt.ad.clone();
     let ox1 = bt.ox1;
     let ox2 = bt.ox2;
-    let topo_name = bt.topo_name.clone();
+    let topo_name = bt.scenario.name();
     let result = body(bt).await;
     if let Err(e) = &result {
         warn!(ad.log, "{topo_name} failed: {e:#}");
         if diag_on_fail {
-            collect_mgd_duo_diagnostics(&ad, ox1, ox2, &topo_name).await;
+            collect_mgd_duo_diagnostics(&ad, ox1, ox2, topo_name).await;
         }
     }
     result
@@ -236,11 +411,12 @@ where
 /// Launch two Helios nodes with a direct link between them and obtain mgd
 /// admin clients over their management links.
 async fn boot_mgd_duo(
-    topo_name: &str,
+    scenario: MgdDuoScenario,
     persistent: bool,
     diag_on_fail: bool,
 ) -> Result<BootedMgdDuo> {
-    let MgdDuo { mut d, ox1, ox2 } = mgd_duo(topo_name)?;
+    let topo_name = scenario.name();
+    let MgdDuo { mut d, ox1, ox2 } = MgdDuo::build(scenario)?;
     d.persistent = persistent;
     d.launch().await.context("launch failed")?;
     let ad = Arc::new(d);
@@ -249,8 +425,8 @@ async fn boot_mgd_duo(
         let ox1_illumos = ox1.illumos();
         let ox2_illumos = ox2.illumos();
         let (mgmt1, mgmt2) = tokio::try_join!(
-            ox1_illumos.dhcp(&ad, MGD_DUO_MGMT_ADDR),
-            ox2_illumos.dhcp(&ad, MGD_DUO_MGMT_ADDR),
+            ox1_illumos.dhcp(&ad, HELIOS_MGMT_ADDR),
+            ox2_illumos.dhcp(&ad, HELIOS_MGMT_ADDR),
         )?;
         let mgd1 = ox1.client(&ad, mgmt1).await?;
         let mgd2 = ox2.client(&ad, mgmt2).await?;
@@ -266,7 +442,7 @@ async fn boot_mgd_duo(
             ox2,
             mgd1,
             mgd2,
-            topo_name: topo_name.to_string(),
+            scenario,
         }),
         Err(e) => {
             warn!(ad.log, "{topo_name} boot failed: {e:#}");
@@ -279,19 +455,19 @@ async fn boot_mgd_duo(
     }
 }
 
-/// Launch the quartet topology and complete the work shared by every quartet-based
-/// test: dhcp mgmt, concurrent peer install + npuvm setup, dpd startup,
-/// softnpu link creation, and tfport readiness. The caller supplies a closure
-/// that populates a `JoinSet` with per-peer setup futures so that they run
-/// concurrently with the npuvm install.
-async fn boot_quartet<F>(
-    topo_name: &str,
+/// Launch the interop topology and complete the work shared by every interop
+/// test: dhcp mgmt, concurrent vendor-peer install + npuvm setup, peer mgd and
+/// dpd startup, softnpu link creation, and tfport readiness. The caller
+/// supplies a closure that populates a `JoinSet` with vendor-peer setup futures
+/// so that they run concurrently with the npuvm install.
+async fn boot_interop<F>(
+    scenario: InteropScenario,
     persistent: bool,
     diag_on_fail: bool,
     commits: NpuvmCommits,
     protocols: ProtocolDiagnostics,
     spawn_peer_setups: F,
-) -> Result<BootedQuartet>
+) -> Result<BootedInterop>
 where
     F: FnOnce(
         FrrNode,
@@ -300,63 +476,78 @@ where
         Arc<Runner>,
     ) -> tokio::task::JoinSet<Result<()>>,
 {
-    let Quartet {
+    let Interop {
         mut d,
         ox,
+        peer,
         cr1,
         cr2,
         cr3,
-    } = quartet(topo_name)?;
+    } = Interop::build(scenario)?;
+    let topo_name = scenario.name();
     d.persistent = persistent;
     clear_staged_routing_configs().context("clear stale Junos config")?;
-    info!(d.log, "{topo_name}: launching quartet topology");
+    info!(d.log, "{topo_name}: launching interop topology");
     timeout(LAUNCH_TIMEOUT, d.launch())
         .await
         .context("launch timed out")?
         .context("launch failed")?;
-    info!(d.log, "{topo_name}: quartet topology launch complete");
+    info!(d.log, "{topo_name}: interop topology launch complete");
     let ad = Arc::new(d);
 
     // Any failure between launch and Ok needs to dump diagnostics from the
     // running deployment. Wrap the rest of boot in a closure so we have a
     // single Err path to hook.
-    let result =
-        boot_quartet_inner(&ad, ox, cr1, cr2, cr3, commits, spawn_peer_setups)
-            .await;
+    let result = boot_interop_inner(
+        &ad,
+        ox,
+        peer,
+        InteropRouters { cr1, cr2, cr3 },
+        commits,
+        spawn_peer_setups,
+    )
+    .await;
 
     match result {
-        Ok((mgd, dpd, mgmt_addr)) => Ok(BootedQuartet {
+        Ok((mgd, peer_mgd, dpd, mgmt_addr)) => Ok(BootedInterop {
             ad,
             ox,
+            peer,
             cr1,
             cr2,
             cr3,
             mgd,
+            peer_mgd,
             dpd,
             mgmt_addr,
-            topo_name: topo_name.to_string(),
+            scenario,
             protocols,
         }),
         Err(e) => {
             warn!(ad.log, "{topo_name} boot failed: {e:#}");
             if diag_on_fail {
-                collect_boot_diagnostics(&ad, ox, cr1, cr2, cr3, topo_name)
-                    .await;
+                collect_interop_boot_diagnostics(
+                    &ad,
+                    ox,
+                    peer,
+                    InteropRouters { cr1, cr2, cr3 },
+                    topo_name,
+                )
+                .await;
             }
             Err(e)
         }
     }
 }
 
-async fn boot_quartet_inner<F>(
+async fn boot_interop_inner<F>(
     ad: &Arc<Runner>,
     ox: MgdNode,
-    cr1: FrrNode,
-    cr2: EosNode,
-    cr3: JuniperNode,
+    peer: MgdNode,
+    routers: InteropRouters,
     commits: NpuvmCommits,
     spawn_peer_setups: F,
-) -> Result<(MgdClient, DpdClient, IpAddr)>
+) -> Result<(MgdClient, MgdClient, DpdClient, IpAddr)>
 where
     F: FnOnce(
         FrrNode,
@@ -365,13 +556,19 @@ where
         Arc<Runner>,
     ) -> tokio::task::JoinSet<Result<()>>,
 {
-    let mgmt_addr = ox.illumos().dhcp(ad, "vioif1/dhcp").await?;
+    let InteropRouters { cr1, cr2, cr3 } = routers;
+    let ox_illumos = ox.illumos();
+    let peer_illumos = peer.illumos();
+    let (mgmt_addr, peer_mgmt_addr) = tokio::try_join!(
+        ox_illumos.dhcp(ad, HELIOS_MGMT_ADDR),
+        peer_illumos.dhcp(ad, HELIOS_MGMT_ADDR),
+    )?;
 
     let mut js = spawn_peer_setups(cr1, cr2, cr3, ad.clone());
     let npuvm_ad = ad.clone();
     js.spawn(async move {
         ox.dendrite()
-            .npuvm(npuvm_ad, 3, 0, commits)
+            .npuvm(npuvm_ad, 4, 0, commits)
             .await
             .context("setup ox npuvm")
     });
@@ -379,48 +576,53 @@ where
         result?;
     }
 
-    let mgd = ox.client(ad, mgmt_addr).await?;
+    let (mgd, peer_mgd) = tokio::try_join!(
+        ox.client(ad, mgmt_addr),
+        peer.client(ad, peer_mgmt_addr),
+    )?;
+    peer.run_mgd(ad).await?;
+    wait_for_mgd(&peer_mgd, OP_TIMEOUT, &ad.log)
+        .await
+        .context("wait for peer mgd")?;
+
     let dpd = ox.dendrite().client(ad, mgmt_addr).await?;
     wait_for_dpd(&dpd, OP_TIMEOUT, &ad.log)
         .await
         .context("wait_for_dpd")?;
 
-    for link in ["qsfp0", "qsfp1", "qsfp2"] {
+    for link in ["qsfp0", "qsfp1", "qsfp2", "qsfp3"] {
         softnpu_link_create(&dpd, link)
             .await
             .context(format!("create {link}"))?;
     }
-    for link in ["tfportqsfp0_0", "tfportqsfp1_0", "tfportqsfp2_0"] {
+    for link in [
+        "tfportqsfp0_0",
+        "tfportqsfp1_0",
+        "tfportqsfp2_0",
+        "tfportqsfp3_0",
+    ] {
         ox.illumos().wait_for_link(ad, link, OP_TIMEOUT).await?;
     }
 
-    Ok((mgd, dpd, mgmt_addr))
+    Ok((mgd, peer_mgd, dpd, mgmt_addr))
 }
 
-pub async fn cleanup_quartet_unnumbered_test() -> Result<()> {
-    clear_staged_routing_configs().context("clear stale Junos config")?;
-    cleanup_topology(QUARTET_UNNUMBERED_TOPO_NAME, |name| {
-        quartet(name).map(drop)
-    })
+/// Always attempt both deployment and staged-config cleanup. In particular, a
+/// filesystem error must not leave a persistent Falcon deployment running.
+fn cleanup_interop_deployment(scenario: InteropScenario) -> Result<()> {
+    let deployment_result = Interop::build(scenario).map(drop);
+    let config_result =
+        clear_staged_routing_configs().context("clear stale Junos config");
+    deployment_result?;
+    config_result
 }
 
-pub async fn cleanup_mgd_unnumbered_test() -> Result<()> {
-    cleanup_topology(MGD_UNNUMBERED_TOPO_NAME, |name| mgd_duo(name).map(drop))
-}
-
-fn cleanup_topology(
-    topo_name: &str,
-    cleanup: impl FnOnce(&str) -> Result<()>,
-) -> Result<()> {
-    cleanup(topo_name)
-}
-
-pub async fn run_mgd_unnumbered_test(
+async fn run_mgd_unnumbered(
+    scenario: MgdDuoScenario,
     persistent: bool,
     diag_on_fail: bool,
 ) -> Result<()> {
-    let bt = boot_mgd_duo(MGD_UNNUMBERED_TOPO_NAME, persistent, diag_on_fail)
-        .await?;
+    let bt = boot_mgd_duo(scenario, persistent, diag_on_fail).await?;
 
     run_mgd_duo_with_optional_diagnostics(bt, diag_on_fail, mgd_unnumbered_body)
         .await
@@ -437,7 +639,7 @@ async fn mgd_unnumbered_body(bt: BootedMgdDuo) -> Result<()> {
     } = bt;
 
     for ox in [ox1, ox2] {
-        let addr = format!("{MGD_DUO_PEER_LINK}/ll");
+        let addr = format!("{HELIOS_PEER_LINK}/ll");
         ox.illumos()
             .addrconf(&ad, &addr)
             .await
@@ -476,14 +678,14 @@ async fn mgd_unnumbered_body(bt: BootedMgdDuo) -> Result<()> {
     let ox1_neighbor = basic_unnumbered_neighbor(
         "ox2",
         "mgd-duo",
-        MGD_DUO_PEER_LINK,
+        HELIOS_PEER_LINK,
         OX1_ASN,
         0,
     );
     let ox2_neighbor = basic_unnumbered_neighbor(
         "ox1",
         "mgd-duo",
-        MGD_DUO_PEER_LINK,
+        HELIOS_PEER_LINK,
         OX2_ASN,
         0,
     );
@@ -526,13 +728,14 @@ async fn mgd_unnumbered_body(bt: BootedMgdDuo) -> Result<()> {
     Ok(())
 }
 
-pub async fn run_quartet_unnumbered_test(
+async fn run_interop_unnumbered(
+    scenario: InteropScenario,
     persistent: bool,
     diag_on_fail: bool,
     commits: NpuvmCommits,
 ) -> Result<()> {
-    let bt = boot_quartet(
-        QUARTET_UNNUMBERED_TOPO_NAME,
+    let bt = boot_interop(
+        scenario,
         persistent,
         diag_on_fail,
         commits,
@@ -558,61 +761,86 @@ pub async fn run_quartet_unnumbered_test(
     )
     .await?;
 
-    run_with_optional_diagnostics(bt, diag_on_fail, quartet_unnumbered_body)
+    run_with_optional_diagnostics(bt, diag_on_fail, interop_unnumbered_body)
         .await
 }
 
-async fn quartet_unnumbered_body(bt: BootedQuartet) -> Result<()> {
-    let BootedQuartet {
+async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
+    let BootedInterop {
         ad,
         ox,
+        peer,
         cr1,
         cr2,
         cr3,
         mgd,
+        peer_mgd,
         dpd,
         ..
     } = bt;
-    let peers = QuartetNodes { cr1, cr2, cr3 };
+    let peers = InteropRouters { cr1, cr2, cr3 };
 
-    for link in ["tfportqsfp0_0", "tfportqsfp1_0", "tfportqsfp2_0"] {
-        let addr = format!("{link}/ll");
+    for link in [
+        "tfportqsfp0_0/ll",
+        "tfportqsfp1_0/ll",
+        "tfportqsfp2_0/ll",
+        "tfportqsfp3_0/ll",
+    ] {
         ox.illumos()
-            .addrconf(&ad, &addr)
+            .addrconf(&ad, link)
             .await
-            .context(format!("create {addr}"))?;
+            .context(format!("create {link}"))?;
     }
+    let peer_addr = format!("{HELIOS_PEER_LINK}/ll");
+    peer.illumos()
+        .addrconf(&ad, &peer_addr)
+        .await
+        .context(format!("create {peer_addr}"))?;
 
     ox.run_mgd(&ad).await?;
     ox.ddm().run_ddm(&ad).await?;
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
-    // Fanout of 3 so all peer paths survive best-path selection and we can
+    // Fanout of 4 so all peer paths survive best-path selection and we can
     // validate ECMP in loc_rib and dpd.
     mgd.update_bestpath_fanout(&BestpathFanoutRequest {
-        fanout: std::num::NonZeroU8::new(3).expect("fanout > 0"),
+        fanout: std::num::NonZeroU8::new(4).expect("fanout > 0"),
     })
     .await
     .context("mgd: set bestpath fanout")?;
 
-    let local_asn: u32 = 33;
+    const LOCAL_ASN: u32 = 33;
+    const PEER_ASN: u32 = 47;
+    const PEER_V4_PREFIX: &str = "1.2.3.0/24";
+    const PEER_V6_PREFIX: &str = "fd99::/64";
+    const OX_V4_ORIGIN: &str = "4.5.6.0/24";
+    const OX_V6_ORIGIN: &str = "fdee::/64";
 
-    info!(ad.log, "adding BGP router to mgd");
+    info!(ad.log, "adding BGP routers to both mgd nodes");
 
     mgd.create_router(&Router {
-        asn: local_asn,
+        asn: LOCAL_ASN,
         graceful_shutdown: false,
         id: 33,
         listen: "[::]:179".to_owned(),
     })
     .await
     .context("mgd: create router")?;
+    peer_mgd
+        .create_router(&Router {
+            asn: PEER_ASN,
+            graceful_shutdown: false,
+            id: 47,
+            listen: "[::]:179".to_owned(),
+        })
+        .await
+        .context("peer mgd: create router")?;
 
     mgd.create_unnumbered_neighbor(&basic_unnumbered_neighbor(
         "cr1",
         "test",
         "tfportqsfp0_0",
-        33,
+        LOCAL_ASN,
         0,
     ))
     .await
@@ -622,7 +850,7 @@ async fn quartet_unnumbered_body(bt: BootedQuartet) -> Result<()> {
         "cr2",
         "test",
         "tfportqsfp1_0",
-        33,
+        LOCAL_ASN,
         1800,
     ))
     .await
@@ -632,87 +860,129 @@ async fn quartet_unnumbered_body(bt: BootedQuartet) -> Result<()> {
         "cr3",
         "test",
         "tfportqsfp2_0",
-        33,
+        LOCAL_ASN,
         1800,
     ))
     .await
     .context("mgd: create cr3 unnumbered neighbor")?;
 
+    mgd.create_unnumbered_neighbor(&basic_unnumbered_neighbor(
+        "peer",
+        "test",
+        "tfportqsfp3_0",
+        LOCAL_ASN,
+        0,
+    ))
+    .await
+    .context("mgd: create peer unnumbered neighbor")?;
+
+    peer_mgd
+        .create_unnumbered_neighbor(&basic_unnumbered_neighbor(
+            "ox",
+            "test",
+            HELIOS_PEER_LINK,
+            PEER_ASN,
+            0,
+        ))
+        .await
+        .context("peer mgd: create ox unnumbered neighbor")?;
+
     mgd.create_origin4(&Origin4 {
-        asn: 33,
-        prefixes: vec!["4.5.6.0/24".parse().expect("parse ipv4 origin")],
+        asn: LOCAL_ASN,
+        prefixes: vec![OX_V4_ORIGIN.parse().expect("parse ipv4 origin")],
     })
     .await
     .context("announce v4 prefix")?;
 
     mgd.create_origin6(&Origin6 {
-        asn: 33,
-        prefixes: vec!["fdee::/64".parse().expect("parse ipv6 origin")],
+        asn: LOCAL_ASN,
+        prefixes: vec![OX_V6_ORIGIN.parse().expect("parse ipv6 origin")],
     })
     .await
     .context("announce v6 prefix")?;
 
-    // Prefixes announced by the two peers back to ox, and by ox back to them.
-    const CR_V4_PREFIX: &str = "1.2.3.0/24";
-    const CR_V6_PREFIX: &str = "fd99::/64";
-    const OX_V4_ORIGIN: &str = "4.5.6.0/24";
-    const OX_V6_ORIGIN: &str = "fdee::/64";
+    peer_mgd
+        .create_origin4(&Origin4 {
+            asn: PEER_ASN,
+            prefixes: vec![
+                PEER_V4_PREFIX.parse().expect("parse peer ipv4 origin"),
+            ],
+        })
+        .await
+        .context("peer mgd: announce v4 prefix")?;
+    peer_mgd
+        .create_origin6(&Origin6 {
+            asn: PEER_ASN,
+            prefixes: vec![
+                PEER_V6_PREFIX.parse().expect("parse peer ipv6 origin"),
+            ],
+        })
+        .await
+        .context("peer mgd: announce v6 prefix")?;
 
     wait_for_eq!(
-        mgd.get_neighbors(local_asn)
+        mgd.get_neighbors(LOCAL_ASN)
             .await
             .map(|x| x.into_inner().len())
             .unwrap_or(0),
-        3,
+        4,
         "mgd neighbor count"
     );
 
     expect_bgp_neighbor_states(
         &mgd,
-        local_asn,
-        QuartetPeerStates::new(
+        LOCAL_ASN,
+        InteropPeerStates::new(
+            FsmStateKind::Established,
             FsmStateKind::Established,
             FsmStateKind::Established,
             FsmStateKind::Established,
         ),
     )
     .await?;
+    wait_for_eq!(
+        neighbor_fsm_state(&peer_mgd, PEER_ASN, "ox").await,
+        Some(FsmStateKind::Established),
+        "peer mgd bgp ox established"
+    );
 
     // All peers advertise the same prefix, so mgd should see a single
-    // imported entry per family with three paths, and — with fanout=3 — the
-    // same three paths should survive into the selected (loc) RIB.
+    // imported entry per family with four paths, and — with fanout=4 — the
+    // same four paths should survive into the selected (loc) RIB.
     wait_for_eq!(
-        mgd_imported_paths(&mgd, AddressFamily::Ipv4, CR_V4_PREFIX).await,
-        Some(3),
+        mgd_imported_paths(&mgd, AddressFamily::Ipv4, PEER_V4_PREFIX).await,
+        Some(4),
         "mgd imported paths for 1.2.3.0/24"
     );
     wait_for_eq!(
-        mgd_imported_paths(&mgd, AddressFamily::Ipv6, CR_V6_PREFIX).await,
-        Some(3),
+        mgd_imported_paths(&mgd, AddressFamily::Ipv6, PEER_V6_PREFIX).await,
+        Some(4),
         "mgd imported paths for fd99::/64"
     );
     wait_for_eq!(
-        mgd_selected_paths(&mgd, AddressFamily::Ipv4, CR_V4_PREFIX).await,
-        Some(3),
+        mgd_selected_paths(&mgd, AddressFamily::Ipv4, PEER_V4_PREFIX).await,
+        Some(4),
         "mgd selected paths for 1.2.3.0/24"
     );
     wait_for_eq!(
-        mgd_selected_paths(&mgd, AddressFamily::Ipv6, CR_V6_PREFIX).await,
-        Some(3),
+        mgd_selected_paths(&mgd, AddressFamily::Ipv6, PEER_V6_PREFIX).await,
+        Some(4),
         "mgd selected paths for fd99::/64"
     );
 
-    // dpd should have the specific prefixes, each with three ECMP targets.
-    let cr_v4: Ipv4Net = CR_V4_PREFIX.parse().expect("parse cr v4 prefix");
-    let cr_v6: Ipv6Net = CR_V6_PREFIX.parse().expect("parse cr v6 prefix");
+    // dpd should have the specific prefixes, each with four ECMP targets.
+    let peer_v4: Ipv4Net =
+        PEER_V4_PREFIX.parse().expect("parse peer v4 prefix");
+    let peer_v6: Ipv6Net =
+        PEER_V6_PREFIX.parse().expect("parse peer v6 prefix");
     wait_for_eq!(
-        dpd_v4_targets(&dpd, &cr_v4).await.len(),
-        3,
+        dpd_v4_targets(&dpd, &peer_v4).await.len(),
+        4,
         "dpd ipv4 targets for 1.2.3.0/24"
     );
     wait_for_eq!(
-        dpd_v6_targets(&dpd, &cr_v6).await.len(),
-        3,
+        dpd_v6_targets(&dpd, &peer_v6).await.len(),
+        4,
         "dpd ipv6 targets for fd99::/64"
     );
 
@@ -777,31 +1047,43 @@ async fn quartet_unnumbered_body(bt: BootedQuartet) -> Result<()> {
         true,
         "cr3 imported fdee::/64"
     );
+    wait_for_eq!(
+        mgd_imported_paths(&peer_mgd, AddressFamily::Ipv4, OX_V4_ORIGIN).await,
+        Some(1),
+        "peer imported 4.5.6.0/24"
+    );
+    wait_for_eq!(
+        mgd_imported_paths(&peer_mgd, AddressFamily::Ipv6, OX_V6_ORIGIN).await,
+        Some(1),
+        "peer imported fdee::/64"
+    );
 
-    info!(ad.log, "quartet bgp unnumbered test passed 🎉");
+    info!(ad.log, "interop bgp unnumbered test passed 🎉");
 
     Ok(())
 }
 
-/// Snapshot logs and live state from every VM in the quartet into `/work/` so
+/// Snapshot logs and live state from every configured interop VM into `/work/` so
 /// a failed run preserves the evidence past deployment teardown. The actual
 /// per-daemon and per-peer collection lives on each node type's
 /// `collect_diagnostics` method; this function is just the composition.
-async fn collect_diagnostics(
+async fn collect_interop_diagnostics(
     d: &Runner,
     ox: MgdNode,
-    cr1: FrrNode,
-    cr2: EosNode,
-    cr3: JuniperNode,
+    peer: MgdNode,
+    routers: InteropRouters,
     topo_name: &str,
     protocols: ProtocolDiagnostics,
 ) {
+    let InteropRouters { cr1, cr2, cr3 } = routers;
     warn!(d.log, "collecting diagnostics for {topo_name}");
     // ox VM: illumos network state, plus each daemon's log via its lens.
     ox.illumos().collect_diagnostics(d, topo_name).await;
     ox.dendrite().collect_diagnostics(d, topo_name).await;
     ox.ddm().collect_diagnostics(d, topo_name).await;
     ox.collect_diagnostics(d, topo_name).await;
+    peer.illumos().collect_diagnostics(d, topo_name).await;
+    peer.collect_diagnostics(d, topo_name).await;
     // Peer routers.
     cr1.collect_diagnostics(d, topo_name, protocols).await;
     cr2.collect_diagnostics(d, topo_name, protocols).await;
@@ -811,18 +1093,27 @@ async fn collect_diagnostics(
 /// Boot/setup failures happen before the topology is fully configured, so avoid
 /// network-state snapshots (`ip*`, `ipadm`, routes, neighbors). Collect only
 /// lightweight service/container state that explains which setup task failed.
-async fn collect_boot_diagnostics(
+async fn collect_interop_boot_diagnostics(
     d: &Runner,
     ox: MgdNode,
-    cr1: FrrNode,
-    cr2: EosNode,
-    cr3: JuniperNode,
+    peer: MgdNode,
+    routers: InteropRouters,
     topo_name: &str,
 ) {
+    let InteropRouters { cr1, cr2, cr3 } = routers;
     warn!(d.log, "collecting boot diagnostics for {topo_name}");
     crate::diagnostics::capture(d, ox.0, topo_name, "ox-svcs-xv", "svcs -xv")
         .await;
     ox.dendrite().collect_diagnostics(d, topo_name).await;
+    crate::diagnostics::capture(
+        d,
+        peer.0,
+        topo_name,
+        "peer-svcs-xv",
+        "svcs -xv",
+    )
+    .await;
+    peer.collect_diagnostics(d, topo_name).await;
 
     crate::diagnostics::capture(
         d,
@@ -985,20 +1276,14 @@ async fn juniper_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
     Ok(())
 }
 
-pub async fn cleanup_quartet_bfd_static_test() -> Result<()> {
-    clear_staged_routing_configs().context("clear stale Junos config")?;
-    cleanup_topology(QUARTET_BFD_STATIC_TOPO_NAME, |name| {
-        quartet(name).map(drop)
-    })
-}
-
-pub async fn run_quartet_bfd_static_test(
+async fn run_interop_bfd_static(
+    scenario: InteropScenario,
     persistent: bool,
     diag_on_fail: bool,
     commits: NpuvmCommits,
 ) -> Result<()> {
-    let bt = boot_quartet(
-        QUARTET_BFD_STATIC_TOPO_NAME,
+    let bt = boot_interop(
+        scenario,
         persistent,
         diag_on_fail,
         commits,
@@ -1028,22 +1313,24 @@ pub async fn run_quartet_bfd_static_test(
     )
     .await?;
 
-    run_with_optional_diagnostics(bt, diag_on_fail, quartet_bfd_static_body)
+    run_with_optional_diagnostics(bt, diag_on_fail, interop_bfd_static_body)
         .await
 }
 
-async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
-    let BootedQuartet {
+async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
+    let BootedInterop {
         ad,
         ox,
+        peer,
         cr1,
         cr2,
         cr3,
         mgd,
+        peer_mgd,
         dpd,
         ..
     } = bt;
-    let peers = QuartetNodes { cr1, cr2, cr3 };
+    let peers = InteropRouters { cr1, cr2, cr3 };
 
     // Register each ox-side address with dpd so softnpu punts packets for
     // those destinations to the CPU port. Link-local v6 is handled
@@ -1054,6 +1341,7 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
         ("qsfp0", OX_CR1_V4, OX_CR1_V6),
         ("qsfp1", OX_CR2_V4, OX_CR2_V6),
         ("qsfp2", OX_CR3_V4, OX_CR3_V6),
+        ("qsfp3", OX_PEER_V4, OX_PEER_V6),
     ] {
         let port = PortId::Qsfp(qsfp.parse().expect("parse qsfp port"));
         let link = LinkId(0);
@@ -1090,6 +1378,7 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
         ("tfportqsfp0_0", OX_CR1_V4_CIDR, OX_CR1_V6_CIDR),
         ("tfportqsfp1_0", OX_CR2_V4_CIDR, OX_CR2_V6_CIDR),
         ("tfportqsfp2_0", OX_CR3_V4_CIDR, OX_CR3_V6_CIDR),
+        ("tfportqsfp3_0", OX_PEER_V4_CIDR, OX_PEER_V6_CIDR),
     ] {
         let ll = format!("{link}/ll");
         ox.illumos()
@@ -1105,6 +1394,19 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
         }
     }
 
+    let peer_ll = format!("{HELIOS_PEER_LINK}/ll");
+    peer.illumos()
+        .addrconf(&ad, &peer_ll)
+        .await
+        .context(format!("addrconf {peer_ll}"))?;
+    for (suffix, cidr) in [("v4", PEER_V4_CIDR), ("v6", PEER_V6_CIDR)] {
+        let addrobj = format!("{HELIOS_PEER_LINK}/{suffix}");
+        peer.illumos()
+            .staticaddr(&ad, &addrobj, cidr)
+            .await
+            .context(format!("assign {cidr} to {HELIOS_PEER_LINK}"))?;
+    }
+
     ox.run_mgd(&ad).await?;
     // mg-lower's sync loop queries ddm on every prefix change and bails the
     // whole sync when ddm is unreachable. We don't exercise DDM here, but
@@ -1113,10 +1415,10 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
     // Default fanout is 1, which collapses the static paths into a single
-    // selected nexthop. Bump to 3 so all paths propagate through best-path
+    // selected nexthop. Bump to 4 so all paths propagate through best-path
     // selection and land in dpd as ECMP.
     mgd.update_bestpath_fanout(&BestpathFanoutRequest {
-        fanout: std::num::NonZeroU8::new(3).expect("fanout > 0"),
+        fanout: std::num::NonZeroU8::new(4).expect("fanout > 0"),
     })
     .await
     .context("mgd: set bestpath fanout")?;
@@ -1129,7 +1431,7 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
     info!(ad.log, "installing static v4 route {TEST_PREFIX_V4}");
     mgd.static_add_v4_route(&AddStaticRoute4Request {
         routes: StaticRoute4List {
-            list: [CR1_V4, CR2_V4, CR3_V4]
+            list: [CR1_V4, CR2_V4, CR3_V4, PEER_V4]
                 .into_iter()
                 .map(|nh| StaticRoute4 {
                     prefix: prefix_v4,
@@ -1146,7 +1448,7 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
     info!(ad.log, "installing static v6 route {TEST_PREFIX_V6}");
     mgd.static_add_v6_route(&AddStaticRoute6Request {
         routes: StaticRoute6List {
-            list: [CR1_V6, CR2_V6, CR3_V6]
+            list: [CR1_V6, CR2_V6, CR3_V6, PEER_V6]
                 .into_iter()
                 .map(|nh| StaticRoute6 {
                     prefix: prefix_v6,
@@ -1162,15 +1464,17 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
 
     info!(
         ad.log,
-        "adding BFD peers for cr1, cr2, and cr3 (dual-stack)"
+        "adding BFD peers for cr1, cr2, cr3, and peer (dual-stack)"
     );
     for (peer, listen) in [
         (IpAddr::V4(CR1_V4), IpAddr::V4(OX_CR1_V4)),
         (IpAddr::V4(CR2_V4), IpAddr::V4(OX_CR2_V4)),
         (IpAddr::V4(CR3_V4), IpAddr::V4(OX_CR3_V4)),
+        (IpAddr::V4(PEER_V4), IpAddr::V4(OX_PEER_V4)),
         (IpAddr::V6(CR1_V6), IpAddr::V6(OX_CR1_V6)),
         (IpAddr::V6(CR2_V6), IpAddr::V6(OX_CR2_V6)),
         (IpAddr::V6(CR3_V6), IpAddr::V6(OX_CR3_V6)),
+        (IpAddr::V6(PEER_V6), IpAddr::V6(OX_PEER_V6)),
     ] {
         mgd.add_bfd_peer(&BfdPeerConfig {
             peer,
@@ -1182,56 +1486,204 @@ async fn quartet_bfd_static_body(bt: BootedQuartet) -> Result<()> {
         .await
         .context(format!("mgd: add bfd peer {peer}"))?;
     }
+    configure_peer_bfd(&peer_mgd).await?;
 
     use BfdPeerState::{Down, Up};
 
     info!(ad.log, "phase 1: all peers up");
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Up, Up)).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 1")
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Up, Up, Up, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, true, true, true),
+        "phase 1",
+    )
+    .await?;
 
     info!(ad.log, "phase 2: stop frr on cr1");
     cr1.stop_frr(&ad).await?;
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Up, Up)).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, false, true, true, "phase 2")
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Down, Up, Up, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(false, true, true, true),
+        "phase 2",
+    )
+    .await?;
 
     info!(ad.log, "phase 3: pause ceos on cr2");
     cr2.pause(&ad).await?;
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Down, Up))
-        .await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, false, false, true, "phase 3")
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Down, Down, Up, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(false, false, true, true),
+        "phase 3",
+    )
+    .await?;
 
     info!(ad.log, "phase 4: pause cRPD on cr3");
     cr3.pause(&ad).await?;
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Down, Down, Down))
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Down, Down, Down, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(false, false, false, true),
+        "phase 4",
+    )
+    .await?;
+
+    info!(ad.log, "phase 5: stop mgd on peer");
+    peer.stop_mgd(&ad).await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Down, Down, Down, Down),
+    )
+    .await?;
     // With every nexthop shutdown, all shutdown nexthops are reinstated.
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 4")
-        .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, true, true, true),
+        "phase 5",
+    )
+    .await?;
 
-    info!(ad.log, "phase 5: start frr on cr1");
+    info!(ad.log, "phase 6: start frr on cr1");
     cr1.start_frr(&ad).await?;
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Down, Down))
-        .await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, false, false, "phase 5")
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Up, Down, Down, Down),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, false, false, false),
+        "phase 6",
+    )
+    .await?;
 
-    info!(ad.log, "phase 6: unpause ceos on cr2");
+    info!(ad.log, "phase 7: unpause ceos on cr2");
     cr2.unpause(&ad).await?;
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Up, Down)).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, false, "phase 6")
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Up, Up, Down, Down),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, true, false, false),
+        "phase 7",
+    )
+    .await?;
 
-    info!(ad.log, "phase 7: unpause cRPD on cr3");
+    info!(ad.log, "phase 8: unpause cRPD on cr3");
     cr3.unpause(&ad).await?;
-    expect_bfd(&mgd, peers, &ad, QuartetPeerStates::new(Up, Up, Up)).await?;
-    expect_route(&dpd, &prefix_v4, &prefix_v6, true, true, true, "phase 7")
-        .await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Up, Up, Up, Down),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, true, true, false),
+        "phase 8",
+    )
+    .await?;
 
-    info!(ad.log, "quartet bfd static routing test passed 🎉");
+    info!(ad.log, "phase 9: restart mgd on peer");
+    peer.run_mgd(&ad).await?;
+    wait_for_mgd(&peer_mgd, OP_TIMEOUT, &ad.log).await?;
+    // BFD sessions are process-local, so restore them after restarting mgd.
+    configure_peer_bfd(&peer_mgd).await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Up, Up, Up, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, true, true, true),
+        "phase 9",
+    )
+    .await?;
 
+    info!(ad.log, "interop bfd static routing test passed 🎉");
+
+    Ok(())
+}
+
+async fn configure_peer_bfd(mgd: &MgdClient) -> Result<()> {
+    for (peer, listen) in [
+        (IpAddr::V4(OX_PEER_V4), IpAddr::V4(PEER_V4)),
+        (IpAddr::V6(OX_PEER_V6), IpAddr::V6(PEER_V6)),
+    ] {
+        mgd.add_bfd_peer(&BfdPeerConfig {
+            peer,
+            listen,
+            required_rx: BFD_REQUIRED_RX_US,
+            detection_threshold: BFD_DETECTION_MULT,
+            mode: SessionMode::SingleHop,
+        })
+        .await
+        .context(format!("peer mgd: add bfd peer {peer}"))?;
+    }
     Ok(())
 }
 
@@ -1322,16 +1774,17 @@ async fn juniper_bfd_setup(r: JuniperNode, d: Arc<Runner>) -> Result<()> {
 /// peer daemon as a whole, the v4 and v6 sessions to a given peer always
 /// share the same state.
 ///
-/// mgd-side state is always checked. Peer-side state is checked only when
-/// the peer is expected `Up`: a paused daemon cannot answer queries, so
-/// `Down` phases have no observable peer-side truth.
+/// ox mgd-side state is always checked. Peer-side state is checked only when
+/// the peer is expected `Up`: a paused or stopped daemon cannot answer
+/// queries, so `Down` phases have no observable peer-side truth.
 const BFD_STABLE_SAMPLES: usize = 5;
 
 async fn expect_bfd(
     mgd: &MgdClient,
-    peers: QuartetNodes,
+    peer_mgd: &MgdClient,
+    peers: InteropRouters,
     d: &Runner,
-    states: QuartetPeerStates<BfdPeerState>,
+    states: InteropPeerStates<BfdPeerState>,
 ) -> Result<()> {
     for (peer, want) in [
         (IpAddr::V4(CR1_V4), states.cr1),
@@ -1340,6 +1793,8 @@ async fn expect_bfd(
         (IpAddr::V6(CR2_V6), states.cr2),
         (IpAddr::V4(CR3_V4), states.cr3),
         (IpAddr::V6(CR3_V6), states.cr3),
+        (IpAddr::V4(PEER_V4), states.peer),
+        (IpAddr::V6(PEER_V6), states.peer),
     ] {
         let desc = format!("mgd bfd {peer} -> {want:?}");
         wait_for_eq_stable!(
@@ -1383,35 +1838,48 @@ async fn expect_bfd(
             );
         }
     }
+    if matches!(states.peer, BfdPeerState::Up) {
+        for remote in [IpAddr::V4(OX_PEER_V4), IpAddr::V6(OX_PEER_V6)] {
+            let desc = format!("peer bfd {remote} -> Up");
+            wait_for_eq_stable!(
+                bfd_state(peer_mgd, remote).await,
+                Some(BfdPeerState::Up),
+                BFD_STABLE_SAMPLES,
+                &desc
+            );
+        }
+    }
     Ok(())
 }
 
-/// Expect the test's v4 + v6 prefixes to resolve to the given subset of cr1 /
-/// cr2 as dpd targets.
+/// Expect the test's v4 + v6 prefixes to resolve to the given peer subset as
+/// dpd targets.
 async fn expect_route(
     dpd: &DpdClient,
     prefix_v4: &Ipv4Net,
     prefix_v6: &Ipv6Net,
-    cr1_in: bool,
-    cr2_in: bool,
-    cr3_in: bool,
+    included: InteropPeerStates<bool>,
     phase: &str,
 ) -> Result<()> {
-    // Push cr1 before cr2 so the list is already in the sorted order that
-    // dpd_v*_targets returns.
+    // Push peers in address order so the list is already in the sorted order
+    // that dpd_v*_targets returns.
     let mut want_v4: Vec<IpAddr> = Vec::new();
     let mut want_v6: Vec<IpAddr> = Vec::new();
-    if cr1_in {
+    if included.cr1 {
         want_v4.push(IpAddr::V4(CR1_V4));
         want_v6.push(IpAddr::V6(CR1_V6));
     }
-    if cr2_in {
+    if included.cr2 {
         want_v4.push(IpAddr::V4(CR2_V4));
         want_v6.push(IpAddr::V6(CR2_V6));
     }
-    if cr3_in {
+    if included.cr3 {
         want_v4.push(IpAddr::V4(CR3_V4));
         want_v6.push(IpAddr::V6(CR3_V6));
+    }
+    if included.peer {
+        want_v4.push(IpAddr::V4(PEER_V4));
+        want_v6.push(IpAddr::V6(PEER_V6));
     }
 
     let desc_v4 = format!("{phase} v4");
@@ -1440,12 +1908,13 @@ async fn bfd_state(mgd: &MgdClient, peer: IpAddr) -> Option<BfdPeerState> {
 async fn expect_bgp_neighbor_states(
     mgd: &MgdClient,
     local_asn: u32,
-    states: QuartetPeerStates<FsmStateKind>,
+    states: InteropPeerStates<FsmStateKind>,
 ) -> Result<()> {
     for (name, want) in [
         ("cr1", states.cr1),
         ("cr2", states.cr2),
         ("cr3", states.cr3),
+        ("peer", states.peer),
     ] {
         let desc = format!("mgd bgp {name} -> {want:?}");
         wait_for_eq!(

--- a/falcon-lab/src/topo.rs
+++ b/falcon-lab/src/topo.rs
@@ -3,7 +3,20 @@
 use anyhow::Result;
 use libfalcon::{Runner, node, unit::gb};
 
-use crate::{eos::EosNode, frr::FrrNode, juniper::JuniperNode, mgd::MgdNode};
+use crate::{
+    eos::EosNode,
+    frr::FrrNode,
+    juniper::JuniperNode,
+    mgd::MgdNode,
+    scenario::{InteropScenario, MgdDuoScenario},
+};
+
+pub(crate) trait Topology: Sized {
+    type Scenario;
+
+    fn build(scenario: Self::Scenario) -> Result<Self>;
+    fn runner_mut(&mut self) -> &mut Runner;
+}
 
 pub struct MgdDuo {
     pub d: Runner,
@@ -11,74 +24,94 @@ pub struct MgdDuo {
     pub ox2: MgdNode,
 }
 
-pub struct Quartet {
+impl Topology for MgdDuo {
+    type Scenario = MgdDuoScenario;
+
+    fn build(scenario: MgdDuoScenario) -> Result<Self> {
+        let mut d = Runner::new(scenario.name());
+
+        node!(d, ox1, "helios-3.0", 4, gb(4));
+        node!(d, ox2, "helios-3.0", 4, gb(4));
+
+        d.link(ox1, ox2);
+
+        d.default_ext_link(ox1)?;
+        d.default_ext_link(ox2)?;
+
+        d.mount("cargo-bay", "/opt/cargo-bay", ox1)?;
+        d.mount("cargo-bay", "/opt/cargo-bay", ox2)?;
+
+        Ok(Self {
+            d,
+            ox1: MgdNode(ox1),
+            ox2: MgdNode(ox2),
+        })
+    }
+
+    fn runner_mut(&mut self) -> &mut Runner {
+        &mut self.d
+    }
+}
+
+pub struct Interop {
     pub d: Runner,
     pub ox: MgdNode,
+    pub peer: MgdNode,
     pub cr1: FrrNode,
     pub cr2: EosNode,
     pub cr3: JuniperNode,
 }
 
-pub fn mgd_duo(name: &str) -> Result<MgdDuo> {
-    let mut d = Runner::new(name);
+impl Topology for Interop {
+    type Scenario = InteropScenario;
 
-    node!(d, ox1, "helios-3.0", 4, gb(4));
-    node!(d, ox2, "helios-3.0", 4, gb(4));
+    fn build(scenario: InteropScenario) -> Result<Self> {
+        let mut d = Runner::new(scenario.name());
 
-    d.link(ox1, ox2);
+        node!(d, ox, "helios-3.0", 4, gb(4));
+        node!(d, cr1, "debian-13.2", 4, gb(4));
+        node!(d, cr2, "eos-4.35", 4, gb(4));
+        node!(d, cr3, "junos-23.2", 4, gb(4));
+        node!(d, peer, "helios-3.0", 4, gb(4));
 
-    d.default_ext_link(ox1)?;
-    d.default_ext_link(ox2)?;
+        let mut mac_counter = 0;
+        let mut new_mac = || {
+            mac_counter += 1;
+            format!("a8:40:25:00:00:{mac_counter:02}")
+        };
 
-    d.mount("cargo-bay", "/opt/cargo-bay", ox1)?;
-    d.mount("cargo-bay", "/opt/cargo-bay", ox2)?;
+        d.softnpu_link(ox, cr1, Some(new_mac()), None);
+        d.softnpu_link(ox, cr2, Some(new_mac()), None);
+        d.softnpu_link(ox, cr3, Some(new_mac()), None);
+        d.softnpu_link(ox, peer, Some(new_mac()), None);
 
-    Ok(MgdDuo {
-        d,
-        ox1: MgdNode(ox1),
-        ox2: MgdNode(ox2),
-    })
-}
+        d.default_ext_link(ox)?;
+        d.default_ext_link(cr1)?;
+        d.default_ext_link(cr2)?;
+        d.default_ext_link(cr3)?;
+        d.default_ext_link(peer)?;
 
-pub fn quartet(name: &str) -> Result<Quartet> {
-    let mut d = Runner::new(name);
+        d.mount("cargo-bay", "/opt/cargo-bay", ox)?;
+        d.mount_linux("cargo-bay", "/opt/cargo-bay", cr1)?;
+        d.mount("cargo-bay", "/opt/cargo-bay", cr2)?;
+        d.mount_linux("cargo-bay", "/opt/cargo-bay", cr3)?;
+        d.mount("cargo-bay", "/opt/cargo-bay", peer)?;
+        // The Junos image mounts cargo-bay and applies staged configuration
+        // from guest-side systemd services. Keep the 9p device in the spec,
+        // but avoid Falcon's serial-driven setup/mount path for this node.
+        d.do_setup(cr3, false);
 
-    // nodes
-    node!(d, ox, "helios-3.0", 4, gb(4));
-    node!(d, cr1, "debian-13.2", 4, gb(4));
-    node!(d, cr2, "eos-4.35", 4, gb(4));
-    node!(d, cr3, "junos-23.2", 4, gb(4));
+        Ok(Self {
+            d,
+            ox: MgdNode(ox),
+            peer: MgdNode(peer),
+            cr1: FrrNode(cr1),
+            cr2: EosNode(cr2),
+            cr3: JuniperNode(cr3),
+        })
+    }
 
-    // links
-    let mut mac_counter = 0;
-    let mut new_mac = || {
-        mac_counter += 1;
-        format!("a8:40:25:00:00:{mac_counter:02}")
-    };
-
-    d.softnpu_link(ox, cr1, Some(new_mac()), None);
-    d.softnpu_link(ox, cr2, Some(new_mac()), None);
-    d.softnpu_link(ox, cr3, Some(new_mac()), None);
-
-    d.default_ext_link(ox)?;
-    d.default_ext_link(cr1)?;
-    d.default_ext_link(cr2)?;
-    d.default_ext_link(cr3)?;
-
-    d.mount("cargo-bay", "/opt/cargo-bay", ox)?;
-    d.mount_linux("cargo-bay", "/opt/cargo-bay", cr1)?;
-    d.mount("cargo-bay", "/opt/cargo-bay", cr2)?;
-    d.mount_linux("cargo-bay", "/opt/cargo-bay", cr3)?;
-    // The Junos image mounts cargo-bay and applies staged configuration from
-    // guest-side systemd services. Keep the 9p device in the spec, but avoid
-    // Falcon's serial-driven setup/mount path for this node.
-    d.do_setup(cr3, false);
-
-    Ok(Quartet {
-        d,
-        ox: MgdNode(ox),
-        cr1: FrrNode(cr1),
-        cr2: EosNode(cr2),
-        cr3: JuniperNode(cr3),
-    })
+    fn runner_mut(&mut self) -> &mut Runner {
+        &mut self.d
+    }
 }


### PR DESCRIPTION
Refactor falcon-lab to have separate abstractions for Topologies and Scenarios. A Topology is a set of nodes, their backend (VM image), and the links interconnecting them. A Scenario is layered atop a Topology, describing the configuration, diagnostics, and test cases being applied.

The old run targets now look like this:
- mgd-unnumbered -> (mgd-duo, bgp-unnumbered)
- quartet-unnumbered -> (interop, bgp-unnumbered)
- quartet-bfd-static-routing -> (interop, bfd-static-routing)

Signed-off-by: Trey Aspelund <trey@oxidecomputer.com>