### PR TITLE
buildomat: use prebuilt nextest binaries

### DIFF
--- a/.github/buildomat/test-common.sh
+++ b/.github/buildomat/test-common.sh
@@ -1,14 +1,40 @@
 #!/bin/bash
 
+# Install nextest from the prebuilt binaries published by the nextest project
+# rather than building from source via `cargo install`. `cargo install`
+# resolves dependencies fresh from crates.io and an updated transitive dep can
+# break CI with no change on our side. Prebuilt binaries avoid that entirely.
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
 NEXTEST_VERSION='0.9.97'
-PLATFORM='illumos'
 
 source .github/buildomat/common.sh
 
 banner "install"
 pfexec pkg install clang-15
 
-cargo install cargo-nextest --version "$NEXTEST_VERSION"
+# Derive the platform from the host, since jobs sourcing this script run on
+# both illumos and Linux runners. This mirrors omicron's
+# .github/buildomat/build-and-test.sh.
+nextest_host_os="$(uname -s)"
+case "${nextest_host_os}" in
+	SunOS) nextest_platform='illumos' ;;
+	Linux) nextest_platform='linux' ;;
+	*)
+		echo "error: no prebuilt nextest platform for ${nextest_host_os}" >&2
+		exit 1
+		;;
+esac
+nextest_url="https://get.nexte.st/${NEXTEST_VERSION}/${nextest_platform}"
+
+nextest_tmp="$(mktemp -d)"
+trap 'rm -rf "${nextest_tmp}"' EXIT
+nextest_tar="${nextest_tmp}/nextest.tar.gz"
+
+# Download to a file rather than piping into tar so that a failed download
+# can't be masked by tar's success.
+curl -sSfL --retry 10 -o "${nextest_tar}" "${nextest_url}"
+
+mkdir -p "${CARGO_HOME:-${HOME}/.cargo}/bin"
+tar -xzf "${nextest_tar}" -C "${CARGO_HOME:-${HOME}/.cargo}/bin"


### PR DESCRIPTION
Instead of using `cargo install` to get cargo-nextest, use a prebuilt binary. Otherwise changes to transitive dependencies can break the build and thus can break our CI.

Example:
```
135	2026-09-03T21:22:31.876Z	++ cargo install cargo-nextest --version 0.9.97
136	2026-09-03T21:22:31.920Z	    Updating crates.io index
[..]
692	2026-09-03T21:23:08.801Z	   Compiling tinyvec v1.13.0
693	2026-09-03T21:23:08.877Z	error: cannot find macro `vec` in this scope
694	2026-09-03T21:23:08.877Z	   --> /home/build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tinyvec-1.13.0/src/tinyvec.rs:710:21
695	2026-09-03T21:23:08.878Z	    |
696	2026-09-03T21:23:08.878Z	710 |       TinyVec::Heap(vec![A::Item::default(); len])
697	2026-09-03T21:23:08.878Z	    |                     ^^^
698	2026-09-03T21:23:08.878Z	    |
699	2026-09-03T21:23:08.878Z	note: `vec` is imported here, but it is a module, not a macro
700	2026-09-03T21:23:08.878Z	   --> /home/build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tinyvec-1.13.0/src/tinyvec.rs:3:18
701	2026-09-03T21:23:08.878Z	    |
702	2026-09-03T21:23:08.878Z	  3 | use alloc::vec::{self, Vec};
703	2026-09-03T21:23:08.878Z	    |                  ^^^^
704	2026-09-03T21:23:08.878Z	help: consider importing one of these macros
705	2026-09-03T21:23:08.878Z	    |
706	2026-09-03T21:23:08.878Z	  1 + use crate::tinyvec::alloc::vec;
707	2026-09-03T21:23:08.878Z	    |
708	2026-09-03T21:23:08.878Z	  1 + use alloc::vec;
709	2026-09-03T21:23:08.878Z	    |
710	2026-09-03T21:23:08.878Z	
711	2026-09-03T21:23:08.951Z	   Compiling cargo-util-schemas v0.2.0
712	2026-09-03T21:23:09.623Z	error: could not compile `tinyvec` (lib) due to 1 previous error
713	2026-09-03T21:23:09.623Z	warning: build failed, waiting for other jobs to finish...
714	2026-09-03T21:23:14.207Z	error: failed to compile `cargo-nextest v0.9.97`, intermediate artifacts can be found at `/tmp/cargo-installD5ZPVN`.
```