### PR TITLE
falcon-lab: add BIRD to interop topologies

### DIFF
--- a/.github/buildomat/jobs/falcon-lab.sh
+++ b/.github/buildomat/jobs/falcon-lab.sh
@@ -117,3 +117,4 @@ run_test() {
 run_test mgd-duo bgp-unnumbered
 run_test interop bgp-unnumbered
 run_test interop bfd-static-routing
+run_test interop-3-link bgp-md5

--- a/falcon-lab/README.md
+++ b/falcon-lab/README.md
@@ -2,9 +2,9 @@
 
 `falcon-lab` runs Maghemite integration topologies under Falcon. A topology
 defines the VM graph, while a scenario configures and tests that topology. The
-topologies use prebuilt Falcon base images for Helios, Debian/FRR, cEOS, and
-Junos/cRPD nodes, plus a per-run `cargo-bay/` 9p share for binaries and runtime
-configuration.
+topologies use prebuilt Falcon base images for Helios, Debian/FRR, cEOS,
+Junos/cRPD, and BIRD 2 nodes, plus a per-run `cargo-bay/` 9p share for binaries
+and runtime configuration.
 
 ## Topologies and scenarios
 
@@ -16,10 +16,18 @@ mgd-duo  bgp-unnumbered
 interop  bare
 interop  bgp-unnumbered
 interop  bfd-static-routing
+interop-3-link  bare
+interop-3-link  bgp-md5
 ```
 
 `mgd-duo` connects two Maghemite nodes. `interop` connects a Maghemite DUT to
-FRR, Arista EOS, Juniper cRPD, and a second Maghemite node.
+FRR, Arista EOS, Juniper cRPD, BIRD 2, and a second Maghemite node.
+`interop-3-link` uses the same peers with three links per peer.
+
+- `bgp-unnumbered` checks dual-stack route exchange and interop ECMP.
+- `bgp-md5` checks authenticated numbered and unnumbered sessions, stability,
+  and multipath route exchange.
+- `bfd-static-routing` checks dual-stack BFD and static-route failover/recovery.
 
 Run and cleanup commands both take a topology and scenario:
 
@@ -91,12 +99,7 @@ chmod 0600 cargo-bay/falcon-juniper-license.key
 
 The Falcon image named `junos-23.2` is expected to be built by the experimental
 `voxel-image` tooling from the
-[`oxidecomputer/voxel`](https://github.com/oxidecomputer/voxel) repository. The
-portable artifact is uploaded alongside other Falcon assets as:
-
-```text
-https://oxide-falcon-assets.s3.us-west-2.amazonaws.com/junos-23.2_0.raw.xz
-```
+[`oxidecomputer/voxel`](https://github.com/oxidecomputer/voxel) repository.
 
 The image must already contain Docker and the Juniper cRPD image. It must not
 contain a license or topology-specific routing config.
@@ -154,9 +157,9 @@ base-image dataset destroyed/replaced so the new image is used.
 ## Running with diagnostics disabled
 
 Failure diagnostics are enabled by default. Before collecting them, falcon-lab
-attempts to start FRR and unpause cEOS and cRPD so their normal CLI and API
-paths are available. `--no-cleanup` preserves the topology after the run, but
-does not prevent this diagnostic recovery.
+attempts to start FRR and BIRD and unpause cEOS and cRPD so their normal CLI
+and API paths are available. `--no-cleanup` preserves the topology after the
+run, but does not prevent this diagnostic recovery.
 
 To preserve the exact failure state for manual inspection, including peers
 that the scenario left paused or stopped, disable diagnostics as well as

--- a/falcon-lab/src/bird.rs
+++ b/falcon-lab/src/bird.rs
@@ -1,0 +1,214 @@
+//! Baked BIRD 2 peer: explicit networking, configuration, and CLI assertions.
+
+use anyhow::{Context, Result, ensure};
+use libfalcon::{NodeRef, Runner};
+use serde::Deserialize;
+use std::{
+    fs,
+    net::{IpAddr, Ipv6Addr},
+    time::Duration,
+};
+
+use crate::{linux::LinuxNode, wait_for_eq};
+
+mod config;
+pub use config::{ASN, BgpLink, MD5_KEY, bgp_config};
+use config::{bfd_config, bfd_peers_up, protocol_established, route_imported};
+
+#[derive(Copy, Clone)]
+pub struct BirdNode(pub NodeRef);
+
+impl BirdNode {
+    /// Match data interfaces by the MAC assigned by Falcon, not Debian's PCI
+    /// naming/order (the management NIC must never participate in discovery).
+    pub fn data_mac(index: usize) -> String {
+        format!("a8:40:25:01:00:{index:02x}")
+    }
+
+    async fn checked(&self, d: &Runner, command: &str) -> Result<String> {
+        let output = d
+            .exec(
+                self.0,
+                &format!("({command}) && printf '\\nFALCON_BIRD_OK\\n'"),
+            )
+            .await?;
+        ensure!(
+            output.lines().any(|l| l.trim() == "FALCON_BIRD_OK"),
+            "BIRD guest command failed: {command}: {output}"
+        );
+        Ok(output)
+    }
+
+    pub async fn data_interface(
+        &self,
+        d: &Runner,
+        index: usize,
+    ) -> Result<String> {
+        #[derive(Deserialize)]
+        struct Link {
+            ifname: String,
+            address: String,
+        }
+        let output = d.exec(self.0, "ip -j link show").await?;
+        let links: Vec<Link> = serde_json::from_str(&output)
+            .context("parse BIRD interface inventory")?;
+        let mac = Self::data_mac(index);
+        let mut matching = links.iter().filter(|l| l.address == mac);
+        let interface = matching.next().context("BIRD data MAC missing")?;
+        ensure!(matching.next().is_none(), "duplicate BIRD data MAC {mac}");
+        ensure!(
+            interface
+                .ifname
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "unexpected BIRD interface name: {}",
+            interface.ifname
+        );
+        self.checked(d, &format!(
+            "sysctl -w net.ipv6.conf.{}.disable_ipv6=0 && ip link set dev {} up",
+            interface.ifname, interface.ifname
+        )).await?;
+        Ok(interface.ifname.clone())
+    }
+
+    pub async fn link_local(
+        &self,
+        d: &Runner,
+        interface: &str,
+    ) -> Result<Ipv6Addr> {
+        #[derive(Deserialize)]
+        struct Interface {
+            addr_info: Vec<Address>,
+        }
+        #[derive(Deserialize)]
+        struct Address {
+            local: Ipv6Addr,
+            #[serde(default)]
+            tentative: bool,
+            #[serde(default)]
+            dadfailed: bool,
+        }
+        for _ in 0..20 {
+            let output = d
+                .exec(
+                    self.0,
+                    &format!("ip -j -6 addr show dev {interface} scope link"),
+                )
+                .await?;
+            let interfaces: Vec<Interface> = serde_json::from_str(&output)
+                .context("parse BIRD IPv6 addresses")?;
+            if let Some(address) =
+                interfaces.iter().flat_map(|i| &i.addr_info).find(|a| {
+                    a.local.is_unicast_link_local()
+                        && !a.tentative
+                        && !a.dadfailed
+                })
+            {
+                return Ok(address.local);
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        anyhow::bail!(
+            "BIRD {interface}: no usable link-local address after DAD"
+        )
+    }
+
+    pub async fn apply(&self, d: &Runner, config: &str) -> Result<()> {
+        let name = format!("{}-bird.conf", d.get_node(self.0).name);
+        fs::create_dir_all("cargo-bay")?;
+        fs::write(format!("cargo-bay/{name}"), config)?;
+        // Clear the marker ourselves as well: even a missing voxel-init must
+        // not let an earlier successful invocation masquerade as readiness.
+        self.checked(d, &format!(
+            "rm -f /run/voxel-bird-ready && /opt/oxide/voxel-init bird --config /opt/cargo-bay/{name} && test -f /run/voxel-bird-ready && birdc show status"
+        )).await?;
+        Ok(())
+    }
+
+    pub async fn setup_bfd(&self, d: &Runner) -> Result<()> {
+        let interface = self.data_interface(d, 0).await?;
+        self.link_local(d, &interface).await?;
+        self.checked(d, &format!(
+            "ip addr replace 10.0.4.2/24 dev {interface} && ip -6 addr replace fd00:5::2/64 dev {interface}"
+        )).await?;
+        self.apply(d, &bfd_config(&interface)).await
+    }
+
+    pub async fn stop(&self, d: &Runner) -> Result<()> {
+        self.checked(d, "systemctl stop bird && rm -f /run/voxel-bird-ready && test \"$(systemctl is-active bird)\" = inactive").await?;
+        Ok(())
+    }
+
+    pub async fn start(&self, d: &Runner) -> Result<()> {
+        self.checked(d, "systemctl reset-failed bird && systemctl start bird")
+            .await?;
+        wait_for_eq!(
+            self.checked(d, "birdc show status").await.is_ok(),
+            true,
+            "BIRD control socket ready"
+        );
+        Ok(())
+    }
+
+    pub async fn bgp_established(
+        &self,
+        d: &Runner,
+        index: usize,
+    ) -> Result<bool> {
+        let name = format!("dut{index}");
+        let output = d
+            .exec(self.0, &format!("birdc show protocols {name}"))
+            .await?;
+        Ok(protocol_established(&output, &name))
+    }
+
+    pub async fn bgp_imported(
+        &self,
+        d: &Runner,
+        index: usize,
+        prefix: &str,
+    ) -> Result<bool> {
+        let name = format!("dut{index}");
+        let table = if prefix.contains(':') {
+            "master6"
+        } else {
+            "master4"
+        };
+        let output = d.exec(self.0, &format!(
+            "birdc 'show route table {table} for {prefix} protocol {name} all'"
+        )).await?;
+        Ok(route_imported(&output, &name, prefix))
+    }
+
+    pub async fn bfd_peers_up(
+        &self,
+        d: &Runner,
+        wanted: &[IpAddr],
+    ) -> Result<bool> {
+        let output = d.exec(self.0, "birdc show bfd sessions").await?;
+        Ok(bfd_peers_up(&output, wanted))
+    }
+
+    pub async fn collect_diagnostics(&self, d: &Runner, topo: &str) {
+        let name = &d.get_node(self.0).name;
+        for (suffix, command) in [
+            ("image", "cat /var/voxel-image-ready"),
+            ("status", "birdc show status"),
+            ("protocols", "birdc show protocols all"),
+            ("routes4", "birdc show route table master4 all"),
+            ("routes6", "birdc show route table master6 all"),
+            ("bfd", "birdc show bfd sessions"),
+            ("journal", "journalctl -u bird --no-pager -n 200"),
+        ] {
+            crate::diagnostics::capture(
+                d,
+                self.0,
+                topo,
+                &format!("{name}-{suffix}"),
+                command,
+            )
+            .await;
+        }
+        LinuxNode(self.0).collect_diagnostics(d, topo, name).await;
+    }
+}

--- a/falcon-lab/src/bird/config.rs
+++ b/falcon-lab/src/bird/config.rs
@@ -1,0 +1,203 @@
+//! BIRD's configuration and CLI text formats, independent of the Falcon runtime.
+
+use std::net::{IpAddr, Ipv6Addr};
+
+pub const MD5_KEY: &str = "falcon-bgp-md5-test-key";
+pub const ASN: u32 = 48;
+
+pub struct BgpLink {
+    pub interface: String,
+    pub local: Ipv6Addr,
+    pub remote: Ipv6Addr,
+}
+
+pub fn bgp_config(links: &[BgpLink]) -> String {
+    let mut config = format!(
+        r#"router id 1.2.3.3;
+log stderr all;
+protocol device {{}}
+protocol static origins4 {{ ipv4; route 1.2.3.0/24 blackhole; }}
+protocol static origins6 {{ ipv6; route fd99::/64 blackhole; }}
+template bgp dut_unnumbered {{
+    local as {ASN};
+    neighbor as 33;
+    direct;
+    authentication md5;
+    password "{MD5_KEY}";
+    hold time 6;
+    keepalive time 2;
+    connect delay time 1;
+    connect retry time 1;
+    error wait time 1, 5;
+    graceful restart off;
+    ipv4 {{
+        import all;
+        export filter {{
+            if (source = RTS_STATIC) && (net = 1.2.3.0/24) then {{
+                bgp_origin = ORIGIN_IGP; accept;
+            }}
+            reject;
+        }};
+        extended next hop on;
+    }};
+    ipv6 {{
+        import all;
+        export filter {{
+            if (source = RTS_STATIC) && (net = fd99::/64) then {{
+                bgp_origin = ORIGIN_IGP; accept;
+            }}
+            reject;
+        }};
+    }};
+}}
+protocol radv discovery {{
+"#
+    );
+    for link in links {
+        config.push_str(&format!(r#"    interface "{}" {{ min ra interval 3; max ra interval 4; default lifetime 0; }};
+"#, link.interface));
+    }
+    config.push_str("}\n");
+    for (index, link) in links.iter().enumerate() {
+        config.push_str(&format!(
+            r#"protocol bgp dut{index} from dut_unnumbered {{
+    interface "{}";
+    local {};
+    neighbor {};
+}}
+"#,
+            link.interface, link.local, link.remote
+        ));
+    }
+    config
+}
+
+pub fn bfd_config(interface: &str) -> String {
+    format!(
+        r#"router id 1.2.3.3;
+log stderr all;
+protocol device {{}}
+protocol bfd peers {{
+    interface "{interface}" {{ interval 1 s; multiplier 3; }};
+    neighbor 10.0.4.1 dev "{interface}" local 10.0.4.2;
+    neighbor fd00:5::1 dev "{interface}" local fd00:5::2;
+}}
+"#
+    )
+}
+
+pub fn protocol_established(output: &str, name: &str) -> bool {
+    output.lines().any(|line| {
+        let fields: Vec<_> = line.split_whitespace().collect();
+        fields.len() >= 6
+            && fields[0] == name
+            && fields[1] == "BGP"
+            && fields[3] == "up"
+            && fields.last() == Some(&"Established")
+    })
+}
+
+pub fn route_imported(output: &str, name: &str, prefix: &str) -> bool {
+    output.lines().any(|line| {
+        line.split_whitespace().next() == Some(prefix)
+            && line.contains(&format!("[{name} "))
+    }) && output.lines().any(|line| {
+        let mut fields = line.split_whitespace();
+        fields.next() == Some("Type:") && fields.next() == Some("BGP")
+    })
+}
+
+pub fn bfd_peers_up(output: &str, wanted: &[IpAddr]) -> bool {
+    wanted.iter().all(|peer| {
+        output.lines().any(|line| {
+            let fields: Vec<_> = line.split_whitespace().collect();
+            fields.len() >= 3
+                && fields[0].parse::<IpAddr>().ok() == Some(*peer)
+                && fields[2] == "Up"
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn generated_bgp_is_scoped_authenticated_and_export_filtered() {
+        for count in [1, 3] {
+            let links: Vec<_> = (0..count)
+                .map(|i| BgpLink {
+                    interface: format!("enp0s{}", 8 + i),
+                    local: format!("fe80::{}", i + 1).parse().unwrap(),
+                    remote: format!("fe80::{}", i + 10).parse().unwrap(),
+                })
+                .collect();
+            let config = bgp_config(&links);
+            assert_eq!(config.matches("from dut_unnumbered").count(), count);
+            assert_eq!(config.matches("default lifetime 0").count(), count);
+            assert!(config.contains("authentication md5;"));
+            assert!(config.contains(&format!("password \"{MD5_KEY}\";")));
+            assert!(config.contains("extended next hop on;"));
+            assert_eq!(config.matches("source = RTS_STATIC").count(), 2);
+            for (index, link) in links.iter().enumerate() {
+                assert!(config.contains(&format!("protocol bgp dut{index}")));
+                assert!(config.contains(&format!("neighbor {};", link.remote)));
+            }
+        }
+    }
+
+    #[test]
+    fn cli_checks_reject_missing_down_and_wrong_source() {
+        assert!(protocol_established(
+            "dut0 BGP --- up 12:00:00 Established",
+            "dut0"
+        ));
+        assert!(!protocol_established(
+            "dut0 BGP --- start 12:00:00 Active",
+            "dut0"
+        ));
+        assert!(!protocol_established("Unable to connect to server", "dut0"));
+        let route =
+            "4.5.6.0/24 unicast [dut0 12:00:00] * (100)\n Type: BGP univ";
+        assert!(route_imported(route, "dut0", "4.5.6.0/24"));
+        assert!(!route_imported(route, "dut1", "4.5.6.0/24"));
+        assert!(!route_imported(route, "dut0", "4.5.0.0/16"));
+        assert!(!route_imported(
+            &route.replace("BGP", "static"),
+            "dut0",
+            "4.5.6.0/24"
+        ));
+        let wanted =
+            ["10.0.4.1".parse().unwrap(), "fd00:5::1".parse().unwrap()];
+        let bfd = "IP address Interface State Since Interval Timeout\n10.0.4.1 enp0s8 Up 12:00:00 1.000 3.000\nfd00:5::1 enp0s8 Up 12:00:00 1.000 3.000";
+        assert!(bfd_peers_up(bfd, &wanted));
+        assert!(!bfd_peers_up(
+            &bfd.replace("fd00:5::1 enp0s8 Up", "fd00:5::1 enp0s8 Down"),
+            &wanted
+        ));
+        assert!(!bfd_peers_up("", &wanted));
+    }
+
+    /// Set BIRD_CONFIG_DIR to retain the exact generated fixtures for bird -p
+    /// validation on a Linux host; no daemon is started by this test.
+    #[test]
+    fn export_parser_fixtures() {
+        let Ok(dir) = std::env::var("BIRD_CONFIG_DIR") else {
+            return;
+        };
+        fs::create_dir_all(&dir).unwrap();
+        for count in [1, 3] {
+            let links: Vec<_> = (0..count)
+                .map(|i| BgpLink {
+                    interface: format!("eth{i}"),
+                    local: format!("fe80::{}", i + 1).parse().unwrap(),
+                    remote: format!("fe80::{}", i + 10).parse().unwrap(),
+                })
+                .collect();
+            fs::write(format!("{dir}/bgp-{count}.conf"), bgp_config(&links))
+                .unwrap();
+        }
+        fs::write(format!("{dir}/bfd.conf"), bfd_config("eth0")).unwrap();
+    }
+}

--- a/falcon-lab/src/main.rs
+++ b/falcon-lab/src/main.rs
@@ -8,6 +8,7 @@ use crate::scenario::{
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 mod bgp;
+mod bird;
 mod ddm;
 mod dendrite;
 mod diagnostics;

--- a/falcon-lab/src/scenario.rs
+++ b/falcon-lab/src/scenario.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     bgp::basic_unnumbered_neighbor,
+    bird::{self, BgpLink, BirdNode},
     dendrite::{NpuvmCommits, softnpu_link_create, wait_for_dpd},
     diagnostics::ProtocolDiagnostics,
     eos::EosNode,
@@ -291,6 +292,11 @@ const CR2_V6_CIDR: &str = "fd00:2::2/64";
 const CR3_V6_CIDR: &str = "fd00:3::2/64";
 const PEER_V6_CIDR: &str = "fd00:4::2/64";
 
+const OX_BIRD_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 4, 1);
+const BIRD_V4: Ipv4Addr = Ipv4Addr::new(10, 0, 4, 2);
+const OX_BIRD_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 5, 0, 0, 0, 0, 0, 1);
+const BIRD_V6: Ipv6Addr = Ipv6Addr::new(0xfd00, 5, 0, 0, 0, 0, 0, 2);
+
 /// Destination prefixes with nexthops via every interop peer.
 const TEST_PREFIX_V4: &str = "192.168.100.0/24";
 const TEST_PREFIX_V6: &str = "fd01::/64";
@@ -312,6 +318,7 @@ struct BootedInterop {
     cr1: FrrNode,
     cr2: EosNode,
     cr3: JuniperNode,
+    bird: BirdNode,
     mgd: MgdClient,
     peer_mgd: MgdClient,
     dpd: DpdClient,
@@ -326,6 +333,7 @@ struct InteropRouters {
     cr1: FrrNode,
     cr2: EosNode,
     cr3: JuniperNode,
+    bird: BirdNode,
 }
 
 #[derive(Copy, Clone)]
@@ -343,9 +351,13 @@ impl InteropLayout {
     }
 
     const fn front_ports(self) -> usize {
+        5 * self.links_per_peer()
+    }
+
+    const fn links_per_peer(self) -> usize {
         match self {
-            Self::SingleLink(_) => 4,
-            Self::ThreeLinks(_) => 12,
+            Self::SingleLink(_) => 1,
+            Self::ThreeLinks(_) => 3,
         }
     }
 
@@ -362,15 +374,17 @@ struct InteropPeerStates<T> {
     cr2: T,
     cr3: T,
     peer: T,
+    bird: T,
 }
 
 impl<T> InteropPeerStates<T> {
-    fn new(cr1: T, cr2: T, cr3: T, peer: T) -> Self {
+    fn new(cr1: T, cr2: T, cr3: T, peer: T, bird: T) -> Self {
         Self {
             cr1,
             cr2,
             cr3,
             peer,
+            bird,
         }
     }
 }
@@ -405,6 +419,7 @@ where
         cr1: bt.cr1,
         cr2: bt.cr2,
         cr3: bt.cr3,
+        bird: bt.bird,
     };
     let mgd = bt.mgd.clone();
     let peer_mgd = bt.peer_mgd.clone();
@@ -436,12 +451,24 @@ async fn restore_interop_before_diagnostics(
     ad: &Runner,
     routers: InteropRouters,
 ) {
-    let InteropRouters { cr1, cr2, cr3 } = routers;
-    let (cr1_result, cr2_result, cr3_result) = tokio::join!(
+    let InteropRouters {
+        cr1,
+        cr2,
+        cr3,
+        bird,
+    } = routers;
+    let (cr1_result, cr2_result, cr3_result, bird_result) = tokio::join!(
         timeout(OP_TIMEOUT, cr1.start_frr(ad)),
         timeout(OP_TIMEOUT, cr2.unpause(ad)),
         timeout(OP_TIMEOUT, cr3.unpause(ad)),
+        timeout(OP_TIMEOUT, bird.start(ad)),
     );
+    if !matches!(bird_result, Ok(Ok(()))) {
+        warn!(
+            ad.log,
+            "failed to start BIRD before diagnostics: {bird_result:?}"
+        );
+    }
     match cr1_result {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
@@ -557,10 +584,11 @@ where
         FrrNode,
         EosNode,
         JuniperNode,
+        BirdNode,
         Arc<Runner>,
     ) -> tokio::task::JoinSet<Result<()>>,
 {
-    let (mut d, ox, peer, cr1, cr2, cr3) = match layout {
+    let (mut d, ox, peer, cr1, cr2, cr3, bird) = match layout {
         InteropLayout::SingleLink(scenario) => {
             let Interop {
                 d,
@@ -569,8 +597,9 @@ where
                 cr1,
                 cr2,
                 cr3,
+                bird,
             } = Interop::build(scenario)?;
-            (d, ox, peer, cr1, cr2, cr3)
+            (d, ox, peer, cr1, cr2, cr3, bird)
         }
         InteropLayout::ThreeLinks(scenario) => {
             let Interop3Link {
@@ -580,8 +609,9 @@ where
                 cr1,
                 cr2,
                 cr3,
+                bird,
             } = Interop3Link::build(scenario)?;
-            (d, ox, peer, cr1, cr2, cr3)
+            (d, ox, peer, cr1, cr2, cr3, bird)
         }
     };
     let topo_name = layout.name();
@@ -602,7 +632,12 @@ where
         &ad,
         ox,
         peer,
-        InteropRouters { cr1, cr2, cr3 },
+        InteropRouters {
+            cr1,
+            cr2,
+            cr3,
+            bird,
+        },
         commits,
         layout,
         spawn_peer_setups,
@@ -617,6 +652,7 @@ where
             cr1,
             cr2,
             cr3,
+            bird,
             mgd,
             peer_mgd,
             dpd,
@@ -631,7 +667,12 @@ where
                     &ad,
                     ox,
                     peer,
-                    InteropRouters { cr1, cr2, cr3 },
+                    InteropRouters {
+                        cr1,
+                        cr2,
+                        cr3,
+                        bird,
+                    },
                     topo_name,
                 )
                 .await;
@@ -655,10 +696,16 @@ where
         FrrNode,
         EosNode,
         JuniperNode,
+        BirdNode,
         Arc<Runner>,
     ) -> tokio::task::JoinSet<Result<()>>,
 {
-    let InteropRouters { cr1, cr2, cr3 } = routers;
+    let InteropRouters {
+        cr1,
+        cr2,
+        cr3,
+        bird,
+    } = routers;
     let ox_illumos = ox.illumos();
     let peer_illumos = peer.illumos();
     let (mgmt_addr, peer_mgmt_addr) = tokio::try_join!(
@@ -666,7 +713,7 @@ where
         peer_illumos.dhcp(ad, layout.peer_mgmt_addr()),
     )?;
 
-    let mut js = spawn_peer_setups(cr1, cr2, cr3, ad.clone());
+    let mut js = spawn_peer_setups(cr1, cr2, cr3, bird, ad.clone());
     let npuvm_ad = ad.clone();
     js.spawn(async move {
         ox.dendrite()
@@ -855,7 +902,7 @@ async fn run_interop_unnumbered(
         diag_on_fail,
         commits,
         ProtocolDiagnostics::Bgp,
-        |cr1, cr2, cr3, ad| {
+        |cr1, cr2, cr3, _bird, ad| {
             let mut js = tokio::task::JoinSet::new();
             let cr1_ad = ad.clone();
             let cr2_ad = ad.clone();
@@ -888,12 +935,19 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
         cr1,
         cr2,
         cr3,
+        bird,
         mgd,
         peer_mgd,
         dpd,
+        layout,
         ..
     } = bt;
-    let peers = InteropRouters { cr1, cr2, cr3 };
+    let peers = InteropRouters {
+        cr1,
+        cr2,
+        cr3,
+        bird,
+    };
 
     for link in [
         "tfportqsfp0_0/ll",
@@ -916,10 +970,10 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
     ox.ddm().run_ddm(&ad).await?;
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
-    // Fanout of 4 so all peer paths survive best-path selection and we can
+    // Fanout of 5 so all peer paths survive best-path selection and we can
     // validate ECMP in loc_rib and dpd.
     mgd.update_bestpath_fanout(&BestpathFanoutRequest {
-        fanout: std::num::NonZeroU8::new(4).expect("fanout > 0"),
+        fanout: std::num::NonZeroU8::new(5).expect("fanout > 0"),
     })
     .await
     .context("mgd: set bestpath fanout")?;
@@ -991,6 +1045,8 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
     .await
     .context("mgd: create peer unnumbered neighbor")?;
 
+    setup_bird_bgp(&ad, ox, bird, &mgd, layout).await?;
+
     peer_mgd
         .create_unnumbered_neighbor(&basic_unnumbered_neighbor(
             "ox",
@@ -1040,7 +1096,7 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
             .await
             .map(|x| x.into_inner().len())
             .unwrap_or(0),
-        4,
+        5,
         "mgd neighbor count"
     );
 
@@ -1048,6 +1104,7 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
         &mgd,
         LOCAL_ASN,
         InteropPeerStates::new(
+            FsmStateKind::Established,
             FsmStateKind::Established,
             FsmStateKind::Established,
             FsmStateKind::Established,
@@ -1062,42 +1119,42 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
     );
 
     // All peers advertise the same prefix, so mgd should see a single
-    // imported entry per family with four paths, and — with fanout=4 — the
-    // same four paths should survive into the selected (loc) RIB.
+    // imported entry per family with five paths, and — with fanout=5 — the
+    // same five paths should survive into the selected (loc) RIB.
     wait_for_eq!(
         mgd_imported_paths(&mgd, AddressFamily::Ipv4, PEER_V4_PREFIX).await,
-        Some(4),
+        Some(5),
         "mgd imported paths for 1.2.3.0/24"
     );
     wait_for_eq!(
         mgd_imported_paths(&mgd, AddressFamily::Ipv6, PEER_V6_PREFIX).await,
-        Some(4),
+        Some(5),
         "mgd imported paths for fd99::/64"
     );
     wait_for_eq!(
         mgd_selected_paths(&mgd, AddressFamily::Ipv4, PEER_V4_PREFIX).await,
-        Some(4),
+        Some(5),
         "mgd selected paths for 1.2.3.0/24"
     );
     wait_for_eq!(
         mgd_selected_paths(&mgd, AddressFamily::Ipv6, PEER_V6_PREFIX).await,
-        Some(4),
+        Some(5),
         "mgd selected paths for fd99::/64"
     );
 
-    // dpd should have the specific prefixes, each with four ECMP targets.
+    // dpd should have the specific prefixes, each with five ECMP targets.
     let peer_v4: Ipv4Net =
         PEER_V4_PREFIX.parse().expect("parse peer v4 prefix");
     let peer_v6: Ipv6Net =
         PEER_V6_PREFIX.parse().expect("parse peer v6 prefix");
     wait_for_eq!(
         dpd_v4_targets(&dpd, &peer_v4).await.len(),
-        4,
+        5,
         "dpd ipv4 targets for 1.2.3.0/24"
     );
     wait_for_eq!(
         dpd_v6_targets(&dpd, &peer_v6).await.len(),
-        4,
+        5,
         "dpd ipv6 targets for fd99::/64"
     );
 
@@ -1188,10 +1245,90 @@ async fn interop_unnumbered_body(bt: BootedInterop) -> Result<()> {
         );
         Ok::<(), anyhow::Error>(())
     };
-    tokio::try_join!(cr1_imports, cr2_imports, cr3_imports, peer_imports)?;
+    tokio::try_join!(
+        cr1_imports,
+        cr2_imports,
+        cr3_imports,
+        peer_imports,
+        expect_bird_bgp(&ad, bird, layout.links_per_peer())
+    )?;
 
     info!(ad.log, "interop bgp unnumbered test passed 🎉");
 
+    Ok(())
+}
+
+/// BIRD needs an explicit, scoped DUT link-local address, whereas mgd learns
+/// BIRD's address through RAdv. Both ends always use the same TCP MD5 key.
+async fn setup_bird_bgp(
+    d: &Runner,
+    ox: MgdNode,
+    bird: BirdNode,
+    mgd: &MgdClient,
+    layout: InteropLayout,
+) -> Result<()> {
+    let mut links = Vec::new();
+    for index in 0..layout.links_per_peer() {
+        let port = 4 * layout.links_per_peer() + index;
+        let dut_interface = format!("tfportqsfp{port}_0");
+        let address = ox
+            .illumos()
+            .addrconf(d, &format!("{dut_interface}/ll"))
+            .await?;
+        let IpAddr::V6(remote) = address else {
+            anyhow::bail!(
+                "DUT {dut_interface}: expected IPv6 link-local, got {address}"
+            );
+        };
+        anyhow::ensure!(
+            remote.is_unicast_link_local(),
+            "DUT address is not link-local: {remote}"
+        );
+        let interface = bird.data_interface(d, index).await?;
+        let local = bird.link_local(d, &interface).await?;
+        links.push(BgpLink {
+            interface,
+            local,
+            remote,
+        });
+        let mut neighbor = basic_unnumbered_neighbor(
+            &format!("bird{index}"),
+            "bird",
+            &dut_interface,
+            33,
+            0,
+        );
+        neighbor.md5_auth_key = Some(bird::MD5_KEY.to_owned());
+        neighbor.remote_asn = Some(bird::ASN);
+        mgd.create_unnumbered_neighbor(&neighbor)
+            .await
+            .with_context(|| {
+                format!("create authenticated BIRD neighbor {index}")
+            })?;
+    }
+    bird.apply(d, &bird::bgp_config(&links)).await
+}
+
+async fn expect_bird_bgp(
+    d: &Runner,
+    bird: BirdNode,
+    count: usize,
+) -> Result<()> {
+    // One console per VM: query BIRD's links and address families serially.
+    for index in 0..count {
+        wait_for_eq!(
+            bird.bgp_established(d, index).await.unwrap_or(false),
+            true,
+            &format!("BIRD dut{index} Established")
+        );
+        for prefix in ["4.5.6.0/24", "fdee::/64"] {
+            wait_for_eq!(
+                bird.bgp_imported(d, index, prefix).await.unwrap_or(false),
+                true,
+                &format!("BIRD dut{index} imported {prefix}")
+            );
+        }
+    }
     Ok(())
 }
 
@@ -1207,7 +1344,12 @@ async fn collect_interop_diagnostics(
     topo_name: &str,
     protocols: ProtocolDiagnostics,
 ) {
-    let InteropRouters { cr1, cr2, cr3 } = routers;
+    let InteropRouters {
+        cr1,
+        cr2,
+        cr3,
+        bird,
+    } = routers;
     warn!(d.log, "collecting diagnostics for {topo_name}");
     tokio::join!(
         async {
@@ -1224,6 +1366,7 @@ async fn collect_interop_diagnostics(
         cr1.collect_diagnostics(d, topo_name, protocols),
         cr2.collect_diagnostics(d, topo_name, protocols),
         cr3.collect_diagnostics(d, topo_name, protocols),
+        bird.collect_diagnostics(d, topo_name),
     );
 }
 
@@ -1237,7 +1380,12 @@ async fn collect_interop_boot_diagnostics(
     routers: InteropRouters,
     topo_name: &str,
 ) {
-    let InteropRouters { cr1, cr2, cr3 } = routers;
+    let InteropRouters {
+        cr1,
+        cr2,
+        cr3,
+        bird,
+    } = routers;
     warn!(d.log, "collecting boot diagnostics for {topo_name}");
     tokio::join!(
         async {
@@ -1293,6 +1441,7 @@ async fn collect_interop_boot_diagnostics(
             }
         },
         cr3.collect_boot_diagnostics(d, topo_name),
+        bird.collect_diagnostics(d, topo_name),
     );
 }
 
@@ -1446,11 +1595,13 @@ async fn run_interop_bfd_static(
         diag_on_fail,
         commits,
         ProtocolDiagnostics::Bfd,
-        |cr1, cr2, cr3, ad| {
+        |cr1, cr2, cr3, bird, ad| {
             let mut js = tokio::task::JoinSet::new();
             let cr1_ad = ad.clone();
             let cr2_ad = ad.clone();
+            let bird_ad = ad.clone();
             let cr3_ad = ad;
+            js.spawn(async move { bird.setup_bfd(&bird_ad).await });
             js.spawn(async move {
                 frr_bfd_setup(cr1, cr1_ad)
                     .await
@@ -1483,12 +1634,18 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         cr1,
         cr2,
         cr3,
+        bird,
         mgd,
         peer_mgd,
         dpd,
         ..
     } = bt;
-    let peers = InteropRouters { cr1, cr2, cr3 };
+    let peers = InteropRouters {
+        cr1,
+        cr2,
+        cr3,
+        bird,
+    };
 
     // Register each ox-side address with dpd so softnpu punts packets for
     // those destinations to the CPU port. Link-local v6 is handled
@@ -1500,6 +1657,7 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         ("qsfp1", OX_CR2_V4, OX_CR2_V6),
         ("qsfp2", OX_CR3_V4, OX_CR3_V6),
         ("qsfp3", OX_PEER_V4, OX_PEER_V6),
+        ("qsfp4", OX_BIRD_V4, OX_BIRD_V6),
     ] {
         let port = PortId::Qsfp(qsfp.parse().expect("parse qsfp port"));
         let link = LinkId(0);
@@ -1537,6 +1695,7 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         ("tfportqsfp1_0", OX_CR2_V4_CIDR, OX_CR2_V6_CIDR),
         ("tfportqsfp2_0", OX_CR3_V4_CIDR, OX_CR3_V6_CIDR),
         ("tfportqsfp3_0", OX_PEER_V4_CIDR, OX_PEER_V6_CIDR),
+        ("tfportqsfp4_0", "10.0.4.1/24", "fd00:5::1/64"),
     ] {
         let ll = format!("{link}/ll");
         ox.illumos()
@@ -1573,10 +1732,10 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
     wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
 
     // Default fanout is 1, which collapses the static paths into a single
-    // selected nexthop. Bump to 4 so all paths propagate through best-path
+    // selected nexthop. Bump to 5 so all paths propagate through best-path
     // selection and land in dpd as ECMP.
     mgd.update_bestpath_fanout(&BestpathFanoutRequest {
-        fanout: std::num::NonZeroU8::new(4).expect("fanout > 0"),
+        fanout: std::num::NonZeroU8::new(5).expect("fanout > 0"),
     })
     .await
     .context("mgd: set bestpath fanout")?;
@@ -1589,7 +1748,7 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
     info!(ad.log, "installing static v4 route {TEST_PREFIX_V4}");
     mgd.static_add_v4_route(&AddStaticRoute4Request {
         routes: StaticRoute4List {
-            list: [CR1_V4, CR2_V4, CR3_V4, PEER_V4]
+            list: [CR1_V4, CR2_V4, CR3_V4, PEER_V4, BIRD_V4]
                 .into_iter()
                 .map(|nh| StaticRoute4 {
                     prefix: prefix_v4,
@@ -1606,7 +1765,7 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
     info!(ad.log, "installing static v6 route {TEST_PREFIX_V6}");
     mgd.static_add_v6_route(&AddStaticRoute6Request {
         routes: StaticRoute6List {
-            list: [CR1_V6, CR2_V6, CR3_V6, PEER_V6]
+            list: [CR1_V6, CR2_V6, CR3_V6, PEER_V6, BIRD_V6]
                 .into_iter()
                 .map(|nh| StaticRoute6 {
                     prefix: prefix_v6,
@@ -1622,17 +1781,19 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
 
     info!(
         ad.log,
-        "adding BFD peers for cr1, cr2, cr3, and peer (dual-stack)"
+        "adding BFD peers for cr1, cr2, cr3, peer, and BIRD (dual-stack)"
     );
     for (peer, listen) in [
         (IpAddr::V4(CR1_V4), IpAddr::V4(OX_CR1_V4)),
         (IpAddr::V4(CR2_V4), IpAddr::V4(OX_CR2_V4)),
         (IpAddr::V4(CR3_V4), IpAddr::V4(OX_CR3_V4)),
         (IpAddr::V4(PEER_V4), IpAddr::V4(OX_PEER_V4)),
+        (IpAddr::V4(BIRD_V4), IpAddr::V4(OX_BIRD_V4)),
         (IpAddr::V6(CR1_V6), IpAddr::V6(OX_CR1_V6)),
         (IpAddr::V6(CR2_V6), IpAddr::V6(OX_CR2_V6)),
         (IpAddr::V6(CR3_V6), IpAddr::V6(OX_CR3_V6)),
         (IpAddr::V6(PEER_V6), IpAddr::V6(OX_PEER_V6)),
+        (IpAddr::V6(BIRD_V6), IpAddr::V6(OX_BIRD_V6)),
     ] {
         mgd.add_bfd_peer(&BfdPeerConfig {
             peer,
@@ -1654,14 +1815,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Up, Up, Up, Up),
+        InteropPeerStates::new(Up, Up, Up, Up, Up),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(true, true, true, true),
+        InteropPeerStates::new(true, true, true, true, true),
         "phase 1",
     )
     .await?;
@@ -1673,14 +1834,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Down, Up, Up, Up),
+        InteropPeerStates::new(Down, Up, Up, Up, Up),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(false, true, true, true),
+        InteropPeerStates::new(false, true, true, true, true),
         "phase 2",
     )
     .await?;
@@ -1692,14 +1853,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Down, Down, Up, Up),
+        InteropPeerStates::new(Down, Down, Up, Up, Up),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(false, false, true, true),
+        InteropPeerStates::new(false, false, true, true, true),
         "phase 3",
     )
     .await?;
@@ -1711,14 +1872,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Down, Down, Down, Up),
+        InteropPeerStates::new(Down, Down, Down, Up, Up),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(false, false, false, true),
+        InteropPeerStates::new(false, false, false, true, true),
         "phase 4",
     )
     .await?;
@@ -1730,7 +1891,26 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Down, Down, Down, Down),
+        InteropPeerStates::new(Down, Down, Down, Down, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(false, false, false, false, true),
+        "phase 5",
+    )
+    .await?;
+
+    info!(ad.log, "phase 5b: stop BIRD, all peers down");
+    bird.stop(&ad).await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Down, Down, Down, Down, Down),
     )
     .await?;
     // With every nexthop shutdown, all shutdown nexthops are reinstated.
@@ -1738,8 +1918,8 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(true, true, true, true),
-        "phase 5",
+        InteropPeerStates::new(true, true, true, true, true),
+        "phase 5b",
     )
     .await?;
 
@@ -1750,14 +1930,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Up, Down, Down, Down),
+        InteropPeerStates::new(Up, Down, Down, Down, Down),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(true, false, false, false),
+        InteropPeerStates::new(true, false, false, false, false),
         "phase 6",
     )
     .await?;
@@ -1769,14 +1949,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Up, Up, Down, Down),
+        InteropPeerStates::new(Up, Up, Down, Down, Down),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(true, true, false, false),
+        InteropPeerStates::new(true, true, false, false, false),
         "phase 7",
     )
     .await?;
@@ -1788,14 +1968,14 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Up, Up, Up, Down),
+        InteropPeerStates::new(Up, Up, Up, Down, Down),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(true, true, true, false),
+        InteropPeerStates::new(true, true, true, false, false),
         "phase 8",
     )
     .await?;
@@ -1810,15 +1990,34 @@ async fn interop_bfd_static_body(bt: BootedInterop) -> Result<()> {
         &peer_mgd,
         peers,
         &ad,
-        InteropPeerStates::new(Up, Up, Up, Up),
+        InteropPeerStates::new(Up, Up, Up, Up, Down),
     )
     .await?;
     expect_route(
         &dpd,
         &prefix_v4,
         &prefix_v6,
-        InteropPeerStates::new(true, true, true, true),
+        InteropPeerStates::new(true, true, true, true, false),
         "phase 9",
+    )
+    .await?;
+
+    info!(ad.log, "phase 10: restart BIRD, all peers recovered");
+    bird.start(&ad).await?;
+    expect_bfd(
+        &mgd,
+        &peer_mgd,
+        peers,
+        &ad,
+        InteropPeerStates::new(Up, Up, Up, Up, Up),
+    )
+    .await?;
+    expect_route(
+        &dpd,
+        &prefix_v4,
+        &prefix_v6,
+        InteropPeerStates::new(true, true, true, true, true),
+        "phase 10",
     )
     .await?;
 
@@ -1955,6 +2154,8 @@ async fn expect_bfd(
         (IpAddr::V6(CR3_V6), states.cr3),
         (IpAddr::V4(PEER_V4), states.peer),
         (IpAddr::V6(PEER_V6), states.peer),
+        (IpAddr::V4(BIRD_V4), states.bird),
+        (IpAddr::V6(BIRD_V6), states.bird),
     ] {
         let mgd = (*mgd).clone();
         checks.spawn(async move {
@@ -2013,6 +2214,20 @@ async fn expect_bfd(
             Ok(())
         });
     }
+    if matches!(states.bird, BfdPeerState::Up) {
+        let bird = peers.bird;
+        let d = Arc::clone(d);
+        checks.spawn(async move {
+            let wanted = [IpAddr::V4(OX_BIRD_V4), IpAddr::V6(OX_BIRD_V6)];
+            wait_for_eq_stable!(
+                bird.bfd_peers_up(&d, &wanted).await.unwrap_or(false),
+                true,
+                BFD_STABLE_SAMPLES,
+                "BIRD bfd peers -> Up"
+            );
+            Ok(())
+        });
+    }
     if matches!(states.peer, BfdPeerState::Up) {
         for remote in [IpAddr::V4(OX_PEER_V4), IpAddr::V6(OX_PEER_V6)] {
             let peer_mgd = (*peer_mgd).clone();
@@ -2064,6 +2279,10 @@ async fn expect_route(
         want_v4.push(IpAddr::V4(PEER_V4));
         want_v6.push(IpAddr::V6(PEER_V6));
     }
+    if included.bird {
+        want_v4.push(IpAddr::V4(BIRD_V4));
+        want_v6.push(IpAddr::V6(BIRD_V6));
+    }
 
     let desc_v4 = format!("{phase} v4");
     let desc_v6 = format!("{phase} v6");
@@ -2098,6 +2317,7 @@ async fn expect_bgp_neighbor_states(
         ("cr2", states.cr2),
         ("cr3", states.cr3),
         ("peer", states.peer),
+        ("bird0", states.bird),
     ] {
         let desc = format!("mgd bgp {name} -> {want:?}");
         wait_for_eq!(
@@ -2193,4 +2413,21 @@ async fn dpd_v6_targets(dpd: &DpdClient, prefix: &Ipv6Net) -> Vec<IpAddr> {
         .collect();
     out.sort();
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interop_layout_reserves_appended_bird_ports() {
+        let single = InteropLayout::SingleLink(InteropScenario::BgpUnnumbered);
+        let triple = InteropLayout::ThreeLinks(Interop3LinkScenario::BgpMd5);
+        assert_eq!(single.front_ports(), 5);
+        assert_eq!(triple.front_ports(), 15);
+        assert_eq!(4 * single.links_per_peer(), 4);
+        assert_eq!(4 * triple.links_per_peer(), 12);
+        assert_eq!(single.peer_mgmt_addr(), "vioif1/dhcp");
+        assert_eq!(triple.peer_mgmt_addr(), "vioif3/dhcp");
+    }
 }

--- a/falcon-lab/src/scenario/bgp_md5.rs
+++ b/falcon-lab/src/scenario/bgp_md5.rs
@@ -5,13 +5,15 @@ use super::{
     boot_interop, run_with_optional_diagnostics,
 };
 use crate::{
-    dendrite::NpuvmCommits, diagnostics::ProtocolDiagnostics, mgd::wait_for_mgd,
+    bird::MD5_KEY, dendrite::NpuvmCommits, diagnostics::ProtocolDiagnostics,
+    mgd::wait_for_mgd, wait_for_eq,
 };
 use anyhow::{Context, Result};
 use dpd_client::types::{Ipv4Entry, LinkId, PortId};
 use mg_admin_client::{Client as MgdClient, types::Neighbor};
 use mg_api_types::bgp::{
-    config::{Ipv4UnicastConfig, PeerInfo, Router},
+    config::{Ipv4UnicastConfig, Origin4, PeerInfo, Router},
+    history::Origin6,
     policy::ImportExportPolicy4,
     session::FsmStateKind,
 };
@@ -27,7 +29,6 @@ const DUT_ADDR: Ipv4Addr = Ipv4Addr::new(10, 0, 3, 1);
 const PEER_ADDR: Ipv4Addr = Ipv4Addr::new(10, 0, 3, 2);
 const DUT_LINK: &str = "tfportqsfp9_0";
 const PEER_LINK: &str = "vioif0";
-const TEST_KEY: &str = "falcon-bgp-md5-test-key";
 const STABILITY_INTERVAL: Duration = Duration::from_secs(13);
 
 pub(super) async fn run(
@@ -42,16 +43,21 @@ pub(super) async fn run(
         diag_on_fail,
         commits,
         ProtocolDiagnostics::Bgp,
-        |_cr1, _cr2, _cr3, _ad| tokio::task::JoinSet::new(),
+        |_cr1, _cr2, _cr3, _bird, _ad| tokio::task::JoinSet::new(),
     )
     .await?;
     run_with_optional_diagnostics(bt, diag_on_fail, body).await
 }
 
-// This fixture proves session establishment only. Do not reuse it for
+async fn body(bt: BootedInterop) -> Result<()> {
+    numbered_body(&bt).await?;
+    bird_unnumbered_body(&bt).await
+}
+
+// The numbered fixture proves session establishment only. Do not reuse it for
 // route-installation testing: peers such as FRR may select numbered or
 // IPv4-mapped-IPv6 next hops.
-async fn body(bt: BootedInterop) -> Result<()> {
+async fn numbered_body(bt: &BootedInterop) -> Result<()> {
     let BootedInterop {
         ad,
         ox,
@@ -73,20 +79,19 @@ async fn body(bt: BootedInterop) -> Result<()> {
     .await
     .context("dpd: program 10.0.3.1 on qsfp9/0")?;
     ox.illumos()
-        .staticaddr(&ad, &format!("{DUT_LINK}/v4"), "10.0.3.1/24")
+        .staticaddr(ad, &format!("{DUT_LINK}/v4"), "10.0.3.1/24")
         .await
         .context("assign DUT IPv4 address")?;
     peer.illumos()
-        .staticaddr(&ad, &format!("{PEER_LINK}/v4"), "10.0.3.2/24")
+        .staticaddr(ad, &format!("{PEER_LINK}/v4"), "10.0.3.2/24")
         .await
         .context("assign peer IPv4 address")?;
 
-    ox.run_mgd(&ad).await?;
-    wait_for_mgd(&mgd, OP_TIMEOUT, &ad.log).await?;
-    for (client, asn, id, label) in [
-        (&mgd, DUT_ASN, 33, "DUT"),
-        (&peer_mgd, PEER_ASN, 47, "peer"),
-    ] {
+    ox.run_mgd(ad).await?;
+    wait_for_mgd(mgd, OP_TIMEOUT, &ad.log).await?;
+    for (client, asn, id, label) in
+        [(mgd, DUT_ASN, 33, "DUT"), (peer_mgd, PEER_ASN, 47, "peer")]
+    {
         client
             .create_router(&Router {
                 asn,
@@ -110,7 +115,7 @@ async fn body(bt: BootedInterop) -> Result<()> {
         .await
         .context("peer: create active MD5 neighbor")?;
 
-    let (dut, peer) = wait_for_established(&mgd, &peer_mgd).await?;
+    let (dut, peer) = wait_for_established(mgd, peer_mgd).await?;
     anyhow::ensure!(
         dut.local_tcp_port == 179 && dut.remote_tcp_port != 179,
         "DUT did not accept the inbound BGP connection: local port {}, remote port {}",
@@ -128,10 +133,10 @@ async fn body(bt: BootedInterop) -> Result<()> {
     let peer_transitions = transition_counters(&peer);
     let deadline = Instant::now() + STABILITY_INTERVAL;
     while Instant::now() < deadline {
-        let dut = peer_info(&mgd, DUT_ASN, "peer")
+        let dut = peer_info(mgd, DUT_ASN, "peer")
             .await
             .context("DUT PeerInfo disappeared during hold-time observation")?;
-        let peer = peer_info(&peer_mgd, PEER_ASN, "dut").await.context(
+        let peer = peer_info(peer_mgd, PEER_ASN, "dut").await.context(
             "peer PeerInfo disappeared during hold-time observation",
         )?;
         assert_stable(&dut, dut_transitions, "DUT")?;
@@ -139,10 +144,10 @@ async fn body(bt: BootedInterop) -> Result<()> {
         sleep(Duration::from_millis(250)).await;
     }
 
-    let dut = peer_info(&mgd, DUT_ASN, "peer")
+    let dut = peer_info(mgd, DUT_ASN, "peer")
         .await
         .context("DUT PeerInfo disappeared after hold-time observation")?;
-    let peer = peer_info(&peer_mgd, PEER_ASN, "dut")
+    let peer = peer_info(peer_mgd, PEER_ASN, "dut")
         .await
         .context("peer PeerInfo disappeared after hold-time observation")?;
     assert_stable(&dut, dut_transitions, "DUT")?;
@@ -155,6 +160,113 @@ async fn body(bt: BootedInterop) -> Result<()> {
         peer.fsm_state_duration > Duration::from_secs(12),
         "peer was not continuously Established for two hold-time periods"
     );
+    Ok(())
+}
+
+/// Exercise all three BIRD links without weakening the accepted-socket
+/// regression above: these are authenticated IPv6 link-local sessions with
+/// RFC 8950 IPv4 routes, bidirectional imports, and three-way DUT ECMP.
+async fn bird_unnumbered_body(bt: &BootedInterop) -> Result<()> {
+    use mg_api_types::{rdb::rib::AddressFamily, rib::BestpathFanoutRequest};
+    let BootedInterop {
+        ad,
+        ox,
+        bird,
+        mgd,
+        dpd,
+        layout,
+        ..
+    } = bt;
+    ox.ddm().run_ddm(ad).await?;
+    mgd.update_bestpath_fanout(&BestpathFanoutRequest {
+        fanout: std::num::NonZeroU8::new(3).unwrap(),
+    })
+    .await?;
+    mgd.create_origin4(&Origin4 {
+        asn: DUT_ASN,
+        prefixes: vec!["4.5.6.0/24".parse()?],
+    })
+    .await?;
+    mgd.create_origin6(&Origin6 {
+        asn: DUT_ASN,
+        prefixes: vec!["fdee::/64".parse()?],
+    })
+    .await?;
+    super::setup_bird_bgp(ad, *ox, *bird, mgd, *layout).await?;
+    super::expect_bird_bgp(ad, *bird, layout.links_per_peer()).await?;
+
+    wait_for_eq!(
+        mgd.get_neighbors(DUT_ASN)
+            .await
+            .map(|r| r.len())
+            .unwrap_or(0),
+        4,
+        "DUT numbered peer plus three BIRD neighbors"
+    );
+    for (af, prefix) in [
+        (AddressFamily::Ipv4, "1.2.3.0/24"),
+        (AddressFamily::Ipv6, "fd99::/64"),
+    ] {
+        wait_for_eq!(
+            super::mgd_imported_paths(mgd, af, prefix).await,
+            Some(3),
+            &format!("DUT imported three BIRD paths for {prefix}")
+        );
+        wait_for_eq!(
+            super::mgd_selected_paths(mgd, af, prefix).await,
+            Some(3),
+            &format!("DUT selected three BIRD paths for {prefix}")
+        );
+    }
+    let v4 = "1.2.3.0/24".parse()?;
+    let v6 = "fd99::/64".parse()?;
+    wait_for_eq!(
+        super::dpd_v4_targets(dpd, &v4).await.len(),
+        3,
+        "BIRD IPv4 ECMP"
+    );
+    wait_for_eq!(
+        super::dpd_v6_targets(dpd, &v6).await.len(),
+        3,
+        "BIRD IPv6 ECMP"
+    );
+
+    let mut counters = Vec::new();
+    for index in 0..layout.links_per_peer() {
+        let name = format!("bird{index}");
+        let info = peer_info(mgd, DUT_ASN, &name)
+            .await
+            .context("missing BIRD PeerInfo")?;
+        anyhow::ensure!(
+            info.fsm_state == FsmStateKind::Established,
+            "{name} not Established"
+        );
+        counters.push((name, transition_counters(&info)));
+    }
+    let deadline = Instant::now() + STABILITY_INTERVAL;
+    loop {
+        let finished = Instant::now() >= deadline;
+        for (index, (name, transitions)) in counters.iter().enumerate() {
+            let info = peer_info(mgd, DUT_ASN, name)
+                .await
+                .context("BIRD PeerInfo disappeared")?;
+            assert_stable(&info, *transitions, name)?;
+            anyhow::ensure!(
+                bird.bgp_established(ad, index).await?,
+                "BIRD dut{index} left Established"
+            );
+            if finished {
+                anyhow::ensure!(
+                    info.fsm_state_duration > Duration::from_secs(12),
+                    "{name} did not stay Established for two hold periods"
+                );
+            }
+        }
+        if finished {
+            break;
+        }
+        sleep(Duration::from_millis(250)).await;
+    }
     Ok(())
 }
 
@@ -180,7 +292,7 @@ fn md5_neighbor(
         passive,
         remote_asn: Some(remote_asn),
         min_ttl: None,
-        md5_auth_key: Some(TEST_KEY.to_owned()),
+        md5_auth_key: Some(MD5_KEY.to_owned()),
         multi_exit_discriminator: None,
         communities: Vec::new(),
         local_pref: None,

--- a/falcon-lab/src/topo.rs
+++ b/falcon-lab/src/topo.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use libfalcon::{NodeRef, Runner, node, unit::gb};
 
 use crate::{
+    bird::BirdNode,
     eos::EosNode,
     frr::FrrNode,
     juniper::JuniperNode,
@@ -60,6 +61,7 @@ pub struct Interop {
     pub cr1: FrrNode,
     pub cr2: EosNode,
     pub cr3: JuniperNode,
+    pub bird: BirdNode,
 }
 
 pub struct Interop3Link {
@@ -69,6 +71,7 @@ pub struct Interop3Link {
     pub cr1: FrrNode,
     pub cr2: EosNode,
     pub cr3: JuniperNode,
+    pub bird: BirdNode,
 }
 
 struct InteropNodes {
@@ -78,6 +81,7 @@ struct InteropNodes {
     cr1: NodeRef,
     cr2: NodeRef,
     cr3: NodeRef,
+    bird: NodeRef,
 }
 
 fn build_interop(name: &str, links_per_peer: usize) -> Result<InteropNodes> {
@@ -88,6 +92,7 @@ fn build_interop(name: &str, links_per_peer: usize) -> Result<InteropNodes> {
     node!(d, cr2, "eos-4.35", 4, gb(4));
     node!(d, cr3, "junos-23.2", 4, gb(4));
     node!(d, peer, "helios-3.0", 4, gb(4));
+    node!(d, bird, "bird2", 4, gb(4));
 
     let mut mac_counter = 0;
     let mut new_mac = || {
@@ -100,18 +105,24 @@ fn build_interop(name: &str, links_per_peer: usize) -> Result<InteropNodes> {
             d.softnpu_link(ox, remote, Some(new_mac()), None);
         }
     }
+    // Append BIRD: existing DUT ports and remote NIC indices stay unchanged.
+    for index in 0..links_per_peer {
+        d.softnpu_link(ox, bird, Some(BirdNode::data_mac(index)), None);
+    }
 
     d.default_ext_link(ox)?;
     d.default_ext_link(cr1)?;
     d.default_ext_link(cr2)?;
     d.default_ext_link(cr3)?;
     d.default_ext_link(peer)?;
+    d.default_ext_link(bird)?;
 
     d.mount("cargo-bay", "/opt/cargo-bay", ox)?;
     d.mount_linux("cargo-bay", "/opt/cargo-bay", cr1)?;
     d.mount("cargo-bay", "/opt/cargo-bay", cr2)?;
     d.mount_linux("cargo-bay", "/opt/cargo-bay", cr3)?;
     d.mount("cargo-bay", "/opt/cargo-bay", peer)?;
+    d.mount_linux("cargo-bay", "/opt/cargo-bay", bird)?;
     // The Junos image mounts cargo-bay and applies staged configuration
     // from guest-side systemd services. Keep the 9p device in the spec,
     // but avoid Falcon's serial-driven setup/mount path for this node.
@@ -124,6 +135,7 @@ fn build_interop(name: &str, links_per_peer: usize) -> Result<InteropNodes> {
         cr1,
         cr2,
         cr3,
+        bird,
     })
 }
 
@@ -139,6 +151,7 @@ impl Topology for Interop {
             cr1: FrrNode(nodes.cr1),
             cr2: EosNode(nodes.cr2),
             cr3: JuniperNode(nodes.cr3),
+            bird: BirdNode(nodes.bird),
         })
     }
 
@@ -159,6 +172,7 @@ impl Topology for Interop3Link {
             cr1: FrrNode(nodes.cr1),
             cr2: EosNode(nodes.cr2),
             cr3: JuniperNode(nodes.cr3),
+            bird: BirdNode(nodes.bird),
         })
     }
 


### PR DESCRIPTION
Extend five-peer dual-stack BGP and BFD/ECMP failure-recovery coverage, exercise all three BIRD links alongside the existing numbered MD5 regression, and include BIRD diagnostics and CI coverage.

Signed-off-by: Trey Aspelund <trey@oxidecomputer.com>